### PR TITLE
fix: harden release workflow with version verification

### DIFF
--- a/.changeset/fix_release_workflow.md
+++ b/.changeset/fix_release_workflow.md
@@ -1,0 +1,5 @@
+---
+mdt_cli: patch
+---
+
+Fix release workflow to checkout `main` branch instead of tag ref, and add version verification step to prevent publishing mismatches. Also add `cargo check --workspace` to the knope release workflow to catch build errors before creating tags.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -51,6 +53,19 @@ jobs:
       - name: extract version from tag
         id: version
         run: echo "version=${TAG#*/}" >> "${GITHUB_OUTPUT}"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+
+      - name: verify tag version matches code
+        run: |
+          TAG_VERSION="${TAG#*/v}"
+          CARGO_VERSION=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name=="mdt_cli") | .version')
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Version mismatch: tag=$TAG_VERSION cargo=$CARGO_VERSION"
+            exit 1
+          fi
         env:
           TAG: ${{ github.event.release.tag_name }}
         shell: bash

--- a/knope.toml
+++ b/knope.toml
@@ -89,6 +89,10 @@ command = "dprint fmt"
 
 [[workflows.steps]]
 type = "Command"
+command = "cargo check --workspace"
+
+[[workflows.steps]]
+type = "Command"
 command = "git add --all"
 
 [[workflows.steps]]


### PR DESCRIPTION
## Summary
- Add `ref: main` to checkout step in release workflow so it checks out the latest main (which has correct versions) instead of the tag ref
- Add version verification step that compares tag version against Cargo.toml version
- Add `cargo check --workspace` step in knope release workflow to catch build errors before creating tags

## Details
The `mdt_cli/v0.0.1` release failed because the tag pointed to a commit that still had `mdt_lsp = "^0.0.0"` in workspace deps. The fix commit was merged after the tag was created. This PR prevents similar issues by:
1. Checking out `main` instead of the tag (knope pushes to main before creating releases)
2. Verifying the tag version matches the code
3. Running `cargo check` before committing in the release workflow

## Test plan
- [x] Workflow YAML is valid
- [x] Version verification script correctly extracts and compares versions
- [x] knope.toml workflow includes cargo check before git operations