### PR TITLE
docs: add MCP command, fix knope config, add docs-pages workflow

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,51 @@
+name: "docs-pages"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install mdbook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+
+      - name: setup pages
+        uses: actions/configure-pages@v5
+
+      - name: build mdbook
+        run: mdbook build docs
+
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/crates/mdt/changelog.md
+++ b/crates/mdt/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This file is maintained by `knope`.

--- a/crates/mdt_cli/changelog.md
+++ b/crates/mdt_cli/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This file is maintained by `knope`.

--- a/crates/mdt_cli/readme.md
+++ b/crates/mdt_cli/readme.md
@@ -21,6 +21,8 @@
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
+- `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 
 <!-- {/mdtCliUsage} -->
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,4 +35,4 @@ mdt = "0.0.0"
 mdt --help
 ```
 
-You should see the available commands: `init`, `check`, `update`, `list`, and `lsp`.
+You should see the available commands: `init`, `check`, `update`, `list`, `lsp`, and `mcp`.

--- a/docs/src/guide/ci-integration.md
+++ b/docs/src/guide/ci-integration.md
@@ -121,3 +121,49 @@ If you prefer to auto-fix in CI rather than just check, run `mdt update` and com
       exit 1
     fi
 ```
+
+## Publish mdBook on release
+
+This repository publishes the mdBook on every GitHub release (`release.published`) using GitHub Pages.
+
+The workflow lives at `.github/workflows/docs-pages.yml` and:
+
+1. Builds the book with `mdbook build docs`
+2. Uploads `docs/book` as a Pages artifact
+3. Deploys to GitHub Pages
+
+Equivalent workflow structure:
+
+```yaml
+name: docs-pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+      - uses: actions/configure-pages@v5
+      - run: mdbook build docs
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@v4
+```

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -77,6 +77,16 @@ paths = ["templates", "shared/docs"]
 
 When set, only `*.t.md` files within these directories are recognized as template files.
 
+### `max_file_size` — Safety limit for scanned files
+
+Set the maximum file size (in bytes) that mdt will scan. Files larger than this limit return an error.
+
+```toml
+max_file_size = 10485760 # 10 MB
+```
+
+If omitted, mdt uses a default of `10 MB`.
+
 ## Sub-project boundaries
 
 If mdt encounters a directory containing its own `mdt.toml`, it treats that directory as a separate project and skips it. This is useful in monorepos where each package manages its own templates:
@@ -113,4 +123,6 @@ patterns = ["src/**"]
 
 [templates]
 paths = ["templates"]
+
+max_file_size = 10485760
 ```

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -51,3 +51,4 @@ After running `mdt update`, every consumer named `install` has identical content
 - **CI-friendly** — `mdt check` exits non-zero when docs are stale, with JSON and GitHub Actions output formats
 - **Watch mode** — `mdt update --watch` auto-syncs on file changes during development
 - **LSP support** — Language server for editor integration with diagnostics, completions, and hover
+- **MCP support** — `mdt mcp` exposes template data to AI assistants via the Model Context Protocol

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -3,7 +3,7 @@
 ## Global options
 
 ```
-mdt [OPTIONS] <COMMAND>
+mdt [OPTIONS] [COMMAND]
 ```
 
 | Option            | Description                                                                |
@@ -164,6 +164,16 @@ The LSP provides:
 - **Go to definition** — Jump from a consumer tag to its provider definition.
 - **Document symbols** — Lists all blocks in the current file.
 - **Code actions** — Quick-fix to update a stale consumer block in place.
+
+### `mdt mcp`
+
+Start the MCP server for AI integrations. Communicates over stdin/stdout using the Model Context Protocol.
+
+```sh
+mdt mcp
+```
+
+Use this command when you want an AI assistant to query template providers, consumers, and render context directly from your project.
 
 ## Environment variables
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -94,6 +94,18 @@ paths = ["templates", "shared/docs"]
 
 By default (when this section is absent), mdt finds `*.t.md` files anywhere in the project tree.
 
+### `max_file_size`
+
+Maximum file size in bytes that mdt will scan.
+
+```toml
+max_file_size = 10485760
+```
+
+If a scanned file exceeds this value, mdt returns an error instead of reading it.
+
+Default value: `10485760` (10 MB).
+
 ## Complete example
 
 ```toml
@@ -120,6 +132,9 @@ patterns = ["src/**", "docs/**"]
 # Only look for templates in this directory
 [templates]
 paths = ["templates"]
+
+# Refuse to scan files larger than 10 MB
+max_file_size = 10485760
 ```
 
 ## Minimal example
@@ -139,3 +154,4 @@ If `mdt.toml` doesn't exist, mdt uses defaults:
 - No extra exclusions (only built-in exclusions apply)
 - No include filtering (all scannable files are scanned)
 - Templates found anywhere in the project tree
+- `max_file_size` defaults to 10 MB

--- a/knope.toml
+++ b/knope.toml
@@ -1,29 +1,49 @@
+[changes]
+ignore_conventional_commits = true
+
 [packages.mdt]
 versioned_files = [
-	"crates/mdt/Cargo.toml",
+	"Cargo.toml",
 	{ path = "Cargo.toml", dependency = "mdt" },
-	"Cargo.lock",
+	{ path = "Cargo.lock", dependency = "mdt" },
 ]
-scopes = ["mdt"]
 changelog = "crates/mdt/changelog.md"
-extra_changelog_sections = [{ name = "Notes", types = ["note"] }, { name = "Documentation", types = ["docs"] }]
+scopes = ["mdt"]
+
+[[packages.mdt.extra_changelog_sections]]
+name = "Notes"
+footers = []
+types = ["note"]
+
+[[packages.mdt.extra_changelog_sections]]
+name = "Documentation"
+footers = []
+types = ["docs"]
 
 [packages.mdt_cli]
 versioned_files = [
-	"crates/mdt_cli/Cargo.toml",
+	"Cargo.toml",
 	{ path = "Cargo.toml", dependency = "mdt_cli" },
-	"Cargo.lock",
+	{ path = "Cargo.lock", dependency = "mdt_cli" },
 ]
-scopes = ["mdt_cli"]
 changelog = "crates/mdt_cli/changelog.md"
-extra_changelog_sections = [{ name = "Notes", types = ["note"] }, { name = "Documentation", types = ["docs"] }]
+scopes = ["mdt_cli"]
+
+[[packages.mdt_cli.extra_changelog_sections]]
+name = "Notes"
+footers = []
+types = ["note"]
+
+[[packages.mdt_cli.extra_changelog_sections]]
+name = "Documentation"
+footers = []
+types = ["docs"]
 
 [[workflows]]
 name = "release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
-ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,8 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `wra
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
+- `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 
 <!-- {/mdtCliUsage} -->
 

--- a/template.t.md
+++ b/template.t.md
@@ -12,6 +12,7 @@
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
+- `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 
 <!-- {/mdtCliUsage} -->
 


### PR DESCRIPTION
## Summary

- Add `mdt mcp` and `mdt lsp` commands to CLI usage docs, readme, and template provider block
- Document `max_file_size` configuration option in guide and reference
- Document the docs-pages GitHub Actions workflow in CI integration guide
- Add `.github/workflows/docs-pages.yml` to publish mdBook on release via GitHub Pages
- Fix `knope.toml`: correct `versioned_files` paths and restructure `extra_changelog_sections` to valid TOML array-of-tables syntax
- Add initial `changelog.md` files for `mdt` and `mdt_cli` crates (required by knope)

## Test plan

- [ ] CI passes (build, lint, test)
- [ ] Verify `knope.toml` is valid by checking knope can parse it
- [ ] Verify docs build with `mdbook build docs`