### PR TITLE
chore: normalize dependency specs with cargo easy-dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,29 +4,29 @@ default-members = ["crates/*", "docs"]
 resolver = "2"
 
 [workspace.dependencies]
-assert_cmd = "2"
-clap = "4"
-derive_more = { version = "2", features = ["deref", "deref_mut"] }
-doc-comment = "0.3"
-float-cmp = "0.10"
-globset = "0.4"
-insta = "1"
-kdl = "6"
-markdown = "1"
-miette = "7"
-minijinja = "2"
-predicates = "3"
-rstest = "0.26"
-serde = "1"
-serde_json = "1"
-serde_yml = "0.0.12"
-similar-asserts = "1"
-snailquote = "0.3"
-tempfile = "3"
-thiserror = "2"
-tokio = "1"
-toml = "1"
-tower-lsp = "0.20"
+assert_cmd = { default-features = false, version = "^2" }
+clap = { default-features = false, version = "^4" }
+derive_more = { version = "2", features = ["deref", "deref_mut"], default-features = false }
+doc-comment = { default-features = false, version = "^0.3" }
+float-cmp = { default-features = false, version = "^0.10" }
+globset = { default-features = false, version = "^0.4" }
+insta = { default-features = false, version = "^1" }
+kdl = { default-features = false, version = "^6" }
+markdown = { default-features = false, version = "^1" }
+miette = { default-features = false, version = "^7" }
+minijinja = { default-features = false, version = "^2" }
+predicates = { default-features = false, version = "^3" }
+rstest = { default-features = false, version = "^0.26" }
+serde = { default-features = false, version = "^1" }
+serde_json = { default-features = false, version = "^1" }
+serde_yml = { default-features = false, version = "^0.0.12" }
+similar-asserts = { default-features = false, version = "^1" }
+snailquote = { default-features = false, version = "^0.3" }
+tempfile = { default-features = false, version = "^3" }
+thiserror = { default-features = false, version = "^2" }
+tokio = { default-features = false, version = "^1" }
+toml = { default-features = false, version = "^1" }
+tower-lsp = { default-features = false, version = "^0.20" }
 
 # Internal crates
 mdt = { path = "./crates/mdt", version = "0.0.0" }

--- a/crates/mdt/Cargo.toml
+++ b/crates/mdt/Cargo.toml
@@ -13,25 +13,25 @@ rust-version = { workspace = true }
 description = "update markdown content anywhere using comments as template tags"
 
 [dependencies]
-derive_more = { workspace = true }
-float-cmp = { workspace = true }
-globset = { workspace = true }
-kdl = { workspace = true }
-markdown = { workspace = true }
-miette = { workspace = true, features = ["fancy"] }
-minijinja = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-serde_yml = { workspace = true }
-snailquote = { workspace = true }
-thiserror = { workspace = true }
-toml = { workspace = true }
+derive_more = { workspace = true, default-features = true }
+float-cmp = { workspace = true, default-features = true }
+globset = { workspace = true, default-features = true }
+kdl = { workspace = true, default-features = true }
+markdown = { workspace = true, default-features = true }
+miette = { workspace = true, features = ["fancy"], default-features = true }
+minijinja = { workspace = true, default-features = true }
+serde = { workspace = true, features = ["derive"], default-features = true }
+serde_json = { workspace = true, default-features = true }
+serde_yml = { workspace = true, default-features = true }
+snailquote = { workspace = true, default-features = true }
+thiserror = { workspace = true, default-features = true }
+toml = { workspace = true, default-features = true }
 
 [dev-dependencies]
-insta = { workspace = true }
-rstest = { workspace = true }
-similar-asserts = { workspace = true }
-tempfile = { workspace = true }
+insta = { workspace = true, default-features = true }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/crates/mdt_cli/Cargo.toml
+++ b/crates/mdt_cli/Cargo.toml
@@ -17,18 +17,18 @@ name = "mdt"
 path = "src/main.rs"
 
 [dependencies]
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive"], default-features = true }
 mdt = { workspace = true }
 mdt_lsp = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full"], default-features = true }
 
 [dev-dependencies]
-assert_cmd = { workspace = true }
-insta = { workspace = true }
-predicates = { workspace = true }
-rstest = { workspace = true }
-similar-asserts = { workspace = true }
-tempfile = { workspace = true }
+assert_cmd = { workspace = true, default-features = true }
+insta = { workspace = true, default-features = true }
+predicates = { workspace = true, default-features = true }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/crates/mdt_lsp/Cargo.toml
+++ b/crates/mdt_lsp/Cargo.toml
@@ -15,15 +15,15 @@ description = "LSP server for mdt (manage markdown templates)"
 
 [dependencies]
 mdt = { workspace = true }
-serde_json = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-tower-lsp = { workspace = true, features = ["proposed"] }
+serde_json = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["full"], default-features = true }
+tower-lsp = { workspace = true, features = ["proposed"], default-features = true }
 
 [dev-dependencies]
-insta = { workspace = true }
-rstest = { workspace = true }
-similar-asserts = { workspace = true }
-tempfile = { workspace = true }
+insta = { workspace = true, default-features = true }
+rstest = { workspace = true, default-features = true }
+similar-asserts = { workspace = true, default-features = true }
+tempfile = { workspace = true, default-features = true }
 
 [lints]
 workspace = true

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -5,7 +5,7 @@ edition = { workspace = true }
 publish = false
 
 [dependencies]
-doc-comment = { workspace = true }
+doc-comment = { workspace = true, default-features = true }
 mdt = { workspace = true }
 
 [lints]


### PR DESCRIPTION
## Summary

- Set `default-features = false` at workspace dependency level for explicit control
- Set `default-features = true` at individual crate level where defaults are needed
- Add `^` prefix to workspace version specs for clarity

No functional changes — just dependency spec normalization via `cargo easy-dep`.

## Test plan

- [ ] CI passes (build, lint, test)