### PR TITLE
fix: enable publishing for mdt_lsp and mdt_mcp crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "mdt_lsp"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "insta",
  "mdt",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mdt_mcp"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "mdt",
  "rmcp",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "monochange_book"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "mdt",
 ]
@@ -1920,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
@@ -1935,12 +1935,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.9",
+ "toml_datetime 0.6.11",
  "winnow 0.7.14",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ tower-lsp = { default-features = false, version = "^0.20" }
 # Internal crates
 mdt = { path = "./crates/mdt", version = "0.0.1" }
 mdt_cli = { path = "./crates/mdt_cli", version = "0.0.1" }
-mdt_lsp = { path = "./crates/mdt_lsp", version = "0.0.0" }
-mdt_mcp = { path = "./crates/mdt_mcp", version = "0.0.0" }
+mdt_lsp = { path = "./crates/mdt_lsp", version = "0.0.1" }
+mdt_mcp = { path = "./crates/mdt_mcp", version = "0.0.1" }
 
 [workspace.package]
 version = "0.0.1"

--- a/crates/mdt_lsp/Cargo.toml
+++ b/crates/mdt_lsp/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 include = { workspace = true }
 keywords = ["markdown", "templates", "lsp"]
 license = { workspace = true }
-publish = false
 readme = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/mdt_lsp/changelog.md
+++ b/crates/mdt_lsp/changelog.md
@@ -1,0 +1,20 @@
+# Changelog
+
+This file is maintained by `knope`.
+
+## 0.0.1 (2026-02-20)
+
+### Features
+
+#### Implement the mdt language server (LSP).
+
+**LSP features:**
+
+- **Diagnostics:** Warns about stale consumer blocks (content out of date), missing providers (consumer references non-existent provider), and provider blocks in non-template files.
+- **Hover:** Shows provider content preview when hovering over consumer tags. Shows consumer count and locations when hovering over provider tags. Displays transformer chain and source file path.
+- **Completion:** Suggests block names when typing inside `{=`, `{@`, or `{/` tags. Suggests transformer names (`trim`, `indent`, `codeBlock`, etc.) after pipe `|` characters with usage descriptions.
+- **Go to Definition:** Navigates from consumer tag to its provider definition in the template file. From provider tags, navigates to all consumer locations.
+- **Document Symbols:** Lists all provider (`@name`) and consumer (`=name`) blocks in the editor outline/breadcrumb.
+- **Code Actions:** Offers "Update block" quick-fix for stale consumer blocks that replaces content with the latest provider output.
+
+**Incremental updates:** The language server performs incremental document updates on save instead of full project rescans, with full rescans only when `mdt.toml` changes.

--- a/crates/mdt_mcp/Cargo.toml
+++ b/crates/mdt_mcp/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 include = { workspace = true }
 keywords = ["markdown", "templates", "mcp"]
 license = { workspace = true }
-publish = false
 readme = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/mdt_mcp/changelog.md
+++ b/crates/mdt_mcp/changelog.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This file is maintained by `knope`.
+
+## 0.0.1 (2026-02-20)
+
+### Features
+
+#### Add MCP server for mdt.
+
+Provides a Model Context Protocol server with 6 tools: `mdt_check`, `mdt_update`, `mdt_list`, `mdt_get_block`, `mdt_preview`, and `mdt_init`. The server communicates over stdin/stdout and can be launched via `mdt mcp`. Built on the `rmcp` SDK.

--- a/crates/mdt_mcp/readme.md
+++ b/crates/mdt_mcp/readme.md
@@ -1,0 +1,61 @@
+# mdt_mcp
+
+> MCP server for mdt (manage markdown templates)
+
+<br />
+
+[![Crate][crate-image]][crate-link] [![Docs][docs-image]][docs-link] [![Status][ci-status-image]][ci-status-link] [![Unlicense][unlicense-image]][unlicense-link]
+
+<br />
+
+`mdt_mcp` provides a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the `mdt` template engine. It exposes mdt functionality as MCP tools that can be used by AI assistants and other MCP-compatible clients.
+
+## Tools
+
+The server provides the following tools:
+
+- **`mdt_check`** — Verify all consumer blocks are up-to-date
+- **`mdt_update`** — Update all consumer blocks with latest provider content
+- **`mdt_list`** — List all providers and consumers in the project
+- **`mdt_get_block`** — Get the content of a specific block by name
+- **`mdt_preview`** — Preview the result of applying transformers to a block
+- **`mdt_init`** — Initialize a new mdt project with a sample template file
+
+## Usage
+
+The MCP server communicates over stdin/stdout and can be launched via the `mdt` CLI:
+
+```sh
+mdt mcp
+```
+
+### Configuration
+
+Add the following to your MCP client configuration:
+
+```json
+{
+	"mcpServers": {
+		"mdt": {
+			"command": "mdt",
+			"args": ["mcp"]
+		}
+	}
+}
+```
+
+## Installation
+
+```toml
+[dependencies]
+mdt_mcp = "0.0.1"
+```
+
+[crate-image]: https://img.shields.io/crates/v/mdt_mcp.svg
+[crate-link]: https://crates.io/crates/mdt_mcp
+[docs-image]: https://docs.rs/mdt_mcp/badge.svg
+[docs-link]: https://docs.rs/mdt_mcp/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense

--- a/knope.toml
+++ b/knope.toml
@@ -39,6 +39,44 @@ name = "Documentation"
 footers = []
 types = ["docs"]
 
+[packages.mdt_lsp]
+versioned_files = [
+	"Cargo.toml",
+	{ path = "Cargo.toml", dependency = "mdt_lsp" },
+	{ path = "Cargo.lock", dependency = "mdt_lsp" },
+]
+changelog = "crates/mdt_lsp/changelog.md"
+scopes = ["mdt_lsp"]
+
+[[packages.mdt_lsp.extra_changelog_sections]]
+name = "Notes"
+footers = []
+types = ["note"]
+
+[[packages.mdt_lsp.extra_changelog_sections]]
+name = "Documentation"
+footers = []
+types = ["docs"]
+
+[packages.mdt_mcp]
+versioned_files = [
+	"Cargo.toml",
+	{ path = "Cargo.toml", dependency = "mdt_mcp" },
+	{ path = "Cargo.lock", dependency = "mdt_mcp" },
+]
+changelog = "crates/mdt_mcp/changelog.md"
+scopes = ["mdt_mcp"]
+
+[[packages.mdt_mcp.extra_changelog_sections]]
+name = "Notes"
+footers = []
+types = ["note"]
+
+[[packages.mdt_mcp.extra_changelog_sections]]
+name = "Documentation"
+footers = []
+types = ["docs"]
+
 [[workflows]]
 name = "release"
 


### PR DESCRIPTION
## Summary

- Remove `publish = false` from `mdt_lsp` and `mdt_mcp` so they can be published to crates.io
- Fix workspace dependency versions `0.0.0` → `0.0.1` for both crates
- Add `mdt_lsp` and `mdt_mcp` to `knope.toml` for future release management
- Create changelog files and readme for the new publishable crates
- Update `Cargo.lock` (`toml_edit` 0.22.26 → 0.22.27 to fix packaging resolution conflict)

## Context

`knope publish` (`cargo workspaces publish --from-git`) failed for `mdt_cli v0.0.1` because it depends on `mdt_lsp` and `mdt_mcp` which:
1. Had `publish = false` (not on crates.io)
2. Had stale workspace dep versions `0.0.0` while actual package version is `0.0.1`

After merging, the publish order is:
1. `cargo publish -p mdt_lsp`
2. `cargo publish -p mdt_mcp`
3. `cargo publish -p mdt_cli`

Tags and GitHub releases for `mdt_lsp/v0.0.1` and `mdt_mcp/v0.0.1` also need to be created after merge.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo package -p mdt_lsp --allow-dirty --no-verify` succeeds
- [x] `cargo package -p mdt_mcp --allow-dirty --no-verify` succeeds
- [ ] CI passes
- [ ] Publish `mdt_lsp`, `mdt_mcp`, then `mdt_cli` to crates.io
- [ ] Create `mdt_lsp/v0.0.1` and `mdt_mcp/v0.0.1` tags + GitHub releases