### PR TITLE
test: add comprehensive tests with insta snapshots and edge cases

### DIFF
--- a/.changeset/add_comprehensive_testing.md
+++ b/.changeset/add_comprehensive_testing.md
@@ -1,0 +1,5 @@
+---
+mdt: patch
+---
+
+Add comprehensive test coverage including insta snapshot tests for tokenizer and parser output, edge case tests for empty providers, long block names, multiple consumers, boolean arguments, mixed comment styles, and fuzz-style no-panic tests for robustness.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
  "once_cell",
+ "serde",
  "similar",
 ]
 

--- a/crates/mdt/Cargo.toml
+++ b/crates/mdt/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = { workspace = true, default-features = true }
 toml = { workspace = true, default-features = true }
 
 [dev-dependencies]
-insta = { workspace = true, default-features = true }
+insta = { workspace = true, features = ["yaml"], default-features = true }
 rstest = { workspace = true, default-features = true }
 similar-asserts = { workspace = true, default-features = true }
 tempfile = { workspace = true, default-features = true }

--- a/crates/mdt/src/snapshots/mdt____tests__snapshot_parse_consumer_with_all_transformers.snap
+++ b/crates/mdt/src/snapshots/mdt____tests__snapshot_parse_consumer_with_all_transformers.snap
@@ -1,0 +1,73 @@
+---
+source: crates/mdt/src/__tests.rs
+expression: blocks
+---
+[
+    Block {
+        name: "block",
+        type: Consumer,
+        opening: 1:1-1:123 (0-122),
+        closing: 3:1-3:18 (115-132),
+        transformers: [
+            Transformer {
+                type: Trim,
+                args: [],
+            },
+            Transformer {
+                type: TrimStart,
+                args: [],
+            },
+            Transformer {
+                type: TrimEnd,
+                args: [],
+            },
+            Transformer {
+                type: Indent,
+                args: [
+                    String(
+                        "  ",
+                    ),
+                ],
+            },
+            Transformer {
+                type: Prefix,
+                args: [
+                    String(
+                        "# ",
+                    ),
+                ],
+            },
+            Transformer {
+                type: Wrap,
+                args: [
+                    String(
+                        "**",
+                    ),
+                ],
+            },
+            Transformer {
+                type: CodeBlock,
+                args: [
+                    String(
+                        "rs",
+                    ),
+                ],
+            },
+            Transformer {
+                type: Code,
+                args: [],
+            },
+            Transformer {
+                type: Replace,
+                args: [
+                    String(
+                        "a",
+                    ),
+                    String(
+                        "b",
+                    ),
+                ],
+            },
+        ],
+    },
+]

--- a/crates/mdt/src/snapshots/mdt____tests__snapshot_parse_full_document.snap
+++ b/crates/mdt/src/snapshots/mdt____tests__snapshot_parse_full_document.snap
@@ -1,0 +1,40 @@
+---
+source: crates/mdt/src/__tests.rs
+expression: blocks
+---
+[
+    Block {
+        name: "header",
+        type: Provider,
+        opening: 3:1-3:19 (9-27),
+        closing: 7:1-7:19 (58-76),
+        transformers: [],
+    },
+    Block {
+        name: "header",
+        type: Consumer,
+        opening: 11:1-11:19 (90-108),
+        closing: 15:1-15:19 (123-141),
+        transformers: [],
+    },
+    Block {
+        name: "docs",
+        type: Consumer,
+        opening: 17:1-17:36 (143-178),
+        closing: 21:1-21:17 (188-204),
+        transformers: [
+            Transformer {
+                type: Trim,
+                args: [],
+            },
+            Transformer {
+                type: Indent,
+                args: [
+                    String(
+                        "  ",
+                    ),
+                ],
+            },
+        ],
+    },
+]

--- a/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_closing.snap
+++ b/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_closing.snap
@@ -1,0 +1,24 @@
+---
+source: crates/mdt/src/__tests.rs
+expression: groups
+---
+[
+    TokenGroup {
+        tokens: [
+            HtmlCommentOpen,
+            Whitespace(
+                32,
+            ),
+            CloseTag,
+            Ident(
+                "blockName",
+            ),
+            BraceClose,
+            Whitespace(
+                32,
+            ),
+            HtmlCommentClose,
+        ],
+        position: 1:1-1:22 (0-21),
+    },
+]

--- a/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_consumer.snap
+++ b/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_consumer.snap
@@ -1,0 +1,37 @@
+---
+source: crates/mdt/src/__tests.rs
+expression: groups
+---
+[
+    TokenGroup {
+        tokens: [
+            HtmlCommentOpen,
+            Whitespace(
+                32,
+            ),
+            ConsumerTag,
+            Ident(
+                "exampleName",
+            ),
+            Pipe,
+            Ident(
+                "trim",
+            ),
+            Pipe,
+            Ident(
+                "indent",
+            ),
+            ArgumentDelimiter,
+            String(
+                "/// ",
+                34,
+            ),
+            BraceClose,
+            Whitespace(
+                32,
+            ),
+            HtmlCommentClose,
+        ],
+        position: 1:1-1:45 (0-44),
+    },
+]

--- a/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_provider.snap
+++ b/crates/mdt/src/snapshots/mdt____tests__snapshot_tokenize_provider.snap
@@ -1,0 +1,24 @@
+---
+source: crates/mdt/src/__tests.rs
+expression: groups
+---
+[
+    TokenGroup {
+        tokens: [
+            HtmlCommentOpen,
+            Whitespace(
+                32,
+            ),
+            ProviderTag,
+            Ident(
+                "myProvider",
+            ),
+            BraceClose,
+            Whitespace(
+                32,
+            ),
+            HtmlCommentClose,
+        ],
+        position: 1:1-1:23 (0-22),
+    },
+]


### PR DESCRIPTION
## Summary
- Add 20 new tests: 5 insta snapshot tests, 8 edge case tests, 3 fuzz-style no-panic tests, 4 malformed input tests
- Enable `yaml` feature on insta for readable snapshot output
- Total test count: 161 (141 existing + 20 new)

## New tests
**Insta Snapshots:** tokenize consumer/provider/closing, parse full document, parse all transformers
**Edge Cases:** empty provider content, 200-char block name, multiple consumers same provider, boolean transformer args, multiple data formats, deeply nested data access, mixed comment styles
**Fuzz/No-Panic:** 23 edge-case tokenizer inputs, 7 parser inputs, 7 source scanner inputs
**Malformed Input:** incomplete comments, missing close braces, empty tag names

## Test plan
- [x] All 161 tests pass
- [x] Insta snapshots accepted and committed
- [x] Formatting verified with dprint