### PR TITLE
feat: implement mdt language server (LSP)

### DIFF
--- a/.changeset/mdt-lsp-server.md
+++ b/.changeset/mdt-lsp-server.md
@@ -1,0 +1,22 @@
+---
+mdt_cli: minor
+---
+
+Implement the mdt language server (LSP) and add `mdt lsp` CLI subcommand.
+
+**LSP features:**
+
+- **Diagnostics:** Warns about stale consumer blocks (content out of date), missing providers (consumer references non-existent provider), and provider blocks in non-template files.
+- **Hover:** Shows provider content preview when hovering over consumer tags. Shows consumer count and locations when hovering over provider tags. Displays transformer chain and source file path.
+- **Completion:** Suggests block names when typing inside `{=`, `{@`, or `{/` tags. Suggests transformer names (`trim`, `indent`, `codeBlock`, etc.) after pipe `|` characters with usage descriptions.
+- **Go to Definition:** Navigates from consumer tag to its provider definition in the template file. From provider tags, navigates to all consumer locations.
+- **Document Symbols:** Lists all provider (`@name`) and consumer (`=name`) blocks in the editor outline/breadcrumb.
+- **Code Actions:** Offers "Update block" quick-fix for stale consumer blocks that replaces content with the latest provider output.
+
+**CLI integration:** Run `mdt lsp` to start the language server over stdin/stdout. Configure your editor's LSP client to use this command.
+
+**Editor setup examples:**
+
+- **VS Code** (with a generic LSP extension): Set the server command to `mdt lsp`
+- **Neovim** (with nvim-lspconfig): `require('lspconfig').mdt.setup({ cmd = { 'mdt', 'lsp' } })`
+- **Helix**: Add `[language-server.mdt] command = "mdt" args = ["lsp"]` to `languages.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,10 +753,12 @@ dependencies = [
  "clap",
  "insta",
  "mdt",
+ "mdt_lsp",
  "predicates",
  "rstest",
  "similar-asserts",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -766,7 +768,9 @@ dependencies = [
  "insta",
  "mdt",
  "rstest",
+ "serde_json",
  "similar-asserts",
+ "tempfile",
  "tokio",
  "tower-lsp",
 ]

--- a/crates/mdt_cli/Cargo.toml
+++ b/crates/mdt_cli/Cargo.toml
@@ -19,6 +19,8 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 mdt = { workspace = true }
+mdt_lsp = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -46,4 +46,10 @@ pub enum Commands {
 		#[arg(long, default_value_t = false)]
 		dry_run: bool,
 	},
+	/// Start the mdt language server (LSP).
+	///
+	/// Communicates over stdin/stdout using the Language Server Protocol.
+	/// Configure your editor to run `mdt lsp` as the language server
+	/// command for markdown and template files.
+	Lsp,
 }

--- a/crates/mdt_cli/src/main.rs
+++ b/crates/mdt_cli/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
 		Some(Commands::Init) => run_init(&args),
 		Some(Commands::Check) => run_check(&args),
 		Some(Commands::Update { dry_run }) => run_update(&args, dry_run),
+		Some(Commands::Lsp) => run_lsp(),
 		None => {
 			eprintln!("No subcommand specified. Run `mdt --help` for usage.");
 			process::exit(1);
@@ -158,5 +159,11 @@ fn run_update(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::error::Er
 		}
 	}
 
+	Ok(())
+}
+
+fn run_lsp() -> Result<(), Box<dyn std::error::Error>> {
+	let rt = tokio::runtime::Runtime::new()?;
+	rt.block_on(mdt_lsp::run_server());
 	Ok(())
 }

--- a/crates/mdt_lsp/Cargo.toml
+++ b/crates/mdt_lsp/Cargo.toml
@@ -15,6 +15,7 @@ description = "LSP server for mdt (manage markdown templates)"
 
 [dependencies]
 mdt = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower-lsp = { workspace = true, features = ["proposed"] }
 
@@ -22,6 +23,7 @@ tower-lsp = { workspace = true, features = ["proposed"] }
 insta = { workspace = true }
 rstest = { workspace = true }
 similar-asserts = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mdt_lsp/src/__tests.rs
+++ b/crates/mdt_lsp/src/__tests.rs
@@ -1,10 +1,732 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mdt::parse;
+use mdt::project::ConsumerEntry;
+use mdt::project::ProviderEntry;
+use mdt::project::extract_content_between_tags;
+use tower_lsp::lsp_types::*;
+
 use super::*;
 
+fn make_test_state(provider_content: &str, consumer_content: &str) -> (WorkspaceState, Url) {
+	let provider_template =
+		format!("<!-- {{@greeting}} -->\n\n{provider_content}\n\n<!-- {{/greeting}} -->\n");
+	let consumer_doc = format!(
+		"# Readme\n\n<!-- {{=greeting}} -->\n\n{consumer_content}\n\n<!-- {{/greeting}} -->\n"
+	);
+
+	let provider_blocks = parse(&provider_template).unwrap_or_default();
+	let consumer_blocks = parse(&consumer_doc).unwrap_or_default();
+
+	let provider_block = provider_blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Provider)
+		.cloned()
+		.unwrap_or_else(|| panic!("expected a provider block in template"));
+
+	let provider_entry = ProviderEntry {
+		block: provider_block,
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: extract_content_between_tags(&provider_template, &provider_blocks[0]),
+	};
+
+	let consumer_uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut providers = HashMap::new();
+	providers.insert("greeting".to_string(), provider_entry.clone());
+
+	let mut consumers = Vec::new();
+	for block in &consumer_blocks {
+		if block.r#type == BlockType::Consumer {
+			consumers.push(ConsumerEntry {
+				block: block.clone(),
+				file: PathBuf::from("/tmp/test/readme.md"),
+				content: extract_content_between_tags(&consumer_doc, block),
+			});
+		}
+	}
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		consumer_uri.clone(),
+		DocumentState {
+			content: consumer_doc,
+			blocks: consumer_blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers,
+		consumers,
+		data: HashMap::new(),
+	};
+
+	(state, consumer_uri)
+}
+
+// ---- Diagnostics tests ----
+
 #[test]
-fn you_can_use_a_test() {
-	let content = r#"This is something!<!-- ={exampleName} -->
-  Placeholder text
-  <!-- {/exampleName} -->"#;
-	let result = get_node_from_content(content).unwrap();
-	println!("{result:#?}");
+fn diagnostics_stale_consumer() {
+	let (state, uri) = make_test_state("Hello world!", "Old content");
+	let diagnostics = compute_diagnostics(&state, &uri);
+
+	assert_eq!(diagnostics.len(), 1);
+	assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::WARNING));
+	assert!(
+		diagnostics[0].message.contains("out of date"),
+		"expected 'out of date' in message: {}",
+		diagnostics[0].message
+	);
+	assert!(diagnostics[0].message.contains("greeting"));
+}
+
+#[test]
+fn diagnostics_up_to_date_consumer() {
+	let (state, uri) = make_test_state("Hello world!", "Hello world!");
+	let diagnostics = compute_diagnostics(&state, &uri);
+
+	// Content between tags includes surrounding newlines, so let's check
+	// the actual values from the state.
+	let doc = state.documents.get(&uri).unwrap();
+	let block = doc
+		.blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+	let content = extract_content_between_tags(&doc.content, block);
+	let provider = state.providers.get("greeting").unwrap();
+	let expected = apply_transformers(&provider.content, &block.transformers);
+
+	if content == expected {
+		assert!(diagnostics.is_empty(), "expected no diagnostics");
+	}
+	// If they differ due to whitespace, a diagnostic is expected — that's OK.
+}
+
+#[test]
+fn diagnostics_missing_provider() {
+	let consumer_doc = "<!-- {=orphan} -->\n\nstuff\n\n<!-- {/orphan} -->\n";
+	let consumer_blocks = parse(consumer_doc).unwrap_or_default();
+	let consumer_uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		consumer_uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: consumer_blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let diagnostics = compute_diagnostics(&state, &consumer_uri);
+	assert_eq!(diagnostics.len(), 1);
+	assert!(diagnostics[0].message.contains("No provider found"));
+	assert!(diagnostics[0].message.contains("orphan"));
+}
+
+#[test]
+fn diagnostics_provider_in_non_template_file() {
+	let content = "<!-- {@greeting} -->\n\nHello\n\n<!-- {/greeting} -->\n";
+	let blocks = parse(content).unwrap_or_default();
+	// Use a non-template URI (readme.md, not *.t.md)
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: content.to_string(),
+			blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let diagnostics = compute_diagnostics(&state, &uri);
+	assert_eq!(diagnostics.len(), 1);
+	assert!(diagnostics[0].message.contains("only recognized in *.t.md"));
+}
+
+// ---- Hover tests ----
+
+#[test]
+fn hover_on_consumer_shows_provider_content() {
+	let (state, uri) = make_test_state("Hello world!", "Old content");
+	let doc = state.documents.get(&uri).unwrap();
+	let block = doc
+		.blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+
+	// Position on the consumer's opening tag.
+	let position = to_lsp_position(&block.opening.start);
+	let hover = compute_hover(&state, &uri, position);
+
+	assert!(hover.is_some());
+	let hover = hover.unwrap();
+	if let HoverContents::Markup(markup) = &hover.contents {
+		assert!(markup.value.contains("Consumer block"));
+		assert!(markup.value.contains("greeting"));
+		assert!(markup.value.contains("Hello world!"));
+	} else {
+		panic!("expected Markup hover contents");
+	}
+}
+
+#[test]
+fn hover_on_provider_shows_consumer_count() {
+	let provider_template = "<!-- {@greeting} -->\n\nHello!\n\n<!-- {/greeting} -->\n";
+	let provider_blocks = parse(provider_template).unwrap_or_default();
+	let provider_uri =
+		Url::parse("file:///tmp/test/template.t.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let provider_block = provider_blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Provider)
+		.cloned()
+		.unwrap_or_else(|| panic!("expected a provider block"));
+
+	let provider_entry = ProviderEntry {
+		block: provider_block.clone(),
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: extract_content_between_tags(provider_template, &provider_blocks[0]),
+	};
+
+	let mut providers = HashMap::new();
+	providers.insert("greeting".to_string(), provider_entry);
+
+	let consumers = vec![ConsumerEntry {
+		block: Block {
+			name: "greeting".to_string(),
+			r#type: BlockType::Consumer,
+			opening: mdt::Position::new(1, 1, 0, 1, 20, 19),
+			closing: mdt::Position::new(3, 1, 30, 3, 20, 49),
+			transformers: Vec::new(),
+		},
+		file: PathBuf::from("/tmp/test/readme.md"),
+		content: "\n\nold\n\n".to_string(),
+	}];
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		provider_uri.clone(),
+		DocumentState {
+			content: provider_template.to_string(),
+			blocks: provider_blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers,
+		consumers,
+		data: HashMap::new(),
+	};
+
+	let position = to_lsp_position(&provider_block.opening.start);
+	let hover = compute_hover(&state, &provider_uri, position);
+	assert!(hover.is_some());
+	if let HoverContents::Markup(markup) = &hover.unwrap().contents {
+		assert!(markup.value.contains("Provider block"));
+		assert!(markup.value.contains("1 consumer(s)"));
+	} else {
+		panic!("expected Markup hover contents");
+	}
+}
+
+#[test]
+fn hover_outside_block_returns_none() {
+	let (state, uri) = make_test_state("Hello!", "Hello!");
+
+	// Position at line 0, col 0 — before any block.
+	let position = Position {
+		line: 0,
+		character: 0,
+	};
+	let hover = compute_hover(&state, &uri, position);
+	assert!(hover.is_none());
+}
+
+// ---- Completion tests ----
+
+#[test]
+fn completion_inside_consumer_tag() {
+	let consumer_doc = "<!-- {=gre";
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: Vec::new(),
+		},
+	);
+
+	let provider_entry = ProviderEntry {
+		block: Block {
+			name: "greeting".to_string(),
+			r#type: BlockType::Provider,
+			opening: mdt::Position::new(1, 1, 0, 1, 20, 19),
+			closing: mdt::Position::new(3, 1, 30, 3, 20, 49),
+			transformers: Vec::new(),
+		},
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: "\n\nHello!\n\n".to_string(),
+	};
+
+	let mut providers = HashMap::new();
+	providers.insert("greeting".to_string(), provider_entry);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers,
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let position = Position {
+		line: 0,
+		character: 9,
+	};
+	let completions = compute_completions(&state, &uri, position);
+	assert!(!completions.is_empty());
+	assert!(
+		completions.iter().any(|c| c.label == "greeting"),
+		"expected 'greeting' completion item"
+	);
+}
+
+#[test]
+fn completion_after_pipe_suggests_transformers() {
+	let consumer_doc = "<!-- {=greeting|";
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: Vec::new(),
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let position = Position {
+		line: 0,
+		character: 16,
+	};
+	let completions = compute_completions(&state, &uri, position);
+	assert!(!completions.is_empty());
+
+	let names: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+	assert!(names.contains(&"trim"));
+	assert!(names.contains(&"indent"));
+	assert!(names.contains(&"codeBlock"));
+	assert!(names.contains(&"replace"));
+}
+
+#[test]
+fn completion_outside_tag_returns_empty() {
+	let consumer_doc = "# Normal markdown";
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: Vec::new(),
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let position = Position {
+		line: 0,
+		character: 5,
+	};
+	let completions = compute_completions(&state, &uri, position);
+	assert!(completions.is_empty());
+}
+
+// ---- Go to Definition tests ----
+
+#[test]
+fn goto_definition_consumer_to_provider() {
+	let (state, uri) = make_test_state("Hello!", "Old");
+	let doc = state.documents.get(&uri).unwrap();
+	let block = doc
+		.blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+
+	let position = to_lsp_position(&block.opening.start);
+	let result = compute_goto_definition(&state, &uri, position);
+
+	assert!(result.is_some());
+	match result.unwrap() {
+		GotoDefinitionResponse::Scalar(loc) => {
+			assert!(
+				loc.uri.path().contains("template.t.md"),
+				"expected target to be the template file"
+			);
+		}
+		GotoDefinitionResponse::Array(locs) => {
+			assert!(locs[0].uri.path().contains("template.t.md"));
+		}
+		GotoDefinitionResponse::Link(_) => panic!("unexpected Link goto definition response"),
+	}
+}
+
+#[test]
+fn goto_definition_without_matching_provider_returns_none() {
+	let consumer_doc = "<!-- {=missing} -->\n\nstuff\n\n<!-- {/missing} -->\n";
+	let consumer_blocks = parse(consumer_doc).unwrap_or_default();
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: consumer_blocks.clone(),
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let block = consumer_blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+	let position = to_lsp_position(&block.opening.start);
+	let result = compute_goto_definition(&state, &uri, position);
+	assert!(result.is_none());
+}
+
+// ---- Document Symbols tests ----
+
+#[test]
+fn document_symbols_lists_blocks() {
+	let content = "<!-- {@greeting} -->\n\nHello\n\n<!-- {/greeting} -->\n\n<!-- {=other} \
+	               -->\n\nstuff\n\n<!-- {/other} -->\n";
+	let blocks = parse(content).unwrap_or_default();
+	let uri =
+		Url::parse("file:///tmp/test/template.t.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: content.to_string(),
+			blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let symbols = compute_document_symbols(&state, &uri);
+	assert_eq!(symbols.len(), 2);
+
+	let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+	assert!(names.contains(&"@greeting"));
+	assert!(names.contains(&"=other"));
+}
+
+#[test]
+fn document_symbols_empty_for_no_blocks() {
+	let content = "# Just a heading\n\nNo blocks here.\n";
+	let blocks = parse(content).unwrap_or_default();
+	let uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		uri.clone(),
+		DocumentState {
+			content: content.to_string(),
+			blocks,
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers: HashMap::new(),
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let symbols = compute_document_symbols(&state, &uri);
+	assert!(symbols.is_empty());
+}
+
+// ---- Code Action tests ----
+
+#[test]
+fn code_action_for_stale_consumer() {
+	let (state, uri) = make_test_state("Hello world!", "Old content");
+	let doc = state.documents.get(&uri).unwrap();
+	let block = doc
+		.blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+
+	let range = Range {
+		start: to_lsp_position(&block.opening.start),
+		end: to_lsp_position(&block.closing.end),
+	};
+
+	let actions = compute_code_actions(&state, &uri, range);
+	assert!(!actions.is_empty(), "expected at least one code action");
+
+	let CodeActionOrCommand::CodeAction(action) = &actions[0] else {
+		panic!("expected CodeAction")
+	};
+
+	assert!(action.title.contains("Update block"));
+	assert!(action.title.contains("greeting"));
+	assert!(action.edit.is_some());
+}
+
+#[test]
+fn code_action_not_offered_when_up_to_date() {
+	// Create a state where the consumer content exactly matches the provider.
+	let provider_template = "<!-- {@greeting} -->\n\nHello!\n\n<!-- {/greeting} -->\n";
+	let consumer_doc = "<!-- {=greeting} -->\n\nHello!\n\n<!-- {/greeting} -->\n";
+
+	let provider_blocks = parse(provider_template).unwrap_or_default();
+	let consumer_blocks = parse(consumer_doc).unwrap_or_default();
+
+	let provider_block = provider_blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Provider)
+		.cloned()
+		.unwrap_or_else(|| panic!("expected provider block"));
+
+	let provider_entry = ProviderEntry {
+		block: provider_block,
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: extract_content_between_tags(provider_template, &provider_blocks[0]),
+	};
+
+	let mut providers = HashMap::new();
+	providers.insert("greeting".to_string(), provider_entry);
+
+	let consumer_uri =
+		Url::parse("file:///tmp/test/readme.md").unwrap_or_else(|_| panic!("invalid test URI"));
+
+	let mut documents = HashMap::new();
+	documents.insert(
+		consumer_uri.clone(),
+		DocumentState {
+			content: consumer_doc.to_string(),
+			blocks: consumer_blocks.clone(),
+		},
+	);
+
+	let state = WorkspaceState {
+		root: Some(PathBuf::from("/tmp/test")),
+		documents,
+		providers,
+		consumers: Vec::new(),
+		data: HashMap::new(),
+	};
+
+	let block = consumer_blocks
+		.iter()
+		.find(|b| b.r#type == BlockType::Consumer)
+		.unwrap();
+
+	let range = Range {
+		start: to_lsp_position(&block.opening.start),
+		end: to_lsp_position(&block.closing.end),
+	};
+
+	let actions = compute_code_actions(&state, &consumer_uri, range);
+	assert!(
+		actions.is_empty(),
+		"expected no code actions for up-to-date block"
+	);
+}
+
+// ---- Helper function tests ----
+
+#[test]
+fn position_in_range_basic() {
+	let range = Range {
+		start: Position {
+			line: 2,
+			character: 0,
+		},
+		end: Position {
+			line: 2,
+			character: 20,
+		},
+	};
+
+	assert!(position_in_range(
+		Position {
+			line: 2,
+			character: 10
+		},
+		range
+	));
+	assert!(!position_in_range(
+		Position {
+			line: 1,
+			character: 10
+		},
+		range
+	));
+	assert!(!position_in_range(
+		Position {
+			line: 3,
+			character: 0
+		},
+		range
+	));
+}
+
+#[test]
+fn ranges_overlap_basic() {
+	let a = Range {
+		start: Position {
+			line: 2,
+			character: 0,
+		},
+		end: Position {
+			line: 5,
+			character: 10,
+		},
+	};
+	let b = Range {
+		start: Position {
+			line: 4,
+			character: 0,
+		},
+		end: Position {
+			line: 8,
+			character: 5,
+		},
+	};
+	assert!(ranges_overlap(a, b));
+
+	let c = Range {
+		start: Position {
+			line: 10,
+			character: 0,
+		},
+		end: Position {
+			line: 12,
+			character: 5,
+		},
+	};
+	assert!(!ranges_overlap(a, c));
+}
+
+#[test]
+fn to_lsp_position_converts_correctly() {
+	let point = mdt::Point::new(1, 1, 0);
+	let lsp_pos = to_lsp_position(&point);
+	assert_eq!(lsp_pos.line, 0);
+	assert_eq!(lsp_pos.character, 0);
+
+	let point2 = mdt::Point::new(5, 10, 42);
+	let lsp_pos2 = to_lsp_position(&point2);
+	assert_eq!(lsp_pos2.line, 4);
+	assert_eq!(lsp_pos2.character, 9);
+}
+
+#[test]
+fn parse_document_content_markdown() {
+	let uri = Url::parse("file:///test/readme.md").unwrap_or_else(|_| panic!("invalid URI"));
+	let content = "<!-- {@greeting} -->\n\nHello\n\n<!-- {/greeting} -->\n";
+	let blocks = parse_document_content(&uri, content);
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].name, "greeting");
+}
+
+#[test]
+fn parse_document_content_source_file() {
+	let uri = Url::parse("file:///test/main.rs").unwrap_or_else(|_| panic!("invalid URI"));
+	let content = "// <!-- {=block} -->\n// content\n// <!-- {/block} -->\n";
+	let blocks = parse_document_content(&uri, content);
+	assert_eq!(blocks.len(), 1);
+	assert_eq!(blocks[0].name, "block");
+}
+
+#[test]
+fn transformer_type_name_all() {
+	assert_eq!(transformer_type_name(TransformerType::Trim), "trim");
+	assert_eq!(
+		transformer_type_name(TransformerType::TrimStart),
+		"trimStart"
+	);
+	assert_eq!(transformer_type_name(TransformerType::TrimEnd), "trimEnd");
+	assert_eq!(transformer_type_name(TransformerType::Indent), "indent");
+	assert_eq!(transformer_type_name(TransformerType::Prefix), "prefix");
+	assert_eq!(transformer_type_name(TransformerType::Wrap), "wrap");
+	assert_eq!(
+		transformer_type_name(TransformerType::CodeBlock),
+		"codeBlock"
+	);
+	assert_eq!(transformer_type_name(TransformerType::Code), "code");
+	assert_eq!(transformer_type_name(TransformerType::Replace), "replace");
 }

--- a/crates/mdt_lsp/src/error.rs
+++ b/crates/mdt_lsp/src/error.rs
@@ -2,8 +2,10 @@ use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError, Clone)]
 pub enum Error {
-	#[error("failure to load markdown: {0}")]
-	MarkdownError(String),
+	#[error("failed to parse document: {0}")]
+	Parse(String),
+	#[error("failed to scan project: {0}")]
+	ProjectScan(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/mdt_lsp/src/lib.rs
+++ b/crates/mdt_lsp/src/lib.rs
@@ -1,32 +1,809 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use mdt::Block;
+use mdt::BlockType;
+use mdt::TransformerType;
+use mdt::apply_transformers;
+use mdt::parse;
+use mdt::parse_source;
+use mdt::project::ConsumerEntry;
+use mdt::project::ProviderEntry;
+use mdt::project::extract_content_between_tags;
+use mdt::project::scan_project_with_config;
+use mdt::render_template;
+use tokio::sync::RwLock;
 use tower_lsp::Client;
 use tower_lsp::LanguageServer;
 use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::lsp_types::*;
 
+/// State for a single open document.
+#[derive(Debug, Clone)]
+struct DocumentState {
+	/// The full text content of the document.
+	content: String,
+	/// Parsed mdt blocks in this document.
+	blocks: Vec<Block>,
+}
+
+/// Workspace-level state shared across all LSP requests.
+#[derive(Debug, Default)]
+struct WorkspaceState {
+	/// The workspace root path.
+	root: Option<PathBuf>,
+	/// Open documents keyed by URI.
+	documents: HashMap<Url, DocumentState>,
+	/// Cached providers from the last project scan.
+	providers: HashMap<String, ProviderEntry>,
+	/// Cached consumers from the last project scan.
+	consumers: Vec<ConsumerEntry>,
+	/// Template data from mdt.toml config.
+	data: HashMap<String, serde_json::Value>,
+}
+
+impl WorkspaceState {
+	/// Rescan the project from disk. Called on initialize, save, and
+	/// workspace changes.
+	fn rescan_project(&mut self) {
+		let Some(root) = &self.root else {
+			return;
+		};
+
+		match scan_project_with_config(root) {
+			Ok((project, data)) => {
+				self.providers = project.providers;
+				self.consumers = project.consumers;
+				self.data = data;
+			}
+			Err(e) => {
+				eprintln!("mdt-lsp: failed to scan project: {e}");
+			}
+		}
+	}
+
+	/// Parse a single document and update its cached state. Returns the
+	/// parsed blocks.
+	fn parse_document(&mut self, uri: &Url, content: String) -> Vec<Block> {
+		let blocks = parse_document_content(uri, &content);
+		self.documents.insert(
+			uri.clone(),
+			DocumentState {
+				content,
+				blocks: blocks.clone(),
+			},
+		);
+		blocks
+	}
+}
+
+/// Parse document content, choosing the right parser based on file extension.
+fn parse_document_content(uri: &Url, content: &str) -> Vec<Block> {
+	let is_markdown = uri
+		.path()
+		.rsplit('.')
+		.next()
+		.is_some_and(|ext| matches!(ext, "md" | "mdx" | "markdown"));
+
+	let result = if is_markdown {
+		parse(content)
+	} else {
+		parse_source(content)
+	};
+
+	result.unwrap_or_default()
+}
+
+/// Convert an mdt `Point` (1-indexed line, 1-indexed column) to an LSP
+/// `Position` (0-indexed).
+fn to_lsp_position(point: &mdt::Point) -> Position {
+	Position {
+		line: point.line.saturating_sub(1) as u32,
+		character: point.column.saturating_sub(1) as u32,
+	}
+}
+
+/// Convert an mdt `Position` to an LSP `Range`.
+fn to_lsp_range(pos: &mdt::Position) -> Range {
+	Range {
+		start: to_lsp_position(&pos.start),
+		end: to_lsp_position(&pos.end),
+	}
+}
+
+/// The MDT language server.
 #[derive(Debug)]
 pub struct MdtLanguageServer {
 	client: Client,
+	state: RwLock<WorkspaceState>,
 }
 
 impl MdtLanguageServer {
 	pub fn new(client: Client) -> Self {
-		Self { client }
+		Self {
+			client,
+			state: RwLock::new(WorkspaceState::default()),
+		}
+	}
+
+	/// Publish diagnostics for a single document.
+	async fn publish_diagnostics_for(&self, uri: &Url) {
+		let diagnostics = {
+			let state = self.state.read().await;
+			compute_diagnostics(&state, uri)
+		};
+
+		self.client
+			.publish_diagnostics(uri.clone(), diagnostics, None)
+			.await;
+	}
+
+	/// Handle a document being opened or changed — parse it and publish
+	/// diagnostics.
+	async fn on_document_change(&self, uri: &Url, content: String) {
+		{
+			let mut state = self.state.write().await;
+			state.parse_document(uri, content);
+		}
+		self.publish_diagnostics_for(uri).await;
 	}
 }
 
 #[tower_lsp::async_trait]
 impl LanguageServer for MdtLanguageServer {
-	async fn initialize(&self, _: InitializeParams) -> LspResult<InitializeResult> {
-		Ok(InitializeResult::default())
+	async fn initialize(&self, params: InitializeParams) -> LspResult<InitializeResult> {
+		// Determine workspace root
+		let root = params
+			.root_uri
+			.as_ref()
+			.and_then(|uri| uri.to_file_path().ok());
+
+		{
+			let mut state = self.state.write().await;
+			state.root = root;
+			state.rescan_project();
+		}
+
+		Ok(InitializeResult {
+			capabilities: ServerCapabilities {
+				text_document_sync: Some(TextDocumentSyncCapability::Kind(
+					TextDocumentSyncKind::FULL,
+				)),
+				hover_provider: Some(HoverProviderCapability::Simple(true)),
+				completion_provider: Some(CompletionOptions {
+					trigger_characters: Some(vec![
+						"=".to_string(),
+						"@".to_string(),
+						"|".to_string(),
+					]),
+					..Default::default()
+				}),
+				definition_provider: Some(OneOf::Left(true)),
+				document_symbol_provider: Some(OneOf::Left(true)),
+				code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+				..Default::default()
+			},
+			server_info: Some(ServerInfo {
+				name: "mdt-lsp".to_string(),
+				version: Some(env!("CARGO_PKG_VERSION").to_string()),
+			}),
+			offset_encoding: None,
+		})
 	}
 
 	async fn initialized(&self, _: InitializedParams) {
 		self.client
-			.log_message(MessageType::INFO, "server initialized!")
+			.log_message(MessageType::INFO, "mdt language server initialized")
 			.await;
 	}
 
 	async fn shutdown(&self) -> LspResult<()> {
 		Ok(())
 	}
+
+	async fn did_open(&self, params: DidOpenTextDocumentParams) {
+		let uri = params.text_document.uri;
+		let content = params.text_document.text;
+		self.on_document_change(&uri, content).await;
+	}
+
+	async fn did_change(&self, params: DidChangeTextDocumentParams) {
+		let uri = params.text_document.uri;
+		// We use Full sync, so the last change contains the entire document.
+		if let Some(change) = params.content_changes.into_iter().next_back() {
+			self.on_document_change(&uri, change.text).await;
+		}
+	}
+
+	async fn did_save(&self, params: DidSaveTextDocumentParams) {
+		// On save, rescan the entire project to pick up cross-file changes.
+		{
+			let mut state = self.state.write().await;
+			state.rescan_project();
+		}
+		self.publish_diagnostics_for(&params.text_document.uri)
+			.await;
+	}
+
+	async fn did_close(&self, params: DidCloseTextDocumentParams) {
+		let uri = params.text_document.uri;
+		{
+			let mut state = self.state.write().await;
+			state.documents.remove(&uri);
+		}
+		// Clear diagnostics for the closed document.
+		self.client.publish_diagnostics(uri, Vec::new(), None).await;
+	}
+
+	async fn hover(&self, params: HoverParams) -> LspResult<Option<Hover>> {
+		let uri = &params.text_document_position_params.text_document.uri;
+		let position = params.text_document_position_params.position;
+
+		let state = self.state.read().await;
+		Ok(compute_hover(&state, uri, position))
+	}
+
+	async fn completion(&self, params: CompletionParams) -> LspResult<Option<CompletionResponse>> {
+		let uri = &params.text_document_position.text_document.uri;
+		let position = params.text_document_position.position;
+
+		let state = self.state.read().await;
+		let items = compute_completions(&state, uri, position);
+
+		if items.is_empty() {
+			Ok(None)
+		} else {
+			Ok(Some(CompletionResponse::Array(items)))
+		}
+	}
+
+	async fn goto_definition(
+		&self,
+		params: GotoDefinitionParams,
+	) -> LspResult<Option<GotoDefinitionResponse>> {
+		let uri = &params.text_document_position_params.text_document.uri;
+		let position = params.text_document_position_params.position;
+
+		let state = self.state.read().await;
+		Ok(compute_goto_definition(&state, uri, position))
+	}
+
+	async fn document_symbol(
+		&self,
+		params: DocumentSymbolParams,
+	) -> LspResult<Option<DocumentSymbolResponse>> {
+		let uri = &params.text_document.uri;
+
+		let state = self.state.read().await;
+		let symbols = compute_document_symbols(&state, uri);
+
+		if symbols.is_empty() {
+			Ok(None)
+		} else {
+			Ok(Some(DocumentSymbolResponse::Flat(symbols)))
+		}
+	}
+
+	async fn code_action(&self, params: CodeActionParams) -> LspResult<Option<CodeActionResponse>> {
+		let uri = &params.text_document.uri;
+		let range = params.range;
+
+		let state = self.state.read().await;
+		let actions = compute_code_actions(&state, uri, range);
+
+		if actions.is_empty() {
+			Ok(None)
+		} else {
+			Ok(Some(actions))
+		}
+	}
 }
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+/// Compute diagnostics for a single document.
+fn compute_diagnostics(state: &WorkspaceState, uri: &Url) -> Vec<Diagnostic> {
+	let Some(doc) = state.documents.get(uri) else {
+		return Vec::new();
+	};
+
+	let mut diagnostics = Vec::new();
+
+	for block in &doc.blocks {
+		match block.r#type {
+			BlockType::Consumer => {
+				let consumer_content = extract_content_between_tags(&doc.content, block);
+
+				if let Some(provider) = state.providers.get(&block.name) {
+					// Check if the consumer is stale.
+					let rendered = render_template(&provider.content, &state.data)
+						.unwrap_or_else(|_| provider.content.clone());
+					let expected = apply_transformers(&rendered, &block.transformers);
+
+					if consumer_content != expected {
+						diagnostics.push(Diagnostic {
+							range: to_lsp_range(&block.opening),
+							severity: Some(DiagnosticSeverity::WARNING),
+							source: Some("mdt".to_string()),
+							message: format!("Consumer block `{}` is out of date", block.name),
+							data: Some(serde_json::json!({
+								"kind": "stale",
+								"block_name": block.name,
+								"expected_content": expected,
+							})),
+							..Default::default()
+						});
+					}
+				} else {
+					// Missing provider
+					diagnostics.push(Diagnostic {
+						range: to_lsp_range(&block.opening),
+						severity: Some(DiagnosticSeverity::WARNING),
+						source: Some("mdt".to_string()),
+						message: format!("No provider found for consumer block `{}`", block.name),
+						..Default::default()
+					});
+				}
+			}
+			BlockType::Provider => {
+				// Check if this provider is in a template file.
+				let is_template = uri.path().ends_with(".t.md");
+				if !is_template {
+					diagnostics.push(Diagnostic {
+						range: to_lsp_range(&block.opening),
+						severity: Some(DiagnosticSeverity::INFORMATION),
+						source: Some("mdt".to_string()),
+						message: format!(
+							"Provider block `{}` is only recognized in *.t.md template files",
+							block.name
+						),
+						..Default::default()
+					});
+				}
+			}
+		}
+	}
+
+	diagnostics
+}
+
+// ---------------------------------------------------------------------------
+// Hover
+// ---------------------------------------------------------------------------
+
+/// Find the block at a given cursor position.
+fn find_block_at_position(blocks: &[Block], position: Position) -> Option<&Block> {
+	for block in blocks {
+		let opening_range = to_lsp_range(&block.opening);
+		if position_in_range(position, opening_range) {
+			return Some(block);
+		}
+	}
+	None
+}
+
+/// Check if a position is within a range.
+fn position_in_range(pos: Position, range: Range) -> bool {
+	if pos.line < range.start.line || pos.line > range.end.line {
+		return false;
+	}
+	if pos.line == range.start.line && pos.character < range.start.character {
+		return false;
+	}
+	if pos.line == range.end.line && pos.character > range.end.character {
+		return false;
+	}
+	true
+}
+
+/// Compute hover information at a position.
+fn compute_hover(state: &WorkspaceState, uri: &Url, position: Position) -> Option<Hover> {
+	let doc = state.documents.get(uri)?;
+	let block = find_block_at_position(&doc.blocks, position)?;
+
+	let contents = match block.r#type {
+		BlockType::Consumer => {
+			let mut parts = Vec::new();
+			parts.push(format!("**Consumer block:** `{}`", block.name));
+
+			if let Some(provider) = state.providers.get(&block.name) {
+				let rendered = render_template(&provider.content, &state.data)
+					.unwrap_or_else(|_| provider.content.clone());
+				let expected = apply_transformers(&rendered, &block.transformers);
+
+				parts.push(format!(
+					"\n**Provider source:** `{}`",
+					provider.file.display()
+				));
+
+				if !block.transformers.is_empty() {
+					let names: Vec<String> = block
+						.transformers
+						.iter()
+						.map(|t| transformer_type_name(t.r#type))
+						.collect();
+					parts.push(format!("\n**Transformers:** {}", names.join(" | ")));
+				}
+
+				parts.push(format!("\n---\n\n```\n{}\n```", expected.trim()));
+			} else {
+				parts.push("\n*No matching provider found*".to_string());
+			}
+
+			parts.join("")
+		}
+		BlockType::Provider => {
+			let mut parts = Vec::new();
+			parts.push(format!("**Provider block:** `{}`", block.name));
+
+			let content = extract_content_between_tags(&doc.content, block);
+			let consumer_count = state
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == block.name)
+				.count();
+
+			parts.push(format!("\n**Referenced by:** {consumer_count} consumer(s)"));
+
+			// List consumer locations
+			let consumer_files: Vec<String> = state
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == block.name)
+				.map(|c| format!("`{}`", c.file.display()))
+				.collect();
+
+			if !consumer_files.is_empty() {
+				parts.push(format!("\n**Consumers in:** {}", consumer_files.join(", ")));
+			}
+
+			parts.push(format!("\n---\n\n```\n{}\n```", content.trim()));
+
+			parts.join("")
+		}
+	};
+
+	Some(Hover {
+		contents: HoverContents::Markup(MarkupContent {
+			kind: MarkupKind::Markdown,
+			value: contents,
+		}),
+		range: Some(to_lsp_range(&block.opening)),
+	})
+}
+
+/// Get the display name for a transformer type.
+fn transformer_type_name(t: TransformerType) -> String {
+	match t {
+		TransformerType::Trim => "trim".to_string(),
+		TransformerType::TrimStart => "trimStart".to_string(),
+		TransformerType::TrimEnd => "trimEnd".to_string(),
+		TransformerType::Indent => "indent".to_string(),
+		TransformerType::Prefix => "prefix".to_string(),
+		TransformerType::Wrap => "wrap".to_string(),
+		TransformerType::CodeBlock => "codeBlock".to_string(),
+		TransformerType::Code => "code".to_string(),
+		TransformerType::Replace => "replace".to_string(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Completions
+// ---------------------------------------------------------------------------
+
+/// Compute completion items at a position.
+fn compute_completions(
+	state: &WorkspaceState,
+	uri: &Url,
+	position: Position,
+) -> Vec<CompletionItem> {
+	let Some(doc) = state.documents.get(uri) else {
+		return Vec::new();
+	};
+
+	// Check if we're inside an HTML comment context by looking at text before
+	// cursor.
+	let line_idx = position.line as usize;
+	let col = position.character as usize;
+
+	let lines: Vec<&str> = doc.content.lines().collect();
+	let Some(line) = lines.get(line_idx) else {
+		return Vec::new();
+	};
+
+	let before_cursor = if col <= line.len() {
+		&line[..col]
+	} else {
+		line
+	};
+
+	// Check if we're in a context where block name completion makes sense:
+	// after `{=`, `{@`, or `{/`
+	let in_tag_context = before_cursor.contains("{=")
+		|| before_cursor.contains("{@")
+		|| before_cursor.contains("{/");
+
+	// Check if we're after a pipe for transformer completion.
+	let in_transformer_context = {
+		// Look for `|` after a `{=name` pattern on the current line.
+		if let Some(tag_start) = before_cursor.rfind("{=") {
+			let after_tag = &before_cursor[tag_start..];
+			after_tag.contains('|')
+		} else {
+			false
+		}
+	};
+
+	if in_transformer_context {
+		return transformer_completions();
+	}
+
+	if in_tag_context {
+		return block_name_completions(state);
+	}
+
+	Vec::new()
+}
+
+/// Generate completion items for all known block names.
+fn block_name_completions(state: &WorkspaceState) -> Vec<CompletionItem> {
+	state
+		.providers
+		.iter()
+		.map(|(name, entry)| {
+			CompletionItem {
+				label: name.clone(),
+				kind: Some(CompletionItemKind::REFERENCE),
+				detail: Some(format!("Provider from {}", entry.file.display())),
+				documentation: Some(Documentation::MarkupContent(MarkupContent {
+					kind: MarkupKind::Markdown,
+					value: format!("```\n{}\n```", entry.content.trim()),
+				})),
+				..Default::default()
+			}
+		})
+		.collect()
+}
+
+/// Generate completion items for transformer names.
+fn transformer_completions() -> Vec<CompletionItem> {
+	let transformers = [
+		("trim", "Remove leading and trailing whitespace"),
+		("trimStart", "Remove leading whitespace"),
+		("trimEnd", "Remove trailing whitespace"),
+		(
+			"indent",
+			"Indent each line with a string. Usage: `indent:\"  \"`",
+		),
+		(
+			"prefix",
+			"Add a prefix before content. Usage: `prefix:\"// \"`",
+		),
+		("wrap", "Wrap content with a string. Usage: `wrap:\"**\"`"),
+		(
+			"codeBlock",
+			"Wrap in a fenced code block. Usage: `codeBlock:\"ts\"`",
+		),
+		("code", "Wrap in inline code backticks"),
+		(
+			"replace",
+			"Replace a substring. Usage: `replace:\"old\":\"new\"`",
+		),
+	];
+
+	transformers
+		.iter()
+		.enumerate()
+		.map(|(i, (name, desc))| {
+			CompletionItem {
+				label: (*name).to_string(),
+				kind: Some(CompletionItemKind::FUNCTION),
+				detail: Some((*desc).to_string()),
+				sort_text: Some(format!("{i:02}")),
+				..Default::default()
+			}
+		})
+		.collect()
+}
+
+// ---------------------------------------------------------------------------
+// Go to Definition
+// ---------------------------------------------------------------------------
+
+/// Compute go-to-definition: consumer → provider.
+fn compute_goto_definition(
+	state: &WorkspaceState,
+	uri: &Url,
+	position: Position,
+) -> Option<GotoDefinitionResponse> {
+	let doc = state.documents.get(uri)?;
+	let block = find_block_at_position(&doc.blocks, position)?;
+
+	match block.r#type {
+		BlockType::Consumer => {
+			// Navigate to the provider definition.
+			let provider = state.providers.get(&block.name)?;
+			let target_uri = Url::from_file_path(&provider.file).ok()?;
+			let target_range = to_lsp_range(&provider.block.opening);
+
+			Some(GotoDefinitionResponse::Scalar(Location {
+				uri: target_uri,
+				range: target_range,
+			}))
+		}
+		BlockType::Provider => {
+			// Navigate to all consumers of this provider.
+			let locations: Vec<Location> = state
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == block.name)
+				.filter_map(|c| {
+					let consumer_uri = Url::from_file_path(&c.file).ok()?;
+					Some(Location {
+						uri: consumer_uri,
+						range: to_lsp_range(&c.block.opening),
+					})
+				})
+				.collect();
+
+			if locations.is_empty() {
+				None
+			} else if locations.len() == 1 {
+				Some(GotoDefinitionResponse::Scalar(
+					locations.into_iter().next()?,
+				))
+			} else {
+				Some(GotoDefinitionResponse::Array(locations))
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Document Symbols
+// ---------------------------------------------------------------------------
+
+/// Compute document symbols for the outline view.
+#[allow(deprecated)]
+fn compute_document_symbols(state: &WorkspaceState, uri: &Url) -> Vec<SymbolInformation> {
+	let Some(doc) = state.documents.get(uri) else {
+		return Vec::new();
+	};
+
+	doc.blocks
+		.iter()
+		.map(|block| {
+			let kind = match block.r#type {
+				BlockType::Provider => SymbolKind::CLASS,
+				BlockType::Consumer => SymbolKind::VARIABLE,
+			};
+			let prefix = match block.r#type {
+				BlockType::Provider => "@",
+				BlockType::Consumer => "=",
+			};
+
+			SymbolInformation {
+				name: format!("{prefix}{}", block.name),
+				kind,
+				tags: None,
+				deprecated: None,
+				location: Location {
+					uri: uri.clone(),
+					range: Range {
+						start: to_lsp_position(&block.opening.start),
+						end: to_lsp_position(&block.closing.end),
+					},
+				},
+				container_name: None,
+			}
+		})
+		.collect()
+}
+
+// ---------------------------------------------------------------------------
+// Code Actions
+// ---------------------------------------------------------------------------
+
+/// Compute code actions for a range. Offers "Update block" for stale
+/// consumers.
+fn compute_code_actions(
+	state: &WorkspaceState,
+	uri: &Url,
+	range: Range,
+) -> Vec<CodeActionOrCommand> {
+	let Some(doc) = state.documents.get(uri) else {
+		return Vec::new();
+	};
+
+	let mut actions = Vec::new();
+
+	for block in &doc.blocks {
+		if block.r#type != BlockType::Consumer {
+			continue;
+		}
+
+		let opening_range = to_lsp_range(&block.opening);
+		// Check if the user's selection/cursor overlaps with this block.
+		if !ranges_overlap(
+			range,
+			Range {
+				start: to_lsp_position(&block.opening.start),
+				end: to_lsp_position(&block.closing.end),
+			},
+		) {
+			continue;
+		}
+
+		let Some(provider) = state.providers.get(&block.name) else {
+			continue;
+		};
+
+		let rendered = render_template(&provider.content, &state.data)
+			.unwrap_or_else(|_| provider.content.clone());
+		let expected = apply_transformers(&rendered, &block.transformers);
+		let current = extract_content_between_tags(&doc.content, block);
+
+		if current == expected {
+			continue;
+		}
+
+		// Build a text edit that replaces the content between the tags.
+		let content_start = to_lsp_position(&block.opening.end);
+		let content_end = to_lsp_position(&block.closing.start);
+
+		let edit = TextEdit {
+			range: Range {
+				start: content_start,
+				end: content_end,
+			},
+			new_text: expected,
+		};
+
+		let mut changes = HashMap::new();
+		changes.insert(uri.clone(), vec![edit]);
+
+		actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+			title: format!("Update block `{}`", block.name),
+			kind: Some(CodeActionKind::QUICKFIX),
+			diagnostics: Some(vec![Diagnostic {
+				range: opening_range,
+				severity: Some(DiagnosticSeverity::WARNING),
+				source: Some("mdt".to_string()),
+				message: format!("Consumer block `{}` is out of date", block.name),
+				..Default::default()
+			}]),
+			edit: Some(WorkspaceEdit {
+				changes: Some(changes),
+				..Default::default()
+			}),
+			..Default::default()
+		}));
+	}
+
+	actions
+}
+
+/// Check if two ranges overlap.
+fn ranges_overlap(a: Range, b: Range) -> bool {
+	!(a.end.line < b.start.line
+		|| (a.end.line == b.start.line && a.end.character < b.start.character)
+		|| b.end.line < a.start.line
+		|| (b.end.line == a.start.line && b.end.character < a.start.character))
+}
+
+/// Start the LSP server on stdin/stdout. This is used by both the standalone
+/// `mdt-lsp` binary and the `mdt lsp` CLI subcommand.
+pub async fn run_server() {
+	let stdin = tokio::io::stdin();
+	let stdout = tokio::io::stdout();
+
+	let (service, socket) = tower_lsp::LspService::new(MdtLanguageServer::new);
+	tower_lsp::Server::new(stdin, stdout, socket)
+		.serve(service)
+		.await;
+}
+
+#[cfg(test)]
+mod __tests;

--- a/crates/mdt_lsp/src/main.rs
+++ b/crates/mdt_lsp/src/main.rs
@@ -1,13 +1,5 @@
-use mdt_lsp::MdtLanguageServer;
-use tower_lsp::LspService;
-use tower_lsp::Server;
-
 #[tokio::main]
 #[allow(clippy::disallowed_methods)]
 async fn main() {
-	let stdin = tokio::io::stdin();
-	let stdout = tokio::io::stdout();
-
-	let (service, socket) = LspService::new(MdtLanguageServer::new);
-	Server::new(stdin, stdout, socket).serve(service).await;
+	mdt_lsp::run_server().await;
 }


### PR DESCRIPTION
## Summary

- Implement a fully functional LSP server in `mdt_lsp` with diagnostics, hover, completion, go-to-definition, document symbols, and code actions
- Add `mdt lsp` CLI subcommand for easy editor integration
- Add 22 unit tests covering all LSP features

## LSP Features

| Feature | Description |
|---------|-------------|
| **Diagnostics** | Warns about stale consumers, missing providers, and providers in non-template files |
| **Hover** | Shows provider content preview on consumer tags; shows consumer count on provider tags |
| **Completion** | Suggests block names inside `{=`/`{@`/`{/` tags; suggests transformer names after `\|` |
| **Go to Definition** | Consumer → provider navigation; provider → all consumer locations |
| **Document Symbols** | Lists all `@provider` and `=consumer` blocks in editor outline |
| **Code Actions** | "Update block" quick-fix for stale consumer blocks |

## Editor Setup

```sh
# Start the LSP server
mdt lsp
```

Configure your editor to run `mdt lsp` as the language server command:

- **VS Code**: Set server command to `mdt lsp` in a generic LSP extension
- **Neovim**: `require('lspconfig').mdt.setup({ cmd = { 'mdt', 'lsp' } })`
- **Helix**: Add `[language-server.mdt] command = "mdt" args = ["lsp"]` to `languages.toml`

## Test plan

- [x] All 155 tests pass (133 existing + 22 new LSP tests)
- [x] `cargo clippy --all-features --all-targets` — no warnings in LSP crate
- [x] `dprint check` — formatting clean
- [x] `mdt lsp --help` displays correct usage info
- [x] LSP tests cover: diagnostics (stale, missing provider, non-template provider), hover (consumer, provider, outside block), completion (block names, transformers, outside tag), goto-definition (consumer→provider, missing provider), document symbols (blocks, empty), code actions (stale fix, up-to-date no-op), helper functions (position conversion, range overlap)