### PR TITLE
fix: enable automatic GitHub Pages configuration

### DIFF
--- a/.changeset/fix_docs_pages_workflow.md
+++ b/.changeset/fix_docs_pages_workflow.md
@@ -1,0 +1,5 @@
+---
+mdt_cli: patch
+---
+
+Fix docs-pages workflow by enabling automatic GitHub Pages configuration. The `enablement: true` flag on `actions/configure-pages@v5` auto-enables Pages via the GitHub API, resolving the "Get Pages site failed" error.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -15,6 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Docs deploy on any release tag since docs are project-wide
   build:
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -29,6 +30,8 @@ jobs:
 
       - name: setup pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: build mdbook
         run: mdbook build docs


### PR DESCRIPTION
## Summary
- Add `enablement: true` to `actions/configure-pages@v5` step in docs-pages workflow
- This auto-enables GitHub Pages via the API, preventing the "Pages not enabled" error

## Details
The docs-pages workflow was failing because GitHub Pages wasn't enabled in the repo settings. The `enablement: true` flag on `configure-pages` handles this automatically.

## Test plan
- [x] Workflow YAML is valid
- [x] `enablement: true` is a supported parameter for configure-pages@v5
- [ ] Trigger workflow_dispatch after merge to verify Pages deployment