### PR TITLE
feat: improve CLI output, performance, and test coverage

### DIFF
--- a/.changeset/codebase-improvements.md
+++ b/.changeset/codebase-improvements.md
@@ -1,0 +1,16 @@
+---
+mdt: minor
+mdt_cli: patch
+---
+
+Improve CLI output, performance, error handling, and test coverage.
+
+**CLI improvements:** Verbose mode now shows provider details including names and file paths. Both `check` and `update` commands now warn about consumer blocks referencing non-existent providers. Improved help text with description and quick-start examples.
+
+**Performance:** Optimized `Point::advance` with a new `advance_str` method that avoids allocating via `Display::to_string()` on the hot path. The lexer now uses `advance_start_str` for string-based position tracking. Engine `compute_updates` uses pre-allocated `String::with_capacity` instead of `format!` for content replacement, and avoids unnecessary equality comparison by tracking updates with a boolean flag.
+
+**Exclude patterns:** Added `[exclude]` section to `mdt.toml` configuration with glob pattern support for skipping directories or files during scanning. Uses the `globset` crate for pattern matching.
+
+**Error handling:** Replaced a `panic!` in the lexer with a graceful `break` when the context stack is unexpectedly empty. Added missing provider warnings to CLI output.
+
+**Test coverage:** More than doubled the test count from 57 to 133 tests. New tests cover: all transformer types (trim, indent, prefix, wrap, codeBlock, code, replace), transformer chaining, edge cases (empty content, unicode, numeric arguments), engine operations (check, compute_updates, write_updates, idempotency, multiple consumers per file, missing providers), project scanning (hidden dirs, node_modules, exclude patterns, sub-project boundaries, source files), config loading (all formats, multiple namespaces, missing files, exclude patterns, `.yml` extension), template rendering (undefined variables, arrays, conditionals), source scanner (multiple blocks, Python comments, position tracking), error messages, and CLI integration tests (verbose output, warnings, multi-block updates, surrounding content preservation, data interpolation).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +728,7 @@ dependencies = [
  "derive_more",
  "doc-comment",
  "float-cmp 0.9.0",
+ "globset",
  "insta",
  "kdl",
  "markdown",

--- a/crates/mdt/Cargo.toml
+++ b/crates/mdt/Cargo.toml
@@ -16,6 +16,7 @@ description = "update markdown content anywhere using comments as template tags"
 derive_more = { workspace = true }
 doc-comment = { workspace = true } # TODO replace with `mdt` template
 float-cmp = { workspace = true }
+globset = { workspace = true }
 kdl = { workspace = true }
 markdown = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }

--- a/crates/mdt/src/__tests.rs
+++ b/crates/mdt/src/__tests.rs
@@ -141,7 +141,636 @@ old
 	Ok(())
 }
 
-// Config tests
+// --- Transformer tests ---
+
+#[test]
+fn transformer_trim() {
+	let result = apply_transformers(
+		"  hello world  \n",
+		&[Transformer {
+			r#type: TransformerType::Trim,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "hello world");
+}
+
+#[test]
+fn transformer_trim_start() {
+	let result = apply_transformers(
+		"\n  hello  ",
+		&[Transformer {
+			r#type: TransformerType::TrimStart,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "hello  ");
+}
+
+#[test]
+fn transformer_trim_end() {
+	let result = apply_transformers(
+		"  hello  \n",
+		&[Transformer {
+			r#type: TransformerType::TrimEnd,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "  hello");
+}
+
+#[test]
+fn transformer_indent_multiline() {
+	let result = apply_transformers(
+		"line1\nline2\nline3",
+		&[Transformer {
+			r#type: TransformerType::Indent,
+			args: vec![Argument::String("  ".to_string())],
+		}],
+	);
+	assert_eq!(result, "  line1\n  line2\n  line3");
+}
+
+#[test]
+fn transformer_indent_preserves_empty_lines() {
+	let result = apply_transformers(
+		"line1\n\nline3",
+		&[Transformer {
+			r#type: TransformerType::Indent,
+			args: vec![Argument::String("  ".to_string())],
+		}],
+	);
+	assert_eq!(result, "  line1\n\n  line3");
+}
+
+#[test]
+fn transformer_prefix() {
+	let result = apply_transformers(
+		"content",
+		&[Transformer {
+			r#type: TransformerType::Prefix,
+			args: vec![Argument::String(">>> ".to_string())],
+		}],
+	);
+	assert_eq!(result, ">>> content");
+}
+
+#[test]
+fn transformer_wrap() {
+	let result = apply_transformers(
+		"inner",
+		&[Transformer {
+			r#type: TransformerType::Wrap,
+			args: vec![Argument::String("**".to_string())],
+		}],
+	);
+	assert_eq!(result, "**inner**");
+}
+
+#[test]
+fn transformer_code_block_with_language() {
+	let result = apply_transformers(
+		"let x = 1;",
+		&[Transformer {
+			r#type: TransformerType::CodeBlock,
+			args: vec![Argument::String("ts".to_string())],
+		}],
+	);
+	assert_eq!(result, "```ts\nlet x = 1;\n```");
+}
+
+#[test]
+fn transformer_code_block_without_language() {
+	let result = apply_transformers(
+		"hello",
+		&[Transformer {
+			r#type: TransformerType::CodeBlock,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "```\nhello\n```");
+}
+
+#[test]
+fn transformer_code_inline() {
+	let result = apply_transformers(
+		"my_fn",
+		&[Transformer {
+			r#type: TransformerType::Code,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "`my_fn`");
+}
+
+#[test]
+fn transformer_replace() {
+	let result = apply_transformers(
+		"Hello World, World!",
+		&[Transformer {
+			r#type: TransformerType::Replace,
+			args: vec![
+				Argument::String("World".to_string()),
+				Argument::String("Rust".to_string()),
+			],
+		}],
+	);
+	assert_eq!(result, "Hello Rust, Rust!");
+}
+
+#[test]
+fn transformer_chain_trim_then_indent() {
+	let result = apply_transformers(
+		"\n  content here  \n",
+		&[
+			Transformer {
+				r#type: TransformerType::Trim,
+				args: vec![],
+			},
+			Transformer {
+				r#type: TransformerType::Indent,
+				args: vec![Argument::String("/// ".to_string())],
+			},
+		],
+	);
+	assert_eq!(result, "/// content here");
+}
+
+#[test]
+fn transformer_on_empty_content() {
+	let result = apply_transformers(
+		"",
+		&[Transformer {
+			r#type: TransformerType::Trim,
+			args: vec![],
+		}],
+	);
+	assert_eq!(result, "");
+}
+
+#[test]
+fn transformer_chain_trim_prefix_code() {
+	let result = apply_transformers(
+		"\n  my_func  \n",
+		&[
+			Transformer {
+				r#type: TransformerType::Trim,
+				args: vec![],
+			},
+			Transformer {
+				r#type: TransformerType::Code,
+				args: vec![],
+			},
+			Transformer {
+				r#type: TransformerType::Prefix,
+				args: vec![Argument::String("See: ".to_string())],
+			},
+		],
+	);
+	assert_eq!(result, "See: `my_func`");
+}
+
+#[test]
+fn transformer_replace_with_empty_replacement() {
+	let result = apply_transformers(
+		"remove this word",
+		&[Transformer {
+			r#type: TransformerType::Replace,
+			args: vec![
+				Argument::String("this ".to_string()),
+				Argument::String(String::new()),
+			],
+		}],
+	);
+	assert_eq!(result, "remove word");
+}
+
+// --- Engine tests ---
+
+#[test]
+fn check_project_with_matching_content() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nExpected content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nExpected content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let result = check_project(&project, &data)?;
+	assert!(result.is_ok());
+
+	Ok(())
+}
+
+#[test]
+fn check_project_detects_stale() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nNew content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nOld content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let result = check_project(&project, &data)?;
+	assert!(!result.is_ok());
+	assert_eq!(result.stale.len(), 1);
+	assert_eq!(result.stale[0].block_name, "block");
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_replaces_content() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@info} -->\n\nUpdated info.\n\n<!-- {/info} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("doc.md"),
+		"# Doc\n\n<!-- {=info} -->\n\nOld info.\n\n<!-- {/info} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let updates = compute_updates(&project, &data)?;
+	assert_eq!(updates.updated_count, 1);
+	assert_eq!(updates.updated_files.len(), 1);
+	let content = updates.updated_files.values().next().unwrap_or_else(|| {
+		panic!("expected one file");
+	});
+	assert!(content.contains("Updated info."));
+	assert!(!content.contains("Old info."));
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_multiple_consumers_same_file() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@blockA} -->\n\nContent A.\n\n<!-- {/blockA} -->\n\n<!-- {@blockB} -->\n\nContent \
+		 B.\n\n<!-- {/blockB} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=blockA} -->\n\nOld A.\n\n<!-- {/blockA} -->\n\n<!-- {=blockB} -->\n\nOld \
+		 B.\n\n<!-- {/blockB} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let updates = compute_updates(&project, &data)?;
+	assert_eq!(updates.updated_count, 2);
+	let content = updates.updated_files.values().next().unwrap_or_else(|| {
+		panic!("expected one file");
+	});
+	assert!(content.contains("Content A."));
+	assert!(content.contains("Content B."));
+	assert!(!content.contains("Old A."));
+	assert!(!content.contains("Old B."));
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_skips_missing_provider() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@existing} -->\n\nContent.\n\n<!-- {/existing} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	// Consumer references non-existent provider "missing"
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=missing} -->\n\nOrphan.\n\n<!-- {/missing} -->\n\n<!-- {=existing} \
+		 -->\n\nOld.\n\n<!-- {/existing} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let updates = compute_updates(&project, &data)?;
+	// Only the existing consumer should be updated
+	assert_eq!(updates.updated_count, 1);
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_noop_when_in_sync() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nSame content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nSame content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let updates = compute_updates(&project, &data)?;
+	assert_eq!(updates.updated_count, 0);
+	assert!(updates.updated_files.is_empty());
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_idempotent() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nFinal content.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("doc.md"),
+		"<!-- {=block} -->\n\nOld.\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	// First update
+	let project = scan_project(tmp.path())?;
+	let data = HashMap::new();
+	let updates = compute_updates(&project, &data)?;
+	write_updates(&updates)?;
+	assert_eq!(updates.updated_count, 1);
+
+	// Second update should be noop
+	let project = scan_project(tmp.path())?;
+	let updates = compute_updates(&project, &data)?;
+	assert_eq!(updates.updated_count, 0);
+
+	Ok(())
+}
+
+#[test]
+fn compute_updates_with_template_rendering() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[data]\npkg = \"package.json\"\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("package.json"),
+		r#"{"name": "my-lib", "version": "2.0.0"}"#,
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@install} -->\n\nnpm install {{ pkg.name }}@{{ pkg.version }}\n\n<!-- {/install} \
+		 -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=install} -->\n\nold\n\n<!-- {/install} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let (project, data) = scan_project_with_config(tmp.path())?;
+	let updates = compute_updates(&project, &data)?;
+	assert_eq!(updates.updated_count, 1);
+	let content = updates.updated_files.values().next().unwrap_or_else(|| {
+		panic!("expected one file");
+	});
+	assert!(content.contains("npm install my-lib@2.0.0"));
+
+	Ok(())
+}
+
+// --- Project scanning tests ---
+
+#[test]
+fn find_missing_providers_detects_orphans() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@existingBlock} -->\n\ncontent\n\n<!-- {/existingBlock} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=orphanBlock} -->\n\nstuff\n\n<!-- {/orphanBlock} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let missing = find_missing_providers(&project);
+	assert_eq!(missing, vec!["orphanBlock"]);
+
+	Ok(())
+}
+
+#[test]
+fn find_missing_providers_empty_when_all_match() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let missing = find_missing_providers(&project);
+	assert!(missing.is_empty());
+
+	Ok(())
+}
+
+#[test]
+fn validate_project_errors_on_missing_provider() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=noProvider} -->\n\norphan\n\n<!-- {/noProvider} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	let result = validate_project(&project);
+	assert!(result.is_err());
+
+	Ok(())
+}
+
+#[test]
+fn is_template_file_correct() {
+	assert!(is_template_file(std::path::Path::new("template.t.md")));
+	assert!(is_template_file(std::path::Path::new("docs/api.t.md")));
+	assert!(!is_template_file(std::path::Path::new("readme.md")));
+	assert!(!is_template_file(std::path::Path::new("template.md")));
+}
+
+#[test]
+fn extract_content_between_tags_empty_block() {
+	let block = Block {
+		name: "test".to_string(),
+		r#type: BlockType::Provider,
+		opening: Position::new(1, 1, 0, 1, 10, 10),
+		closing: Position::new(1, 10, 10, 1, 20, 20),
+		transformers: vec![],
+	};
+	let content = extract_content_between_tags("0123456789<!-- {/test} -->", &block);
+	assert_eq!(content, "");
+}
+
+#[test]
+fn scan_project_skips_hidden_dirs() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::create_dir_all(tmp.path().join(".hidden")).unwrap_or_else(|e| panic!("mkdir: {e}"));
+	std::fs::write(
+		tmp.path().join(".hidden/readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	// Only the template file's provider should be found, not the hidden dir
+	// consumer
+	assert!(project.consumers.is_empty());
+
+	Ok(())
+}
+
+#[test]
+fn scan_project_skips_node_modules() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::create_dir_all(tmp.path().join("node_modules/pkg"))
+		.unwrap_or_else(|e| panic!("mkdir: {e}"));
+	std::fs::write(
+		tmp.path().join("node_modules/pkg/readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	assert!(project.consumers.is_empty());
+
+	Ok(())
+}
+
+#[test]
+fn scan_project_with_exclude_patterns() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::create_dir_all(tmp.path().join("vendor")).unwrap_or_else(|e| panic!("mkdir: {e}"));
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[exclude]\npatterns = [\"vendor/**\"]\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("vendor/lib.md"),
+		"<!-- {=block} -->\n\nvendor content\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let (project, _data) = scan_project_with_config(tmp.path())?;
+	// Should find the readme consumer but not the vendor one
+	assert_eq!(project.consumers.len(), 1);
+	assert!(
+		project.consumers[0]
+			.file
+			.to_string_lossy()
+			.contains("readme.md")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn scan_project_with_source_files() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::create_dir_all(tmp.path().join("src")).unwrap_or_else(|e| panic!("mkdir: {e}"));
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@docs} -->\n\nAPI documentation.\n\n<!-- {/docs} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("src/lib.rs"),
+		"//! <!-- {=docs} -->\n//! old docs\n//! <!-- {/docs} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	assert_eq!(project.providers.len(), 1);
+	assert_eq!(project.consumers.len(), 1);
+	assert_eq!(project.consumers[0].block.name, "docs");
+
+	Ok(())
+}
+
+#[test]
+fn scan_project_sub_project_boundary() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	// Sub-project boundary detection applies to non-root directories.
+	// Place it inside a packages/ dir so walk_dir sees it with is_root=false.
+	std::fs::create_dir_all(tmp.path().join("packages/subproject"))
+		.unwrap_or_else(|e| panic!("mkdir: {e}"));
+	// Create sub-project with its own mdt.toml
+	std::fs::write(tmp.path().join("packages/subproject/mdt.toml"), "[data]\n")
+		.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("packages/subproject/readme.md"),
+		"<!-- {=block} -->\n\nsub content\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	// Sub-project files should not be scanned
+	assert!(project.consumers.is_empty());
+
+	Ok(())
+}
+
+// --- Config tests ---
 
 #[test]
 fn config_load_missing_file() -> MdtResult<()> {
@@ -287,7 +916,99 @@ fn config_unsupported_format() {
 	assert!(result.is_err());
 }
 
-// Template rendering tests
+#[test]
+fn config_load_data_yml_extension() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(tmp.path().join("mdt.toml"), "[data]\ninfo = \"data.yml\"\n")
+		.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("data.yml"),
+		"name: yml-project\nversion: 1.0.0\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let config = MdtConfig::load(tmp.path())?.unwrap_or_else(|| panic!("expected Some"));
+	let data = config.load_data(tmp.path())?;
+
+	let info = data.get("info").unwrap_or_else(|| panic!("expected info"));
+	assert_eq!(info["name"], "yml-project");
+
+	Ok(())
+}
+
+#[test]
+fn config_load_data_missing_file_errors() {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[data]\nmissing = \"does_not_exist.json\"\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let config = MdtConfig::load(tmp.path())
+		.unwrap_or_else(|e| panic!("load: {e}"))
+		.unwrap_or_else(|| panic!("expected Some"));
+	let result = config.load_data(tmp.path());
+	assert!(result.is_err());
+}
+
+#[test]
+fn config_with_exclude_patterns() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[exclude]\npatterns = [\"vendor/**\", \"dist/**\"]\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let config = MdtConfig::load(tmp.path())?.unwrap_or_else(|| panic!("expected Some"));
+	assert_eq!(config.exclude.patterns.len(), 2);
+	assert_eq!(config.exclude.patterns[0], "vendor/**");
+	assert_eq!(config.exclude.patterns[1], "dist/**");
+
+	Ok(())
+}
+
+#[test]
+fn config_with_empty_data_section() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(tmp.path().join("mdt.toml"), "[data]\n")
+		.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let config = MdtConfig::load(tmp.path())?.unwrap_or_else(|| panic!("expected Some"));
+	assert!(config.data.is_empty());
+	let data = config.load_data(tmp.path())?;
+	assert!(data.is_empty());
+
+	Ok(())
+}
+
+#[test]
+fn config_multiple_data_namespaces() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[data]\npkg = \"package.json\"\ncargo = \"Cargo.toml\"\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(tmp.path().join("package.json"), r#"{"name": "js-lib"}"#)
+		.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::write(
+		tmp.path().join("Cargo.toml"),
+		"[package]\nname = \"rs-lib\"\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let config = MdtConfig::load(tmp.path())?.unwrap_or_else(|| panic!("expected Some"));
+	let data = config.load_data(tmp.path())?;
+	assert_eq!(data.len(), 2);
+	assert_eq!(data["pkg"]["name"], "js-lib");
+	assert_eq!(data["cargo"]["package"]["name"], "rs-lib");
+
+	Ok(())
+}
+
+// --- Template rendering tests ---
 
 #[test]
 fn render_template_with_variables() -> MdtResult<()> {
@@ -347,7 +1068,50 @@ fn render_template_nested_access() -> MdtResult<()> {
 	Ok(())
 }
 
-// Source scanner tests
+#[test]
+fn render_template_undefined_variable_chainable() -> MdtResult<()> {
+	let mut data = HashMap::new();
+	data.insert("pkg".to_string(), serde_json::json!({"name": "test"}));
+
+	// Access a non-existent key — should render empty due to Chainable behavior
+	let content = "Value: {{ pkg.nonexistent }}";
+	let result = render_template(content, &data)?;
+	assert_eq!(result, "Value: ");
+
+	Ok(())
+}
+
+#[test]
+fn render_template_with_array_data() -> MdtResult<()> {
+	let mut data = HashMap::new();
+	data.insert(
+		"items".to_string(),
+		serde_json::json!(["alpha", "beta", "gamma"]),
+	);
+
+	let content = "{% for item in items %}{{ item }} {% endfor %}";
+	let result = render_template(content, &data)?;
+	assert_eq!(result, "alpha beta gamma ");
+
+	Ok(())
+}
+
+#[test]
+fn render_template_with_conditional() -> MdtResult<()> {
+	let mut data = HashMap::new();
+	data.insert(
+		"pkg".to_string(),
+		serde_json::json!({"private": true, "name": "secret"}),
+	);
+
+	let content = "{% if pkg.private %}Private package{% else %}Public{% endif %}";
+	let result = render_template(content, &data)?;
+	assert_eq!(result, "Private package");
+
+	Ok(())
+}
+
+// --- Source scanner tests ---
 
 #[test]
 fn source_scanner_extract_html_comments() {
@@ -422,4 +1186,275 @@ fn source_scanner_no_comments() -> MdtResult<()> {
 	assert!(blocks.is_empty());
 
 	Ok(())
+}
+
+#[test]
+fn source_scanner_multiple_blocks() -> MdtResult<()> {
+	let content = "// <!-- {=blockA} -->\n// A\n// <!-- {/blockA} -->\n\n// <!-- {=blockB} \
+	               -->\n// B\n// <!-- {/blockB} -->\n";
+	let blocks = parse_source(content)?;
+	assert_eq!(blocks.len(), 2);
+	assert_eq!(blocks[0].name, "blockA");
+	assert_eq!(blocks[1].name, "blockB");
+
+	Ok(())
+}
+
+#[test]
+fn source_scanner_python_comments() -> MdtResult<()> {
+	let content = "# <!-- {=docs} -->\n# documentation here\n# <!-- {/docs} -->\n";
+	let blocks = parse_source(content)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].name, "docs");
+
+	Ok(())
+}
+
+#[test]
+fn source_scanner_adjacent_comments() {
+	let content = "<!-- {=a} --><!-- {/a} --><!-- {=b} --><!-- {/b} -->";
+	let nodes = extract_html_comments(content);
+	assert_eq!(nodes.len(), 4);
+}
+
+#[test]
+fn source_scanner_comment_positions() {
+	let content = "line1\n<!-- {=block} -->\nline3\n<!-- {/block} -->\n";
+	let nodes = extract_html_comments(content);
+	assert_eq!(nodes.len(), 2);
+	// First comment starts at line 2, column 1
+	let pos0 = nodes[0]
+		.position
+		.as_ref()
+		.unwrap_or_else(|| panic!("expected position"));
+	assert_eq!(pos0.start.line, 2);
+	assert_eq!(pos0.start.column, 1);
+	// Second comment starts at line 4
+	let pos1 = nodes[1]
+		.position
+		.as_ref()
+		.unwrap_or_else(|| panic!("expected position"));
+	assert_eq!(pos1.start.line, 4);
+}
+
+// --- Parser edge case tests ---
+
+#[test]
+fn parse_block_with_underscores_in_name() -> MdtResult<()> {
+	let input = "<!-- {@my_block_name} -->\n\ncontent\n\n<!-- {/my_block_name} -->\n";
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].name, "my_block_name");
+
+	Ok(())
+}
+
+#[test]
+fn parse_block_with_numbers_in_name() -> MdtResult<()> {
+	let input = "<!-- {@block123} -->\n\ncontent\n\n<!-- {/block123} -->\n";
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].name, "block123");
+
+	Ok(())
+}
+
+#[test]
+fn parse_consumer_with_all_transformer_types() -> MdtResult<()> {
+	let input = r##"<!-- {=block|trim|trimStart|trimEnd|indent:"  "|prefix:"# "|wrap:"**"|codeBlock:"rs"|code|replace:"a":"b"} -->
+old
+<!-- {/block} -->
+"##;
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].transformers.len(), 9);
+	assert_eq!(blocks[0].transformers[0].r#type, TransformerType::Trim);
+	assert_eq!(blocks[0].transformers[1].r#type, TransformerType::TrimStart);
+	assert_eq!(blocks[0].transformers[2].r#type, TransformerType::TrimEnd);
+	assert_eq!(blocks[0].transformers[3].r#type, TransformerType::Indent);
+	assert_eq!(blocks[0].transformers[4].r#type, TransformerType::Prefix);
+	assert_eq!(blocks[0].transformers[5].r#type, TransformerType::Wrap);
+	assert_eq!(blocks[0].transformers[6].r#type, TransformerType::CodeBlock);
+	assert_eq!(blocks[0].transformers[7].r#type, TransformerType::Code);
+	assert_eq!(blocks[0].transformers[8].r#type, TransformerType::Replace);
+
+	Ok(())
+}
+
+#[test]
+fn parse_consumer_with_numeric_argument() -> MdtResult<()> {
+	let input = "<!-- {=block|indent:4} -->\nold\n<!-- {/block} -->\n";
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].transformers.len(), 1);
+	assert_eq!(blocks[0].transformers[0].args.len(), 1);
+	match &blocks[0].transformers[0].args[0] {
+		Argument::Number(n) => assert_eq!(*n, 4.0),
+		other => panic!("expected Number, got {other:?}"),
+	}
+
+	Ok(())
+}
+
+#[test]
+fn parse_alternate_transformer_names() -> MdtResult<()> {
+	let input = r#"<!-- {=block|trim_start|trim_end|code_block:"rs"} -->
+old
+<!-- {/block} -->
+"#;
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].transformers[0].r#type, TransformerType::TrimStart);
+	assert_eq!(blocks[0].transformers[1].r#type, TransformerType::TrimEnd);
+	assert_eq!(blocks[0].transformers[2].r#type, TransformerType::CodeBlock);
+
+	Ok(())
+}
+
+#[test]
+fn parse_blocks_preserve_content_offsets() -> MdtResult<()> {
+	let input = "<!-- {@block} -->\nContent here.\n<!-- {/block} -->\n";
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	let content = extract_content_between_tags(input, &blocks[0]);
+	assert_eq!(content, "\nContent here.\n");
+
+	Ok(())
+}
+
+#[test]
+fn parse_provider_in_non_template_file_not_provider() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	// Write a provider block in a non-template file (readme.md)
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {@block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
+
+	let project = scan_project(tmp.path())?;
+	// Provider blocks in non-template files should not be registered as providers
+	assert!(project.providers.is_empty());
+
+	Ok(())
+}
+
+// --- Unicode and special character tests ---
+
+#[test]
+fn parse_unicode_content() -> MdtResult<()> {
+	let input = "<!-- {@block} -->\n\nHello, world! \u{1f600} Привет мир!\n\n<!-- {/block} -->\n";
+	let blocks = parse(input)?;
+	assert_eq!(blocks.len(), 1);
+	let content = extract_content_between_tags(input, &blocks[0]);
+	assert!(content.contains('\u{1f600}'));
+	assert!(content.contains("Привет"));
+
+	Ok(())
+}
+
+#[test]
+fn transformer_indent_with_unicode() {
+	let result = apply_transformers(
+		"line\u{1f600}\nline2",
+		&[Transformer {
+			r#type: TransformerType::Indent,
+			args: vec![Argument::String("  ".to_string())],
+		}],
+	);
+	assert_eq!(result, "  line\u{1f600}\n  line2");
+}
+
+// --- Write updates test ---
+
+#[test]
+fn write_updates_creates_files() -> MdtResult<()> {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	let file_path = tmp.path().join("output.md");
+	std::fs::write(&file_path, "original").unwrap_or_else(|e| panic!("write: {e}"));
+
+	let mut updated_files = HashMap::new();
+	updated_files.insert(file_path.clone(), "updated content".to_string());
+	let updates = UpdateResult {
+		updated_files,
+		updated_count: 1,
+	};
+	write_updates(&updates)?;
+
+	let content = std::fs::read_to_string(&file_path).unwrap_or_else(|e| panic!("read: {e}"));
+	assert_eq!(content, "updated content");
+
+	Ok(())
+}
+
+// --- Error type tests ---
+
+#[test]
+fn error_missing_closing_tag_message() {
+	let err = MdtError::MissingClosingTag("myBlock".to_string());
+	assert!(err.to_string().contains("myBlock"));
+}
+
+#[test]
+fn error_missing_provider_message() {
+	let err = MdtError::MissingProvider("orphan".to_string());
+	assert!(err.to_string().contains("orphan"));
+}
+
+#[test]
+fn error_data_file_message() {
+	let err = MdtError::DataFile {
+		path: "config.json".to_string(),
+		reason: "not found".to_string(),
+	};
+	let msg = err.to_string();
+	assert!(msg.contains("config.json"));
+	assert!(msg.contains("not found"));
+}
+
+#[test]
+fn error_unsupported_format_message() {
+	let err = MdtError::UnsupportedDataFormat("xml".to_string());
+	assert!(err.to_string().contains("xml"));
+}
+
+#[test]
+fn error_template_render_message() {
+	let err = MdtError::TemplateRender("syntax error".to_string());
+	assert!(err.to_string().contains("syntax error"));
+}
+
+#[test]
+fn error_config_parse_message() {
+	let err = MdtError::ConfigParse("unexpected token".to_string());
+	assert!(err.to_string().contains("unexpected token"));
+}
+
+// --- Position tests ---
+
+#[test]
+fn point_advance_str_basic() {
+	let mut point = Point::new(1, 1, 0);
+	point.advance_str("hello");
+	assert_eq!(point.line, 1);
+	assert_eq!(point.column, 6);
+	assert_eq!(point.offset, 5);
+}
+
+#[test]
+fn point_advance_str_with_newlines() {
+	let mut point = Point::new(1, 1, 0);
+	point.advance_str("line1\nline2\nline3");
+	assert_eq!(point.line, 3);
+	assert_eq!(point.column, 5);
+	assert_eq!(point.offset, 17);
+}
+
+#[test]
+fn point_advance_str_empty() {
+	let mut point = Point::new(1, 5, 10);
+	point.advance_str("");
+	assert_eq!(point.line, 1);
+	assert_eq!(point.column, 5);
+	assert_eq!(point.offset, 10);
 }

--- a/crates/mdt/src/config.rs
+++ b/crates/mdt/src/config.rs
@@ -13,12 +13,27 @@ use crate::MdtResult;
 /// [data]
 /// package = "package.json"
 /// cargo = "Cargo.toml"
+///
+/// [exclude]
+/// patterns = ["vendor/**", "generated/**"]
 /// ```
 #[derive(Debug, Deserialize)]
 pub struct MdtConfig {
 	/// Map of namespace name to relative file path for data sources.
 	#[serde(default)]
 	pub data: HashMap<String, PathBuf>,
+	/// Exclusion configuration.
+	#[serde(default)]
+	pub exclude: ExcludeConfig,
+}
+
+/// Configuration for excluding files and directories from scanning.
+#[derive(Debug, Default, Deserialize)]
+pub struct ExcludeConfig {
+	/// Glob patterns for directories or files to skip during scanning.
+	/// These are relative to the project root.
+	#[serde(default)]
+	pub patterns: Vec<String>,
 }
 
 impl MdtConfig {

--- a/crates/mdt/src/engine.rs
+++ b/crates/mdt/src/engine.rs
@@ -129,6 +129,7 @@ pub fn compute_updates(
 		};
 
 		let mut result = original.clone();
+		let mut had_update = false;
 		// Process consumers in reverse offset order so earlier replacements
 		// don't shift the positions of later ones.
 		let mut sorted_consumers: Vec<&&ConsumerEntry> = consumers.iter().collect();
@@ -148,13 +149,19 @@ pub fn compute_updates(
 				let end = consumer.block.closing.start.offset;
 
 				if start <= end && end <= result.len() {
-					result = format!("{}{}{}", &result[..start], new_content, &result[end..]);
+					let mut buf =
+						String::with_capacity(result.len() - (end - start) + new_content.len());
+					buf.push_str(&result[..start]);
+					buf.push_str(&new_content);
+					buf.push_str(&result[end..]);
+					result = buf;
+					had_update = true;
 					updated_count += 1;
 				}
 			}
 		}
 
-		if result != original {
+		if had_update {
 			file_contents.insert(file.clone(), result);
 		}
 	}

--- a/crates/mdt/src/lexer.rs
+++ b/crates/mdt/src/lexer.rs
@@ -30,7 +30,7 @@ impl TokenizerState {
 				let (skipped, remaining) = content.split_at(steps);
 				self.position
 					.iter_mut()
-					.for_each(|position| position.advance_start(skipped));
+					.for_each(|position| position.advance_start_str(skipped));
 				let remaining = if remaining.is_empty() {
 					None
 				} else {
@@ -423,7 +423,7 @@ fn tokenize_node(state: &mut TokenizerState) {
 					}
 				}
 			}
-			None => panic!("stack should never be empty"),
+			None => break,
 		}
 	}
 }

--- a/crates/mdt/src/position.rs
+++ b/crates/mdt/src/position.rs
@@ -26,9 +26,9 @@ impl Point {
 		}
 	}
 
-	pub fn advance(&mut self, text: impl Display) {
-		for char in text.to_string().chars() {
-			if char == '\n' {
+	pub fn advance_str(&mut self, text: &str) {
+		for byte in text.bytes() {
+			if byte == b'\n' {
 				self.line += 1;
 				self.column = 0;
 				self.offset += 1;
@@ -37,6 +37,10 @@ impl Point {
 				self.offset += 1;
 			}
 		}
+	}
+
+	pub fn advance(&mut self, text: impl Display) {
+		self.advance_str(&text.to_string());
 	}
 }
 
@@ -92,6 +96,10 @@ impl Position {
 
 	pub fn from_points(start: Point, end: Point) -> Self {
 		Self { start, end }
+	}
+
+	pub fn advance_start_str(&mut self, text: &str) {
+		self.start.advance_str(text);
 	}
 
 	pub fn advance_start(&mut self, text: impl Display) {

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -4,7 +4,17 @@ use clap::Parser;
 use clap::Subcommand;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(
+	author,
+	version,
+	about = "Keep documentation synchronized across your project using template tags.",
+	long_about = "mdt (manage markdown templates) is a data-driven template engine for keeping \
+	              documentation synchronized across your project.\n\nIt uses comment-based \
+	              template tags to define content once and distribute it to multiple locations — \
+	              markdown files, code comments, READMEs, and more.\n\nQuick start:\n  mdt init    \
+	              Create a template file\n  mdt update  Sync all consumer blocks\n  mdt check   \
+	              Verify everything is up to date"
+)]
 pub struct MdtCli {
 	#[command(subcommand)]
 	pub command: Option<Commands>,
@@ -23,8 +33,14 @@ pub enum Commands {
 	/// Initialize mdt in a project by creating a sample template file.
 	Init,
 	/// Check that all consumer blocks are up to date.
+	///
+	/// Exits with a non-zero status code if any consumer blocks are stale.
+	/// Use this in CI to ensure documentation stays synchronized.
 	Check,
 	/// Update all consumer blocks with the latest provider content.
+	///
+	/// Reads provider blocks from *.t.md template files and replaces
+	/// matching consumer blocks in all scanned files.
 	Update {
 		/// Show what would change without writing files.
 		#[arg(long, default_value_t = false)]

--- a/crates/mdt_cli/tests/check.rs
+++ b/crates/mdt_cli/tests/check.rs
@@ -71,3 +71,101 @@ fn check_with_no_blocks() -> AnyEmptyResult {
 
 	Ok(())
 }
+
+#[test]
+fn check_verbose_shows_provider_count() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\ncontent\n\n<!-- {/block} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("check")
+		.arg("--verbose")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("1 provider(s)"))
+		.stdout(predicates::str::contains("1 consumer(s)"));
+
+	Ok(())
+}
+
+#[test]
+fn check_warns_missing_provider() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	// Consumer with no matching provider
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=orphan} -->\n\nstuff\n\n<!-- {/orphan} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("check")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stderr(predicates::str::contains(
+			"consumer block `orphan` has no matching provider",
+		));
+
+	Ok(())
+}
+
+#[test]
+fn check_stale_shows_block_name_and_file() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@myBlock} -->\n\nnew\n\n<!-- {/myBlock} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=myBlock} -->\n\nold\n\n<!-- {/myBlock} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("check")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.failure()
+		.stderr(predicates::str::contains("Stale: block `myBlock`"))
+		.stderr(predicates::str::contains("readme.md"));
+
+	Ok(())
+}
+
+#[test]
+fn check_multiple_stale_blocks() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@a} -->\n\nnew a\n\n<!-- {/a} -->\n\n<!-- {@b} -->\n\nnew b\n\n<!-- {/b} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=a} -->\n\nold a\n\n<!-- {/a} -->\n\n<!-- {=b} -->\n\nold b\n\n<!-- {/b} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("check")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.failure()
+		.stderr(predicates::str::contains("2 consumer block(s)"));
+
+	Ok(())
+}

--- a/crates/mdt_cli/tests/init.rs
+++ b/crates/mdt_cli/tests/init.rs
@@ -43,3 +43,39 @@ fn init_does_not_overwrite() -> AnyEmptyResult {
 
 	Ok(())
 }
+
+#[test]
+fn init_creates_valid_template() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	Command::cargo_bin("mdt")?
+		.arg("init")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success();
+
+	// The generated template should be parseable by mdt
+	let template_content = std::fs::read_to_string(tmp.path().join("template.t.md"))?;
+	let blocks = mdt::parse(&template_content)?;
+	assert!(!blocks.is_empty(), "init should create at least one block");
+	assert_eq!(blocks[0].r#type, mdt::BlockType::Provider);
+
+	Ok(())
+}
+
+#[test]
+fn init_shows_next_steps() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	Command::cargo_bin("mdt")?
+		.arg("init")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("Next steps"))
+		.stdout(predicates::str::contains("mdt update"));
+
+	Ok(())
+}

--- a/crates/mdt_cli/tests/update.rs
+++ b/crates/mdt_cli/tests/update.rs
@@ -112,3 +112,170 @@ fn update_with_transformers() -> AnyEmptyResult {
 
 	Ok(())
 }
+
+#[test]
+fn update_verbose_shows_files() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nnew\n\n<!-- {/block} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--verbose")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("readme.md"));
+
+	Ok(())
+}
+
+#[test]
+fn update_warns_missing_provider() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=orphan} -->\n\nstuff\n\n<!-- {/orphan} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stderr(predicates::str::contains(
+			"consumer block `orphan` has no matching provider",
+		));
+
+	Ok(())
+}
+
+#[test]
+fn update_multiple_blocks_in_one_file() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@a} -->\n\nalpha\n\n<!-- {/a} -->\n\n<!-- {@b} -->\n\nbeta\n\n<!-- {/b} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=a} -->\n\nold\n\n<!-- {/a} -->\n\n<!-- {=b} -->\n\nold\n\n<!-- {/b} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("Updated 2 block(s)"));
+
+	let content = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	assert!(content.contains("alpha"));
+	assert!(content.contains("beta"));
+	assert!(!content.contains("old"));
+
+	Ok(())
+}
+
+#[test]
+fn update_dry_run_shows_file_list() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nnew\n\n<!-- {/block} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--dry-run")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("readme.md"));
+
+	Ok(())
+}
+
+#[test]
+fn update_with_config_and_data() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("mdt.toml"),
+		"[data]\npkg = \"package.json\"\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("package.json"),
+		r#"{"name": "my-app", "version": "3.0.0"}"#,
+	)?;
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@install} -->\n\nnpm install {{ pkg.name }}@{{ pkg.version }}\n\n<!-- {/install} \
+		 -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"<!-- {=install} -->\n\nold\n\n<!-- {/install} -->\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success();
+
+	let content = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	assert!(content.contains("npm install my-app@3.0.0"));
+
+	Ok(())
+}
+
+#[test]
+fn update_preserves_surrounding_content() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	std::fs::write(
+		tmp.path().join("template.t.md"),
+		"<!-- {@block} -->\n\nnew content\n\n<!-- {/block} -->\n",
+	)?;
+	std::fs::write(
+		tmp.path().join("readme.md"),
+		"# Header\n\nParagraph before.\n\n<!-- {=block} -->\n\nold\n\n<!-- {/block} \
+		 -->\n\nParagraph after.\n",
+	)?;
+
+	let mut cmd = Command::cargo_bin("mdt")?;
+	cmd.arg("update")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success();
+
+	let content = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	assert!(content.contains("# Header"));
+	assert!(content.contains("Paragraph before."));
+	assert!(content.contains("new content"));
+	assert!(content.contains("Paragraph after."));
+	assert!(!content.contains("old"));
+
+	Ok(())
+}


### PR DESCRIPTION
## Summary

- **CLI improvements**: Verbose mode now shows provider details with file paths. Both `check` and `update` warn about consumer blocks referencing non-existent providers. Improved help text with quick-start guide.
- **Performance**: Optimized `Point::advance` to avoid `Display::to_string()` on hot paths. Engine uses pre-allocated buffers for content replacement. Tracks updates with boolean flag instead of string comparison.
- **Exclude patterns**: New `[exclude]` section in `mdt.toml` with glob pattern support via `globset` crate for skipping directories/files during scanning.
- **Error handling**: Replaced panic in lexer with graceful break. Added missing provider warnings.
- **Test coverage**: More than doubled from 57 to 133 tests — covering all transformers, engine operations, project scanning (hidden dirs, node_modules, excludes, sub-projects, source files), config loading (all formats, multiple namespaces, missing files), template rendering (undefined vars, arrays, conditionals), source scanning, error messages, and CLI integration.

## Test plan

- [x] `cargo nextest run` — all 133 tests pass
- [x] `cargo clippy --all-features` — zero warnings
- [x] `dprint check` — formatting clean