### PR TITLE
feat: API completeness improvements

### DIFF
--- a/.changeset/api-completeness.md
+++ b/.changeset/api-completeness.md
@@ -1,0 +1,28 @@
+---
+mdt: minor
+mdt_cli: minor
+---
+
+Comprehensive API completeness improvements across all crates.
+
+**New transformers:** Added `suffix`, `linePrefix`, and `lineSuffix` transformers for more granular content manipulation. `linePrefix` and `lineSuffix` apply prefixes/suffixes to each non-empty line, while `suffix` appends to the entire content. All support both camelCase and snake_case names.
+
+**Duplicate provider detection:** The project scanner now detects and reports duplicate provider block names across template files, with clear error messages indicating both file locations.
+
+**Rich diagnostics:** All error types now include `#[help(...)]` attributes with actionable guidance. Added `UnknownTransformer` and `InvalidTransformerArgs` error variants for better error reporting.
+
+**Transformer validation:** New `validate_transformers()` function checks argument counts against expected ranges for each transformer type.
+
+**Block PartialEq:** `Block`, `Transformer`, and `Argument` types now derive `PartialEq` for easier testing and comparison. Introduced `OrderedFloat` wrapper for approximate float equality.
+
+**CLI enhancements:**
+
+- `mdt check --diff` shows a colorized unified diff of stale consumer blocks
+- `mdt check --format json|github|text` supports machine-readable output formats including GitHub Actions annotations
+- `mdt list` command displays all providers and consumers with relationship status and transformer info
+- `mdt update --watch` watches for file changes and re-runs updates with 200ms debouncing
+- Colored terminal output with `NO_COLOR` env var and `--no-color` flag support
+
+**Config improvements:** Added `[include]` patterns and `[templates]` paths sections to `mdt.toml` for controlling which files are scanned and where template files are located.
+
+**LSP incremental updates:** The language server now performs incremental document updates on save instead of full project rescans, with full rescans only when `mdt.toml` changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -346,6 +346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +622,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +650,17 @@ dependencies = [
  "console",
  "once_cell",
  "similar",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -644,6 +690,26 @@ dependencies = [
  "miette",
  "num",
  "winnow 0.6.24",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -728,6 +794,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
+ "similar",
  "similar-asserts",
  "snailquote",
  "tempfile",
@@ -744,8 +811,12 @@ dependencies = [
  "insta",
  "mdt",
  "mdt_lsp",
+ "notify",
+ "owo-colors",
  "predicates",
  "rstest",
+ "serde_json",
+ "similar",
  "similar-asserts",
  "tempfile",
  "tokio",
@@ -782,7 +853,7 @@ dependencies = [
  "cfg-if",
  "miette-derive",
  "owo-colors",
- "supports-color",
+ "supports-color 3.0.2",
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
@@ -826,6 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -843,6 +915,33 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.9.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "num"
@@ -937,6 +1036,10 @@ name = "owo-colors"
 version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+dependencies = [
+ "supports-color 2.1.0",
+ "supports-color 3.0.2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -958,7 +1061,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1179,6 +1282,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1454,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
 
 [[package]]
 name = "supports-color"
@@ -1746,6 +1868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,12 +1893,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1775,7 +1922,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1784,14 +1940,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1801,10 +1974,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1813,10 +1998,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1825,10 +2022,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1837,10 +2046,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ kdl = { default-features = false, version = "^6" }
 markdown = { default-features = false, version = "^1" }
 miette = { default-features = false, version = "^7" }
 minijinja = { default-features = false, version = "^2" }
+notify = { default-features = false, version = "^8" }
+owo-colors = { default-features = false, version = "^4" }
 predicates = { default-features = false, version = "^3" }
 rstest = { default-features = false, version = "^0.26" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1" }
 serde_yml = { default-features = false, version = "^0.0.12" }
+similar = { default-features = false, version = "^2" }
 similar-asserts = { default-features = false, version = "^1" }
 snailquote = { default-features = false, version = "^0.3" }
 tempfile = { default-features = false, version = "^3" }

--- a/crates/mdt/Cargo.toml
+++ b/crates/mdt/Cargo.toml
@@ -23,6 +23,7 @@ minijinja = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"], default-features = true }
 serde_json = { workspace = true, default-features = true }
 serde_yml = { workspace = true, default-features = true }
+similar = { workspace = true, default-features = true }
 snailquote = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }

--- a/crates/mdt/src/config.rs
+++ b/crates/mdt/src/config.rs
@@ -16,6 +16,12 @@ use crate::MdtResult;
 ///
 /// [exclude]
 /// patterns = ["vendor/**", "generated/**"]
+///
+/// [include]
+/// patterns = ["docs/**/*.rs"]
+///
+/// [templates]
+/// paths = ["shared/templates"]
 /// ```
 #[derive(Debug, Deserialize)]
 pub struct MdtConfig {
@@ -25,6 +31,12 @@ pub struct MdtConfig {
 	/// Exclusion configuration.
 	#[serde(default)]
 	pub exclude: ExcludeConfig,
+	/// Inclusion configuration — additional glob patterns to scan.
+	#[serde(default)]
+	pub include: IncludeConfig,
+	/// Template paths — additional directories to search for `*.t.md` files.
+	#[serde(default)]
+	pub templates: TemplatesConfig,
 }
 
 /// Configuration for excluding files and directories from scanning.
@@ -34,6 +46,24 @@ pub struct ExcludeConfig {
 	/// These are relative to the project root.
 	#[serde(default)]
 	pub patterns: Vec<String>,
+}
+
+/// Configuration for including additional files in scanning.
+#[derive(Debug, Default, Deserialize)]
+pub struct IncludeConfig {
+	/// Additional glob patterns for files to scan.
+	/// These are relative to the project root.
+	#[serde(default)]
+	pub patterns: Vec<String>,
+}
+
+/// Configuration for additional template search paths.
+#[derive(Debug, Default, Deserialize)]
+pub struct TemplatesConfig {
+	/// Additional directories to search for `*.t.md` template files.
+	/// These are relative to the project root.
+	#[serde(default)]
+	pub paths: Vec<PathBuf>,
 }
 
 impl MdtConfig {

--- a/crates/mdt/src/error.rs
+++ b/crates/mdt/src/error.rs
@@ -8,32 +8,84 @@ pub enum MdtError {
 	Io(#[from] std::io::Error),
 
 	#[error("failure to load markdown: {0}")]
-	#[diagnostic(code(mdt::io_error))]
+	#[diagnostic(code(mdt::markdown))]
 	Markdown(String),
-	#[diagnostic(code(mdt::missing_closing_tag))]
-	#[error("missing closing tag for block: {0}")]
+
+	#[error("missing closing tag for block: `{0}`")]
+	#[diagnostic(
+		code(mdt::missing_closing_tag),
+		help("add `<!-- {{/{0}}} -->` to close this block")
+	)]
 	MissingClosingTag(String),
+
 	#[error("invalid token sequence")]
 	#[diagnostic(code(mdt::invalid_token_sequence))]
 	InvalidTokenSequence(usize),
-	#[error("no provider found for consumer block: {0}")]
-	#[diagnostic(code(mdt::missing_provider))]
+
+	#[error("no provider found for consumer block: `{0}`")]
+	#[diagnostic(
+		code(mdt::missing_provider),
+		help("define a provider block `<!-- {{@{0}}} -->...<!-- {{/{0}}} -->` in a *.t.md file")
+	)]
 	MissingProvider(String),
+
 	#[error("consumer block `{name}` in {file} is out of date")]
-	#[diagnostic(code(mdt::stale_consumer))]
+	#[diagnostic(
+		code(mdt::stale_consumer),
+		help("run `mdt update` to synchronize consumer blocks")
+	)]
 	StaleConsumer { name: String, file: String },
+
 	#[error("failed to parse config file: {0}")]
-	#[diagnostic(code(mdt::config_parse))]
+	#[diagnostic(
+		code(mdt::config_parse),
+		help("check that mdt.toml is valid TOML with [data] and/or [exclude] sections")
+	)]
 	ConfigParse(String),
+
 	#[error("failed to load data file `{path}`: {reason}")]
 	#[diagnostic(code(mdt::data_file))]
 	DataFile { path: String, reason: String },
-	#[error("unsupported data file format: {0}")]
-	#[diagnostic(code(mdt::unsupported_format))]
+
+	#[error("unsupported data file format: `{0}`")]
+	#[diagnostic(
+		code(mdt::unsupported_format),
+		help("supported formats: .json, .toml, .yaml, .yml, .kdl")
+	)]
 	UnsupportedDataFormat(String),
+
 	#[error("template rendering failed: {0}")]
 	#[diagnostic(code(mdt::template_render))]
 	TemplateRender(String),
+
+	#[error("duplicate provider `{name}`: defined in `{first_file}` and `{second_file}`")]
+	#[diagnostic(
+		code(mdt::duplicate_provider),
+		help("each provider block name must be unique across the project")
+	)]
+	DuplicateProvider {
+		name: String,
+		first_file: String,
+		second_file: String,
+	},
+
+	#[error("unknown transformer: `{0}`")]
+	#[diagnostic(
+		code(mdt::unknown_transformer),
+		help(
+			"available transformers: trim, trimStart, trimEnd, indent, prefix, suffix, \
+			 linePrefix, lineSuffix, wrap, codeBlock, code, replace"
+		)
+	)]
+	UnknownTransformer(String),
+
+	#[error("transformer `{name}` expects {expected} argument(s), got {got}")]
+	#[diagnostic(code(mdt::invalid_transformer_args))]
+	InvalidTransformerArgs {
+		name: String,
+		expected: String,
+		got: usize,
+	},
 }
 
 pub type MdtResult<T> = Result<T, MdtError>;

--- a/crates/mdt_cli/Cargo.toml
+++ b/crates/mdt_cli/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive"], default-features = true }
 mdt = { workspace = true }
 mdt_lsp = { workspace = true }
+notify = { workspace = true, features = ["macos_fsevent"], default-features = true }
+owo-colors = { workspace = true, features = ["supports-colors"], default-features = true }
+serde_json = { workspace = true, default-features = true }
+similar = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["full"], default-features = true }
 
 [dev-dependencies]

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use clap::Subcommand;
+use clap::ValueEnum;
 
 #[derive(Parser)]
 #[command(
@@ -26,6 +27,10 @@ pub struct MdtCli {
 	/// Enable verbose output.
 	#[arg(long, short, global = true, default_value_t = false)]
 	pub verbose: bool,
+
+	/// Disable colored output.
+	#[arg(long, global = true, default_value_t = false)]
+	pub no_color: bool,
 }
 
 #[derive(Subcommand)]
@@ -36,7 +41,15 @@ pub enum Commands {
 	///
 	/// Exits with a non-zero status code if any consumer blocks are stale.
 	/// Use this in CI to ensure documentation stays synchronized.
-	Check,
+	Check {
+		/// Show a diff for each stale consumer block.
+		#[arg(long, default_value_t = false)]
+		diff: bool,
+
+		/// Output format for check results.
+		#[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+		format: OutputFormat,
+	},
 	/// Update all consumer blocks with the latest provider content.
 	///
 	/// Reads provider blocks from *.t.md template files and replaces
@@ -45,11 +58,27 @@ pub enum Commands {
 		/// Show what would change without writing files.
 		#[arg(long, default_value_t = false)]
 		dry_run: bool,
+
+		/// Watch for file changes and re-run updates automatically.
+		#[arg(long, default_value_t = false)]
+		watch: bool,
 	},
+	/// List all provider and consumer blocks in the project.
+	List,
 	/// Start the mdt language server (LSP).
 	///
 	/// Communicates over stdin/stdout using the Language Server Protocol.
 	/// Configure your editor to run `mdt lsp` as the language server
 	/// command for markdown and template files.
 	Lsp,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+	/// Human-readable text output.
+	Text,
+	/// JSON output for programmatic consumption.
+	Json,
+	/// GitHub Actions annotation format.
+	Github,
 }

--- a/crates/mdt_cli/src/main.rs
+++ b/crates/mdt_cli/src/main.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
 use std::path::PathBuf;
 use std::process;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use clap::Parser;
 use mdt::check_project;
@@ -9,14 +12,62 @@ use mdt::project::scan_project_with_config;
 use mdt::write_updates;
 use mdt_cli::Commands;
 use mdt_cli::MdtCli;
+use mdt_cli::OutputFormat;
+use owo_colors::OwoColorize;
+use similar::ChangeTag;
+use similar::TextDiff;
+
+static USE_COLOR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+fn color_enabled() -> bool {
+	USE_COLOR.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Apply ANSI color codes only when color is enabled.
+macro_rules! colored {
+	($text:expr,red) => {
+		if color_enabled() {
+			format!("{}", $text.red())
+		} else {
+			format!("{}", $text)
+		}
+	};
+	($text:expr,green) => {
+		if color_enabled() {
+			format!("{}", $text.green())
+		} else {
+			format!("{}", $text)
+		}
+	};
+	($text:expr,yellow) => {
+		if color_enabled() {
+			format!("{}", $text.yellow())
+		} else {
+			format!("{}", $text)
+		}
+	};
+	($text:expr,bold) => {
+		if color_enabled() {
+			format!("{}", $text.bold())
+		} else {
+			format!("{}", $text)
+		}
+	};
+}
 
 fn main() {
 	let args = MdtCli::parse();
 
+	// Respect NO_COLOR env var and --no-color flag.
+	if args.no_color || std::env::var_os("NO_COLOR").is_some() {
+		USE_COLOR.store(false, std::sync::atomic::Ordering::Relaxed);
+	}
+
 	let result = match args.command {
 		Some(Commands::Init) => run_init(&args),
-		Some(Commands::Check) => run_check(&args),
-		Some(Commands::Update { dry_run }) => run_update(&args, dry_run),
+		Some(Commands::Check { diff, format }) => run_check(&args, diff, format),
+		Some(Commands::Update { dry_run, watch }) => run_update(&args, dry_run, watch),
+		Some(Commands::List) => run_list(&args),
 		Some(Commands::Lsp) => run_lsp(),
 		None => {
 			eprintln!("No subcommand specified. Run `mdt --help` for usage.");
@@ -25,7 +76,7 @@ fn main() {
 	};
 
 	if let Err(e) = result {
-		eprintln!("error: {e}");
+		eprintln!("{} {e}", colored!("error:", red));
 		process::exit(1);
 	}
 }
@@ -85,37 +136,131 @@ fn scan_and_warn(args: &MdtCli) -> Result<ProjectContext, Box<dyn std::error::Er
 
 	// Warn about consumers referencing non-existent providers
 	for name in &ctx.find_missing_providers() {
-		eprintln!("warning: consumer block `{name}` has no matching provider");
+		eprintln!(
+			"{} consumer block `{name}` has no matching provider",
+			colored!("warning:", yellow)
+		);
 	}
 
 	Ok(ctx)
 }
 
-fn run_check(args: &MdtCli) -> Result<(), Box<dyn std::error::Error>> {
+fn run_check(
+	args: &MdtCli,
+	show_diff: bool,
+	format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
 	let ctx = scan_and_warn(args)?;
+	let root = resolve_root(args);
 	let result = check_project(&ctx)?;
 
 	if result.is_ok() {
-		println!("All consumer blocks are up to date.");
-		Ok(())
-	} else {
-		for entry in &result.stale {
+		match format {
+			OutputFormat::Json => {
+				println!("{{\"ok\":true,\"stale\":[]}}");
+			}
+			OutputFormat::Github | OutputFormat::Text => {
+				println!("All consumer blocks are up to date.");
+			}
+		}
+		return Ok(());
+	}
+
+	match format {
+		OutputFormat::Json => {
+			let stale_entries: Vec<serde_json::Value> = result
+				.stale
+				.iter()
+				.map(|entry| {
+					let rel = make_relative(&entry.file, &root);
+					serde_json::json!({
+						"file": rel,
+						"block": entry.block_name,
+					})
+				})
+				.collect();
+			let output = serde_json::json!({
+				"ok": false,
+				"stale": stale_entries,
+			});
+			println!("{output}");
+		}
+		OutputFormat::Github => {
+			for entry in &result.stale {
+				let rel = make_relative(&entry.file, &root);
+				println!(
+					"::warning file={rel}::Consumer block `{}` is out of date",
+					entry.block_name
+				);
+			}
 			eprintln!(
-				"Stale: block `{}` in {}",
-				entry.block_name,
-				entry.file.display()
+				"\n{} consumer block(s) are out of date. Run `mdt update` to fix.",
+				result.stale.len()
 			);
 		}
-		eprintln!(
-			"\n{} consumer block(s) are out of date. Run `mdt update` to fix.",
-			result.stale.len()
-		);
-		process::exit(1);
+		OutputFormat::Text => {
+			for entry in &result.stale {
+				let rel = make_relative(&entry.file, &root);
+				eprintln!("Stale: block `{}` in {rel}", entry.block_name);
+
+				if show_diff {
+					print_diff(&entry.current_content, &entry.expected_content);
+				}
+			}
+			eprintln!(
+				"\n{} consumer block(s) are out of date. Run `mdt update` to fix.",
+				result.stale.len()
+			);
+		}
+	}
+
+	process::exit(1);
+}
+
+fn run_update(args: &MdtCli, dry_run: bool, watch: bool) -> Result<(), Box<dyn std::error::Error>> {
+	// Run the initial update.
+	run_update_once(args, dry_run)?;
+
+	if !watch || dry_run {
+		return Ok(());
+	}
+
+	// Watch mode
+	println!("\nWatching for file changes... (press Ctrl+C to stop)");
+
+	let root = resolve_root(args);
+	let (tx, rx) = mpsc::channel();
+
+	let mut watcher =
+		notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+			if let Ok(event) = res {
+				if matches!(
+					event.kind,
+					notify::EventKind::Modify(_) | notify::EventKind::Create(_)
+				) {
+					let _ = tx.send(());
+				}
+			}
+		})?;
+
+	use notify::Watcher;
+	watcher.watch(&root, notify::RecursiveMode::Recursive)?;
+
+	loop {
+		rx.recv()?;
+		// Debounce: drain additional events within 200ms.
+		while rx.recv_timeout(Duration::from_millis(200)).is_ok() {}
+
+		println!("\nFile change detected, updating...");
+		if let Err(e) = run_update_once(args, false) {
+			eprintln!("{} {e}", colored!("error:", red));
+		}
 	}
 }
 
-fn run_update(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
+fn run_update_once(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
 	let ctx = scan_and_warn(args)?;
+	let root = resolve_root(args);
 	let updates = compute_updates(&ctx)?;
 
 	if updates.updated_count == 0 {
@@ -130,7 +275,8 @@ fn run_update(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::error::Er
 			updates.updated_files.len()
 		);
 		for path in updates.updated_files.keys() {
-			println!("  {}", path.display());
+			let rel = make_relative(path, &root);
+			println!("  {rel}");
 		}
 	} else {
 		write_updates(&updates)?;
@@ -142,10 +288,73 @@ fn run_update(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::error::Er
 
 		if args.verbose {
 			for path in updates.updated_files.keys() {
-				println!("  {}", path.display());
+				let rel = make_relative(path, &root);
+				println!("  {rel}");
 			}
 		}
 	}
+
+	Ok(())
+}
+
+fn run_list(args: &MdtCli) -> Result<(), Box<dyn std::error::Error>> {
+	let ctx = scan_and_warn(args)?;
+	let root = resolve_root(args);
+
+	if ctx.project.providers.is_empty() && ctx.project.consumers.is_empty() {
+		println!("No provider or consumer blocks found.");
+		return Ok(());
+	}
+
+	// Providers
+	if !ctx.project.providers.is_empty() {
+		println!("{}", colored!("Providers:", bold));
+		let mut names: Vec<_> = ctx.project.providers.keys().collect();
+		names.sort();
+		for name in names {
+			let entry = &ctx.project.providers[name];
+			let rel = make_relative(&entry.file, &root);
+			let consumer_count = ctx
+				.project
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == *name)
+				.count();
+			println!("  @{name} {rel} ({consumer_count} consumer(s))");
+		}
+	}
+
+	// Consumers
+	if !ctx.project.consumers.is_empty() {
+		if !ctx.project.providers.is_empty() {
+			println!();
+		}
+		println!("{}", colored!("Consumers:", bold));
+		for consumer in &ctx.project.consumers {
+			let rel = make_relative(&consumer.file, &root);
+			let has_provider = ctx.project.providers.contains_key(&consumer.block.name);
+			let status = if has_provider { "linked" } else { "orphan" };
+			let transformers = if consumer.block.transformers.is_empty() {
+				String::new()
+			} else {
+				let names: Vec<String> = consumer
+					.block
+					.transformers
+					.iter()
+					.map(|t| t.r#type.to_string())
+					.collect();
+				format!(" |{}", names.join("|"))
+			};
+			println!("  ={} {rel}{transformers} [{status}]", consumer.block.name);
+		}
+	}
+
+	// Summary
+	println!(
+		"\n{} provider(s), {} consumer(s)",
+		ctx.project.providers.len(),
+		ctx.project.consumers.len()
+	);
 
 	Ok(())
 }
@@ -154,4 +363,30 @@ fn run_lsp() -> Result<(), Box<dyn std::error::Error>> {
 	let rt = tokio::runtime::Runtime::new()?;
 	rt.block_on(mdt_lsp::run_server());
 	Ok(())
+}
+
+/// Print a unified diff between two strings, colorized.
+fn print_diff(current: &str, expected: &str) {
+	let diff = TextDiff::from_lines(current, expected);
+	for change in diff.iter_all_changes() {
+		match change.tag() {
+			ChangeTag::Delete => {
+				eprint!("  {}", colored!(format!("-{change}"), red));
+			}
+			ChangeTag::Insert => {
+				eprint!("  {}", colored!(format!("+{change}"), green));
+			}
+			ChangeTag::Equal => {
+				eprint!("   {change}");
+			}
+		}
+	}
+}
+
+/// Make a path relative to root for display purposes.
+fn make_relative(path: &Path, root: &Path) -> String {
+	path.strip_prefix(root)
+		.unwrap_or(path)
+		.display()
+		.to_string()
 }

--- a/crates/mdt_cli/tests/check.rs
+++ b/crates/mdt_cli/tests/check.rs
@@ -18,7 +18,8 @@ fn check_passes_when_up_to_date() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -45,7 +46,8 @@ fn check_fails_when_stale() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -62,7 +64,8 @@ fn check_with_no_blocks() -> AnyEmptyResult {
 	std::fs::write(tmp.path().join("readme.md"), "# Just a readme\n")?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -86,7 +89,8 @@ fn check_verbose_shows_provider_count() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--verbose")
 		.arg("--path")
 		.arg(tmp.path())
@@ -109,7 +113,8 @@ fn check_warns_missing_provider() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -135,7 +140,8 @@ fn check_stale_shows_block_name_and_file() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -160,7 +166,8 @@ fn check_multiple_stale_blocks() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("check")
+	cmd.env("NO_COLOR", "1")
+		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()

--- a/crates/mdt_cli/tests/typescript_workspace.rs
+++ b/crates/mdt_cli/tests/typescript_workspace.rs
@@ -34,7 +34,8 @@ fn update_typescript_workspace() -> AnyEmptyResult {
 	copy_fixture(tmp.path());
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -78,6 +79,7 @@ fn check_typescript_workspace_after_update() -> AnyEmptyResult {
 
 	// First update
 	Command::cargo_bin("mdt")?
+		.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
@@ -86,6 +88,7 @@ fn check_typescript_workspace_after_update() -> AnyEmptyResult {
 
 	// Then check — should pass
 	Command::cargo_bin("mdt")?
+		.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
@@ -103,6 +106,7 @@ fn check_typescript_workspace_stale() -> AnyEmptyResult {
 
 	// Check without updating — should fail because content is stale
 	Command::cargo_bin("mdt")?
+		.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
 		.arg(tmp.path())
@@ -120,13 +124,14 @@ fn dry_run_typescript_workspace() -> AnyEmptyResult {
 	let readme_before = std::fs::read_to_string(tmp.path().join("readme.md"))?;
 
 	Command::cargo_bin("mdt")?
+		.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--dry-run")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
 		.success()
-		.stdout(predicates::str::contains("Dry run"));
+		.stdout(predicates::str::contains("would update"));
 
 	// File should NOT have changed
 	let readme_after = std::fs::read_to_string(tmp.path().join("readme.md"))?;

--- a/crates/mdt_cli/tests/update.rs
+++ b/crates/mdt_cli/tests/update.rs
@@ -18,7 +18,8 @@ fn update_replaces_stale_content() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -47,7 +48,8 @@ fn update_noop_when_in_sync() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -71,13 +73,14 @@ fn update_dry_run_does_not_write() -> AnyEmptyResult {
 	std::fs::write(tmp.path().join("readme.md"), consumer_content)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--dry-run")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
 		.success()
-		.stdout(predicates::str::contains("Dry run"));
+		.stdout(predicates::str::contains("would update"));
 
 	// File should not have changed
 	let content = std::fs::read_to_string(tmp.path().join("readme.md"))?;
@@ -101,7 +104,8 @@ fn update_with_transformers() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -127,7 +131,8 @@ fn update_verbose_shows_files() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--verbose")
 		.arg("--path")
 		.arg(tmp.path())
@@ -148,7 +153,8 @@ fn update_warns_missing_provider() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -174,7 +180,8 @@ fn update_multiple_blocks_in_one_file() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -203,7 +210,8 @@ fn update_dry_run_shows_file_list() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--dry-run")
 		.arg("--path")
 		.arg(tmp.path())
@@ -237,7 +245,8 @@ fn update_with_config_and_data() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()
@@ -264,7 +273,8 @@ fn update_preserves_surrounding_content() -> AnyEmptyResult {
 	)?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
-	cmd.arg("update")
+	cmd.env("NO_COLOR", "1")
+		.arg("update")
 		.arg("--path")
 		.arg(tmp.path())
 		.assert()


### PR DESCRIPTION
## Summary

Comprehensive API completeness improvements across all three crates (`mdt`, `mdt_cli`, `mdt_lsp`), implementing 12 features that bring the project closer to a feature-complete state.

### Core library (`mdt`)
- **New transformers:** `suffix`, `linePrefix`, `lineSuffix` with both camelCase and snake_case name support
- **Duplicate provider detection:** Reports errors when two template files define the same provider name
- **Rich miette diagnostics:** All error variants now include `#[help(...)]` with actionable guidance
- **Transformer validation:** `validate_transformers()` checks argument counts for correctness
- **Block PartialEq/Eq:** `Block`, `Transformer`, `Argument` derive `PartialEq` with `OrderedFloat` wrapper
- **Config improvements:** `[include]` patterns and `[templates]` paths sections in `mdt.toml`

### CLI (`mdt_cli`)
- `mdt check --diff` — colorized unified diff of stale blocks
- `mdt check --format json|github|text` — machine-readable output formats including GitHub Actions annotations
- `mdt list` — displays all providers/consumers with relationship status and transformers
- `mdt update --watch` — watches for file changes with 200ms debouncing
- Colored output with `NO_COLOR` env var and `--no-color` flag support

### LSP (`mdt_lsp`)
- Incremental document updates on save (full rescan only for `mdt.toml` changes)
- New transformer completions for suffix, linePrefix, lineSuffix

## Test plan
- [x] All 178 tests pass (`cargo nextest run`)
- [x] Zero clippy warnings (`cargo clippy --all-features`)
- [x] Formatting clean (`dprint check`)
- [x] 23 new unit tests covering all new features
- [x] Changeset included