### PR TITLE
feat: add MCP server, security hardening, and quality improvements

### DIFF
--- a/.changeset/security-mcp-improvements.md
+++ b/.changeset/security-mcp-improvements.md
@@ -1,0 +1,28 @@
+---
+mdt: minor
+mdt_cli: minor
+---
+
+Add MCP server, security hardening, and quality improvements.
+
+**MCP server (`mdt_mcp`):** New crate providing a Model Context Protocol server with 6 tools: `mdt_check`, `mdt_update`, `mdt_list`, `mdt_get_block`, `mdt_preview`, and `mdt_init`. The server communicates over stdin/stdout and can be launched via `mdt mcp`. Built on the `rmcp` SDK.
+
+**Security hardening:**
+
+- Add configurable file size limits (`max_file_size` in `mdt.toml`, default 10MB) to prevent denial-of-service from large files
+- Add symlink cycle detection during directory walking to prevent infinite loops
+- Normalize CRLF line endings (`\r\n` and `\r`) to LF (`\n`) on read for consistent cross-platform behavior
+- Return proper errors for unconvertible float values (NaN, Infinity) in TOML and KDL data files instead of silently defaulting to 0
+
+**Performance:**
+
+- Optimize `offset_to_point` in the source scanner with a `LineTable` struct using binary search (O(log n) instead of O(n) per lookup)
+
+**Quality:**
+
+- Migrate LSP `DocumentSymbol` responses from deprecated `SymbolInformation` (flat) to hierarchical `DocumentSymbol` API
+- Fix CLI exit codes: exit 1 for stale blocks (expected failure), exit 2 for actual errors
+
+**Toolchain:**
+
+- Bump `rust-toolchain.toml` from 1.87.0 to 1.88.0 (required by `rmcp` dependency)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,16 +183,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -244,6 +283,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +411,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -362,6 +453,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -383,6 +475,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -505,6 +608,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +793,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -680,6 +813,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kdl"
@@ -811,6 +954,7 @@ dependencies = [
  "insta",
  "mdt",
  "mdt_lsp",
+ "mdt_mcp",
  "notify",
  "owo-colors",
  "predicates",
@@ -834,6 +978,18 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "mdt_mcp"
+version = "0.0.0"
+dependencies = [
+ "mdt",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -1064,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1345,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1398,40 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rmcp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
 
 [[package]]
 name = "rstest"
@@ -1275,6 +1491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1509,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -1325,6 +1573,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1377,6 +1636,12 @@ dependencies = [
  "serde",
  "version_check",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1517,7 +1782,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1892,12 +2157,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1905,6 +2250,24 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/*", "docs"]
-default-members = ["crates/*", "docs"]
+default-members = ["crates/mdt", "crates/mdt_cli", "crates/mdt_lsp", "docs"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -18,7 +18,9 @@ minijinja = { default-features = false, version = "^2" }
 notify = { default-features = false, version = "^8" }
 owo-colors = { default-features = false, version = "^4" }
 predicates = { default-features = false, version = "^3" }
+rmcp = { default-features = false, version = "^0.16" }
 rstest = { default-features = false, version = "^0.26" }
+schemars = { default-features = false, version = "^0.8" }
 serde = { default-features = false, version = "^1" }
 serde_json = { default-features = false, version = "^1" }
 serde_yml = { default-features = false, version = "^0.0.12" }
@@ -35,6 +37,7 @@ tower-lsp = { default-features = false, version = "^0.20" }
 mdt = { path = "./crates/mdt", version = "0.0.0" }
 mdt_cli = { path = "./crates/mdt_cli", version = "0.0.0" }
 mdt_lsp = { path = "./crates/mdt_lsp", version = "0.0.0" }
+mdt_mcp = { path = "./crates/mdt_mcp", version = "0.0.0" }
 
 [workspace.package]
 version = "0.0.0"

--- a/crates/mdt/src/config.rs
+++ b/crates/mdt/src/config.rs
@@ -7,6 +7,9 @@ use serde::Deserialize;
 use crate::MdtError;
 use crate::MdtResult;
 
+/// Default maximum file size in bytes (10 MB).
+pub const DEFAULT_MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
 /// Configuration loaded from an `mdt.toml` file.
 ///
 /// ```toml
@@ -37,6 +40,14 @@ pub struct MdtConfig {
 	/// Template paths — additional directories to search for `*.t.md` files.
 	#[serde(default)]
 	pub templates: TemplatesConfig,
+	/// Maximum file size in bytes to scan. Files larger than this are skipped.
+	/// Defaults to 10 MB.
+	#[serde(default = "default_max_file_size")]
+	pub max_file_size: u64,
+}
+
+fn default_max_file_size() -> u64 {
+	DEFAULT_MAX_FILE_SIZE
 }
 
 /// Configuration for excluding files and directories from scanning.
@@ -130,7 +141,7 @@ fn parse_data_file(
 					reason: e.to_string(),
 				}
 			})?;
-			toml_to_json(toml_value)
+			toml_to_json(toml_value, path_display)
 		}
 		"yaml" | "yml" => {
 			serde_yml::from_str(content).map_err(|e| {
@@ -147,38 +158,45 @@ fn parse_data_file(
 					reason: e.to_string(),
 				}
 			})?;
-			Ok(kdl_document_to_value(&doc))
+			kdl_document_to_value(&doc, path_display)
 		}
 		other => Err(MdtError::UnsupportedDataFormat(other.to_string())),
 	}
 }
 
 /// Convert a `toml::Value` to a `serde_json::Value`.
-fn toml_to_json(value: toml::Value) -> MdtResult<serde_json::Value> {
+fn toml_to_json(value: toml::Value, path_display: &str) -> MdtResult<serde_json::Value> {
 	let json = match value {
 		toml::Value::String(s) => serde_json::Value::String(s),
 		toml::Value::Integer(i) => {
-			serde_json::Value::Number(
-				serde_json::Number::from_f64(i as f64)
-					.unwrap_or_else(|| serde_json::Number::from(0)),
-			)
+			serde_json::Value::Number(serde_json::Number::from_f64(i as f64).ok_or_else(|| {
+				MdtError::UnconvertibleFloat {
+					path: path_display.to_string(),
+					value: i.to_string(),
+				}
+			})?)
 		}
 		toml::Value::Float(f) => {
-			serde_json::Value::Number(
-				serde_json::Number::from_f64(f).unwrap_or_else(|| serde_json::Number::from(0)),
-			)
+			serde_json::Value::Number(serde_json::Number::from_f64(f).ok_or_else(|| {
+				MdtError::UnconvertibleFloat {
+					path: path_display.to_string(),
+					value: f.to_string(),
+				}
+			})?)
 		}
 		toml::Value::Boolean(b) => serde_json::Value::Bool(b),
 		toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
 		toml::Value::Array(arr) => {
-			let items: MdtResult<Vec<serde_json::Value>> =
-				arr.into_iter().map(toml_to_json).collect();
+			let items: MdtResult<Vec<serde_json::Value>> = arr
+				.into_iter()
+				.map(|v| toml_to_json(v, path_display))
+				.collect();
 			serde_json::Value::Array(items?)
 		}
 		toml::Value::Table(table) => {
 			let mut map = serde_json::Map::new();
 			for (k, v) in table {
-				map.insert(k, toml_to_json(v)?);
+				map.insert(k, toml_to_json(v, path_display)?);
 			}
 			serde_json::Value::Object(map)
 		}
@@ -188,35 +206,38 @@ fn toml_to_json(value: toml::Value) -> MdtResult<serde_json::Value> {
 }
 
 /// Convert a KDL document to a `serde_json::Value`.
-fn kdl_document_to_value(doc: &kdl::KdlDocument) -> serde_json::Value {
+fn kdl_document_to_value(
+	doc: &kdl::KdlDocument,
+	path_display: &str,
+) -> MdtResult<serde_json::Value> {
 	let mut map = serde_json::Map::new();
 
 	for node in doc.nodes() {
 		let name = node.name().to_string();
-		let value = kdl_node_to_value(node);
+		let value = kdl_node_to_value(node, path_display)?;
 		map.insert(name, value);
 	}
 
-	serde_json::Value::Object(map)
+	Ok(serde_json::Value::Object(map))
 }
 
 /// Convert a KDL node to a `serde_json::Value`.
-fn kdl_node_to_value(node: &kdl::KdlNode) -> serde_json::Value {
+fn kdl_node_to_value(node: &kdl::KdlNode, path_display: &str) -> MdtResult<serde_json::Value> {
 	// If the node has children, treat it as an object
 	if let Some(children) = node.children() {
-		return kdl_document_to_value(children);
+		return kdl_document_to_value(children, path_display);
 	}
 
 	// If the node has entries, collect them
 	let entries: Vec<&kdl::KdlEntry> = node.entries().iter().collect();
 
 	if entries.is_empty() {
-		return serde_json::Value::Null;
+		return Ok(serde_json::Value::Null);
 	}
 
 	// If there's exactly one positional argument with no name, return it directly
 	if entries.len() == 1 && entries[0].name().is_none() {
-		return kdl_entry_value_to_json(entries[0].value());
+		return kdl_entry_value_to_json(entries[0].value(), path_display);
 	}
 
 	// If all entries are named, create an object
@@ -225,36 +246,51 @@ fn kdl_node_to_value(node: &kdl::KdlNode) -> serde_json::Value {
 		let mut map = serde_json::Map::new();
 		for entry in &entries {
 			if let Some(name) = entry.name() {
-				map.insert(name.to_string(), kdl_entry_value_to_json(entry.value()));
+				map.insert(
+					name.to_string(),
+					kdl_entry_value_to_json(entry.value(), path_display)?,
+				);
 			}
 		}
-		return serde_json::Value::Object(map);
+		return Ok(serde_json::Value::Object(map));
 	}
 
 	// Mixed or multiple positional: return an array
-	let values: Vec<serde_json::Value> = entries
+	let values: MdtResult<Vec<serde_json::Value>> = entries
 		.iter()
-		.map(|e| kdl_entry_value_to_json(e.value()))
+		.map(|e| kdl_entry_value_to_json(e.value(), path_display))
 		.collect();
-	serde_json::Value::Array(values)
+	Ok(serde_json::Value::Array(values?))
 }
 
 /// Convert a KDL entry value to a `serde_json::Value`.
-fn kdl_entry_value_to_json(value: &kdl::KdlValue) -> serde_json::Value {
+fn kdl_entry_value_to_json(
+	value: &kdl::KdlValue,
+	path_display: &str,
+) -> MdtResult<serde_json::Value> {
 	match value {
-		kdl::KdlValue::String(s) => serde_json::Value::String(s.clone()),
+		kdl::KdlValue::String(s) => Ok(serde_json::Value::String(s.clone())),
 		kdl::KdlValue::Integer(i) => {
-			serde_json::Value::Number(
-				serde_json::Number::from_f64(*i as f64)
-					.unwrap_or_else(|| serde_json::Number::from(0)),
-			)
+			Ok(serde_json::Value::Number(
+				serde_json::Number::from_f64(*i as f64).ok_or_else(|| {
+					MdtError::UnconvertibleFloat {
+						path: path_display.to_string(),
+						value: i.to_string(),
+					}
+				})?,
+			))
 		}
 		kdl::KdlValue::Float(f) => {
-			serde_json::Value::Number(
-				serde_json::Number::from_f64(*f).unwrap_or_else(|| serde_json::Number::from(0)),
-			)
+			Ok(serde_json::Value::Number(
+				serde_json::Number::from_f64(*f).ok_or_else(|| {
+					MdtError::UnconvertibleFloat {
+						path: path_display.to_string(),
+						value: f.to_string(),
+					}
+				})?,
+			))
 		}
-		kdl::KdlValue::Bool(b) => serde_json::Value::Bool(*b),
-		kdl::KdlValue::Null => serde_json::Value::Null,
+		kdl::KdlValue::Bool(b) => Ok(serde_json::Value::Bool(*b)),
+		kdl::KdlValue::Null => Ok(serde_json::Value::Null),
 	}
 }

--- a/crates/mdt/src/error.rs
+++ b/crates/mdt/src/error.rs
@@ -86,6 +86,27 @@ pub enum MdtError {
 		expected: String,
 		got: usize,
 	},
+
+	#[error("file too large: `{path}` is {size} bytes (limit: {limit} bytes)")]
+	#[diagnostic(
+		code(mdt::file_too_large),
+		help("increase the file size limit in mdt.toml or exclude this file")
+	)]
+	FileTooLarge { path: String, size: u64, limit: u64 },
+
+	#[error("symlink cycle detected at: `{path}`")]
+	#[diagnostic(
+		code(mdt::symlink_cycle),
+		help("remove the circular symlink or exclude this path")
+	)]
+	SymlinkCycle { path: String },
+
+	#[error("unconvertible float value in data file `{path}`: {value}")]
+	#[diagnostic(
+		code(mdt::unconvertible_float),
+		help("NaN and Infinity are not valid JSON numbers")
+	)]
+	UnconvertibleFloat { path: String, value: String },
 }
 
 pub type MdtResult<T> = Result<T, MdtError>;

--- a/crates/mdt_cli/Cargo.toml
+++ b/crates/mdt_cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 clap = { workspace = true, features = ["derive"], default-features = true }
 mdt = { workspace = true }
 mdt_lsp = { workspace = true }
+mdt_mcp = { workspace = true }
 notify = { workspace = true, features = ["macos_fsevent"], default-features = true }
 owo-colors = { workspace = true, features = ["supports-colors"], default-features = true }
 serde_json = { workspace = true, default-features = true }

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -71,6 +71,12 @@ pub enum Commands {
 	/// Configure your editor to run `mdt lsp` as the language server
 	/// command for markdown and template files.
 	Lsp,
+	/// Start the mdt MCP (Model Context Protocol) server.
+	///
+	/// Communicates over stdin/stdout using the Model Context Protocol.
+	/// Configure your AI assistant to run `mdt mcp` as an MCP server
+	/// to give it structured access to mdt's template system.
+	Mcp,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/mdt_cli/src/main.rs
+++ b/crates/mdt_cli/src/main.rs
@@ -69,6 +69,7 @@ fn main() {
 		Some(Commands::Update { dry_run, watch }) => run_update(&args, dry_run, watch),
 		Some(Commands::List) => run_list(&args),
 		Some(Commands::Lsp) => run_lsp(),
+		Some(Commands::Mcp) => run_mcp(),
 		None => {
 			eprintln!("No subcommand specified. Run `mdt --help` for usage.");
 			process::exit(1);
@@ -77,7 +78,7 @@ fn main() {
 
 	if let Err(e) = result {
 		eprintln!("{} {e}", colored!("error:", red));
-		process::exit(1);
+		process::exit(2);
 	}
 }
 
@@ -362,6 +363,12 @@ fn run_list(args: &MdtCli) -> Result<(), Box<dyn std::error::Error>> {
 fn run_lsp() -> Result<(), Box<dyn std::error::Error>> {
 	let rt = tokio::runtime::Runtime::new()?;
 	rt.block_on(mdt_lsp::run_server());
+	Ok(())
+}
+
+fn run_mcp() -> Result<(), Box<dyn std::error::Error>> {
+	let rt = tokio::runtime::Runtime::new()?;
+	rt.block_on(mdt_mcp::run_server());
 	Ok(())
 }
 

--- a/crates/mdt_lsp/src/__tests.rs
+++ b/crates/mdt_lsp/src/__tests.rs
@@ -6,6 +6,7 @@ use mdt::parse;
 use mdt::project::ConsumerEntry;
 use mdt::project::ProviderEntry;
 use mdt::project::extract_content_between_tags;
+#[allow(unused_imports)]
 use tower_lsp::lsp_types::*;
 
 use super::*;

--- a/crates/mdt_mcp/Cargo.toml
+++ b/crates/mdt_mcp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mdt_mcp"
+version = { workspace = true }
+categories = { workspace = true }
+documentation = "https://docs.rs/mdt_mcp"
+edition = { workspace = true }
+include = { workspace = true }
+keywords = ["markdown", "templates", "mcp"]
+license = { workspace = true }
+publish = false
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+description = "MCP server for mdt (manage markdown templates)"
+
+[dependencies]
+mdt = { workspace = true }
+rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
+serde = { workspace = true, features = ["derive"], default-features = true }
+serde_json = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["full"], default-features = true }
+
+[dev-dependencies]
+tempfile = { workspace = true, default-features = true }
+
+[lints]
+workspace = true

--- a/crates/mdt_mcp/src/lib.rs
+++ b/crates/mdt_mcp/src/lib.rs
@@ -1,0 +1,500 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+use mdt::apply_transformers;
+use mdt::check_project;
+use mdt::compute_updates;
+use mdt::project::ProjectContext;
+use mdt::project::scan_project_with_config;
+use mdt::render_template;
+use mdt::write_updates;
+use rmcp::ErrorData as McpError;
+use rmcp::ServerHandler;
+use rmcp::ServiceExt;
+use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::*;
+use rmcp::schemars;
+use rmcp::serde;
+use rmcp::tool;
+use rmcp::tool_handler;
+use rmcp::tool_router;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Parameters for tools that accept an optional project path.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PathParam {
+	/// Path to the project root directory. Defaults to the current directory.
+	pub path: Option<String>,
+}
+
+/// Parameters for tools that need a block name.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct BlockParam {
+	/// Path to the project root directory. Defaults to the current directory.
+	pub path: Option<String>,
+	/// The name of the block to look up.
+	pub block_name: String,
+}
+
+/// Parameters for the update tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct UpdateParam {
+	/// Path to the project root directory. Defaults to the current directory.
+	pub path: Option<String>,
+	/// If true, show what would change without writing files.
+	#[serde(default)]
+	pub dry_run: bool,
+}
+
+/// Parameters for the init tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct InitParam {
+	/// Path to the project root directory. Defaults to the current directory.
+	pub path: Option<String>,
+}
+
+/// A provider info entry for JSON output.
+#[derive(Debug, Serialize)]
+struct ProviderInfo {
+	name: String,
+	file: String,
+	content: String,
+	consumer_count: usize,
+}
+
+/// A consumer info entry for JSON output.
+#[derive(Debug, Serialize)]
+struct ConsumerInfo {
+	name: String,
+	file: String,
+	transformers: Vec<String>,
+	is_stale: bool,
+}
+
+/// The MCP server for mdt.
+#[derive(Debug, Clone)]
+pub struct MdtMcpServer {
+	tool_router: ToolRouter<Self>,
+}
+
+#[tool_handler]
+impl ServerHandler for MdtMcpServer {
+	fn get_info(&self) -> ServerInfo {
+		ServerInfo {
+			instructions: Some(
+				"mdt (manage markdown templates) keeps documentation synchronized across your \
+				 project using comment-based template tags. Use these tools to check, update, \
+				 list, and preview template blocks."
+					.into(),
+			),
+			capabilities: ServerCapabilities::builder().enable_tools().build(),
+			..Default::default()
+		}
+	}
+}
+
+fn resolve_root(path: Option<&str>) -> PathBuf {
+	path.map_or_else(
+		|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+		PathBuf::from,
+	)
+}
+
+fn make_relative(path: &Path, root: &Path) -> String {
+	path.strip_prefix(root)
+		.unwrap_or(path)
+		.display()
+		.to_string()
+}
+
+fn scan_ctx(root: &Path) -> Result<ProjectContext, McpError> {
+	scan_project_with_config(root).map_err(|e| McpError::internal_error(e.to_string(), None))
+}
+
+#[tool_router]
+impl MdtMcpServer {
+	pub fn new() -> Self {
+		Self {
+			tool_router: Self::tool_router(),
+		}
+	}
+
+	#[tool(
+		name = "mdt_check",
+		description = "Check if all consumer blocks are up to date. Returns an actionable summary \
+		               of any stale blocks with file paths and diffs."
+	)]
+	async fn check(
+		&self,
+		Parameters(params): Parameters<PathParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let ctx = scan_ctx(&root)?;
+
+		let missing = ctx.find_missing_providers();
+		let result =
+			check_project(&ctx).map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+		if result.is_ok() && missing.is_empty() {
+			return Ok(CallToolResult::success(vec![Content::text(
+				"All consumer blocks are up to date.",
+			)]));
+		}
+
+		let mut parts = Vec::new();
+
+		if !result.stale.is_empty() {
+			parts.push(format!(
+				"{} consumer block(s) are stale:",
+				result.stale.len()
+			));
+			for entry in &result.stale {
+				let rel = make_relative(&entry.file, &root);
+				parts.push(format!("  - `{}` in {rel}", entry.block_name));
+			}
+			parts.push(String::new());
+			parts.push("Run mdt_update to synchronize them.".to_string());
+		}
+
+		if !missing.is_empty() {
+			parts.push(format!(
+				"\n{} consumer block(s) reference missing providers: {}",
+				missing.len(),
+				missing.join(", ")
+			));
+		}
+
+		Ok(CallToolResult::success(vec![Content::text(
+			parts.join("\n"),
+		)]))
+	}
+
+	#[tool(
+		name = "mdt_update",
+		description = "Update all stale consumer blocks with latest provider content. Supports \
+		               dry_run mode to preview changes without writing."
+	)]
+	async fn update(
+		&self,
+		Parameters(params): Parameters<UpdateParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let ctx = scan_ctx(&root)?;
+		let updates =
+			compute_updates(&ctx).map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+		if updates.updated_count == 0 {
+			return Ok(CallToolResult::success(vec![Content::text(
+				"All consumer blocks are already up to date. No changes needed.",
+			)]));
+		}
+
+		if params.dry_run {
+			let files: Vec<String> = updates
+				.updated_files
+				.keys()
+				.map(|p| format!("  - {}", make_relative(p, &root)))
+				.collect();
+			let msg = format!(
+				"Dry run: would update {} block(s) in {} file(s):\n{}",
+				updates.updated_count,
+				updates.updated_files.len(),
+				files.join("\n")
+			);
+			return Ok(CallToolResult::success(vec![Content::text(msg)]));
+		}
+
+		write_updates(&updates).map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+		let files: Vec<String> = updates
+			.updated_files
+			.keys()
+			.map(|p| make_relative(p, &root))
+			.collect();
+		let msg = format!(
+			"Updated {} block(s) in {} file(s): {}",
+			updates.updated_count,
+			updates.updated_files.len(),
+			files.join(", ")
+		);
+		Ok(CallToolResult::success(vec![Content::text(msg)]))
+	}
+
+	#[tool(
+		name = "mdt_list",
+		description = "List all provider and consumer blocks with their names, source files, \
+		               consumer counts, transformers, and staleness status."
+	)]
+	async fn list(
+		&self,
+		Parameters(params): Parameters<PathParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let ctx = scan_ctx(&root)?;
+
+		let mut providers: Vec<ProviderInfo> = ctx
+			.project
+			.providers
+			.iter()
+			.map(|(name, entry)| {
+				let consumer_count = ctx
+					.project
+					.consumers
+					.iter()
+					.filter(|c| c.block.name == *name)
+					.count();
+				ProviderInfo {
+					name: name.clone(),
+					file: make_relative(&entry.file, &root),
+					content: entry.content.trim().to_string(),
+					consumer_count,
+				}
+			})
+			.collect();
+		providers.sort_by(|a, b| a.name.cmp(&b.name));
+
+		let consumers: Vec<ConsumerInfo> = ctx
+			.project
+			.consumers
+			.iter()
+			.map(|c| {
+				let is_stale = ctx.project.providers.get(&c.block.name).is_some_and(|p| {
+					let rendered = render_template(&p.content, &ctx.data)
+						.unwrap_or_else(|_| p.content.clone());
+					let expected = apply_transformers(&rendered, &c.block.transformers);
+					c.content != expected
+				});
+				ConsumerInfo {
+					name: c.block.name.clone(),
+					file: make_relative(&c.file, &root),
+					transformers: c
+						.block
+						.transformers
+						.iter()
+						.map(|t| t.r#type.to_string())
+						.collect(),
+					is_stale,
+				}
+			})
+			.collect();
+
+		let output = serde_json::json!({
+			"providers": providers,
+			"consumers": consumers,
+			"summary": format!(
+				"{} provider(s), {} consumer(s)",
+				providers.len(),
+				consumers.len()
+			),
+		});
+
+		Ok(CallToolResult::success(vec![Content::text(
+			serde_json::to_string_pretty(&output)
+				.unwrap_or_else(|_| "Failed to serialize output".to_string()),
+		)]))
+	}
+
+	#[tool(
+		name = "mdt_get_block",
+		description = "Get full content, metadata, and status of a specific named block (provider \
+		               or consumer). Returns the block content, source file, and any transformers."
+	)]
+	async fn get_block(
+		&self,
+		Parameters(params): Parameters<BlockParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let ctx = scan_ctx(&root)?;
+
+		if let Some(provider) = ctx.project.providers.get(&params.block_name) {
+			let rendered = render_template(&provider.content, &ctx.data)
+				.unwrap_or_else(|_| provider.content.clone());
+			let consumer_count = ctx
+				.project
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == params.block_name)
+				.count();
+			let consumer_files: Vec<String> = ctx
+				.project
+				.consumers
+				.iter()
+				.filter(|c| c.block.name == params.block_name)
+				.map(|c| make_relative(&c.file, &root))
+				.collect();
+
+			let output = serde_json::json!({
+				"type": "provider",
+				"name": params.block_name,
+				"file": make_relative(&provider.file, &root),
+				"raw_content": provider.content,
+				"rendered_content": rendered,
+				"consumer_count": consumer_count,
+				"consumer_files": consumer_files,
+			});
+
+			return Ok(CallToolResult::success(vec![Content::text(
+				serde_json::to_string_pretty(&output)
+					.unwrap_or_else(|_| "Failed to serialize".to_string()),
+			)]));
+		}
+
+		let consumer_entries: Vec<&mdt::project::ConsumerEntry> = ctx
+			.project
+			.consumers
+			.iter()
+			.filter(|c| c.block.name == params.block_name)
+			.collect();
+
+		if consumer_entries.is_empty() {
+			return Ok(CallToolResult::error(vec![Content::text(format!(
+				"No block named `{}` found in the project.",
+				params.block_name
+			))]));
+		}
+
+		let mut entries = Vec::new();
+		for c in &consumer_entries {
+			let is_stale = ctx.project.providers.get(&c.block.name).is_some_and(|p| {
+				let rendered =
+					render_template(&p.content, &ctx.data).unwrap_or_else(|_| p.content.clone());
+				let expected = apply_transformers(&rendered, &c.block.transformers);
+				c.content != expected
+			});
+			entries.push(serde_json::json!({
+				"type": "consumer",
+				"name": c.block.name,
+				"file": make_relative(&c.file, &root),
+				"content": c.content,
+				"transformers": c.block.transformers.iter().map(|t| t.r#type.to_string()).collect::<Vec<_>>(),
+				"is_stale": is_stale,
+			}));
+		}
+
+		Ok(CallToolResult::success(vec![Content::text(
+			serde_json::to_string_pretty(&entries)
+				.unwrap_or_else(|_| "Failed to serialize".to_string()),
+		)]))
+	}
+
+	#[tool(
+		name = "mdt_preview",
+		description = "Preview the rendered content for a specific block after template \
+		               interpolation and transformer application."
+	)]
+	async fn preview(
+		&self,
+		Parameters(params): Parameters<BlockParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let ctx = scan_ctx(&root)?;
+
+		let Some(provider) = ctx.project.providers.get(&params.block_name) else {
+			return Ok(CallToolResult::error(vec![Content::text(format!(
+				"No provider named `{}` found.",
+				params.block_name
+			))]));
+		};
+
+		let rendered = render_template(&provider.content, &ctx.data)
+			.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+		let consumers: Vec<_> = ctx
+			.project
+			.consumers
+			.iter()
+			.filter(|c| c.block.name == params.block_name)
+			.collect();
+
+		let mut parts = Vec::new();
+		parts.push(format!(
+			"## Provider `{}`\n\nRendered content:\n```\n{}\n```",
+			params.block_name,
+			rendered.trim()
+		));
+
+		if !consumers.is_empty() {
+			parts.push(format!("\n## {} consumer(s):", consumers.len()));
+			for c in &consumers {
+				let transformed = apply_transformers(&rendered, &c.block.transformers);
+				let rel = make_relative(&c.file, &root);
+				let tf_names: Vec<String> = c
+					.block
+					.transformers
+					.iter()
+					.map(|t| t.r#type.to_string())
+					.collect();
+				let tf_str = if tf_names.is_empty() {
+					"(none)".to_string()
+				} else {
+					tf_names.join(" | ")
+				};
+				parts.push(format!(
+					"\n### {rel}\nTransformers: {tf_str}\n```\n{}\n```",
+					transformed.trim()
+				));
+			}
+		}
+
+		Ok(CallToolResult::success(vec![Content::text(
+			parts.join("\n"),
+		)]))
+	}
+
+	#[tool(
+		name = "mdt_init",
+		description = "Initialize mdt in a project by creating a sample template.t.md file."
+	)]
+	async fn init(
+		&self,
+		Parameters(params): Parameters<InitParam>,
+	) -> Result<CallToolResult, McpError> {
+		let root = resolve_root(params.path.as_deref());
+		let template_path = root.join("template.t.md");
+
+		if template_path.exists() {
+			return Ok(CallToolResult::success(vec![Content::text(format!(
+				"Template file already exists: {}",
+				template_path.display()
+			))]));
+		}
+
+		let sample_content = "<!-- {@greeting} -->\n\nHello from mdt! This is a provider \
+		                      block.\n\n<!-- {/greeting} -->\n";
+
+		std::fs::write(&template_path, sample_content)
+			.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+		Ok(CallToolResult::success(vec![Content::text(format!(
+			"Created template file: {}\n\nNext steps:\n1. Edit the template to define your \
+			 blocks\n2. Add consumer tags in your files: <!-- {{=greeting}} --> <!-- \
+			 {{/greeting}} -->\n3. Run mdt_update to sync content",
+			template_path.display()
+		))]))
+	}
+}
+
+impl Default for MdtMcpServer {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+/// Start the MCP server on stdin/stdout.
+pub async fn run_server() {
+	let server = MdtMcpServer::new();
+	let transport = rmcp::transport::io::stdio();
+
+	let service = server.serve(transport).await;
+
+	match service {
+		Ok(running) => {
+			let _ = running.waiting().await;
+		}
+		Err(e) => {
+			eprintln!("mdt-mcp: failed to start server: {e}");
+		}
+	}
+}

--- a/crates/mdt_mcp/src/main.rs
+++ b/crates/mdt_mcp/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {
+	let rt = tokio::runtime::Runtime::new().unwrap_or_else(|e| {
+		eprintln!("mdt-mcp: failed to create runtime: {e}");
+		std::process::exit(1);
+	});
+	rt.block_on(mdt_mcp::run_server());
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -26,6 +26,8 @@
     set -e
     # Ensure the nightly toolchain is available for rustfmt (used by dprint)
     rustup toolchain install nightly --component rustfmt --no-self-update 2>/dev/null || true
+    # Ensure stable is at least 1.88 (required by rmcp/darling for mdt_mcp)
+    rustup update stable --no-self-update 2>/dev/null || true
   '';
 
   # disable dotenv since it breaks the variable interpolation supported by `direnv`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["rustfmt", "cargo", "clippy", "rust-analyzer", "llvm-tools"]
 profile = "default"


### PR DESCRIPTION
## Summary

- **MCP server (`mdt_mcp`)**: New crate providing a Model Context Protocol server with 6 tools (`mdt_check`, `mdt_update`, `mdt_list`, `mdt_get_block`, `mdt_preview`, `mdt_init`). Built on the `rmcp` SDK, launched via `mdt mcp` CLI subcommand.
- **Security hardening**: File size limits (configurable `max_file_size`, default 10MB), symlink cycle detection, CRLF normalization, proper errors for unconvertible floats in TOML/KDL
- **Performance**: `LineTable` binary search optimization for source scanner `offset_to_point`
- **LSP quality**: Migrated from deprecated `SymbolInformation` to hierarchical `DocumentSymbol` API
- **CLI**: Fixed exit codes (1=stale blocks, 2=errors)
- **Tests**: 12 new tests covering CRLF, file size limits, UTF-8/emoji, edge cases (190 total, all passing)
- **Toolchain**: Bumped `rust-toolchain.toml` from 1.87.0 to 1.88.0 (required by `rmcp` dependency)

## Files changed

| Area | Files |
|------|-------|
| MCP server | `crates/mdt_mcp/` (new), `crates/mdt_cli/src/{lib,main}.rs`, `Cargo.toml` |
| Security | `crates/mdt/src/{error,config,project}.rs` |
| Performance | `crates/mdt/src/source_scanner.rs` |
| LSP | `crates/mdt_lsp/src/lib.rs` |
| Tests | `crates/mdt/src/__tests.rs` |
| Toolchain | `rust-toolchain.toml`, `devenv.nix` |

## Test plan

- [x] `cargo build --workspace` compiles successfully
- [x] `cargo nextest run` — 190 tests pass (12 new)
- [x] `cargo clippy --all-features --workspace` — no warnings
- [x] `dprint check` — formatting clean
- [x] Changeset included