### PR TITLE
fix: restrict docs-pages workflow to mdt_cli releases and update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,9 @@ Key style rules: hard tabs, max width 100, one import per line (`imports_granula
 ### Workspace Crates
 
 - **`crates/mdt_core`** — Core library (`mdt_core` on crates.io). Provides the lexer, parser, pattern matcher, project scanner, source file scanner, config loader, and template engine for processing markdown template tags. Uses `minijinja` for template rendering with data interpolation and `miette` for error reporting.
-- **`crates/mdt_cli`** — CLI tool. Provides `init`, `check`, `update`, `list`, `lsp`, and `mcp` commands for managing markdown templates via the command line. Uses `clap` for argument parsing. The binary is named `mdt`.
-- **`crates/mdt_lsp`** — LSP server. Provides language server protocol support for editor integration with diagnostics, completions, hover, go-to-definition, and code actions using `tower-lsp`.
-- **`crates/mdt_mcp`** — MCP server. Exposes mdt functionality to AI assistants via the Model Context Protocol using `rmcp`.
+- **`crates/mdt_cli`** — CLI tool (`mdt_cli` on crates.io). Provides `init`, `check`, `update`, `list`, `lsp`, and `mcp` commands for managing markdown templates via the command line. Uses `clap` for argument parsing. The binary is named `mdt`.
+- **`crates/mdt_lsp`** — LSP server (`mdt_lsp` on crates.io). Provides language server protocol support for editor integration with diagnostics, completions, hover, go-to-definition, and code actions using `tower-lsp`.
+- **`crates/mdt_mcp`** — MCP server (`mdt_mcp` on crates.io). Exposes mdt functionality to AI assistants via the Model Context Protocol using `rmcp`.
 - **`docs/`** — mdbook documentation.
 
 ### Internal Pipeline

--- a/docs/src/guide/ci-integration.md
+++ b/docs/src/guide/ci-integration.md
@@ -124,11 +124,11 @@ If you prefer to auto-fix in CI rather than just check, run `mdt update` and com
 
 ## Publish mdBook on release
 
-This repository publishes the mdBook on `mdt_cli` releases using GitHub Pages. Only CLI releases trigger a docs deploy — library-only releases are skipped.
+This repository publishes the mdBook when an `mdt_cli` release is published on GitHub (or via manual `workflow_dispatch`). Other crate releases (e.g., `mdt_core`, `mdt_lsp`, `mdt_mcp`) do not trigger a docs deploy.
 
 The workflow lives at `.github/workflows/docs-pages.yml` and:
 
-1. Checks the release tag starts with `mdt_cli`
+1. Filters on `mdt_cli` release tags (or manual dispatch)
 2. Builds the book with `mdbook build docs`
 3. Uploads `docs/book` as a Pages artifact
 4. Deploys to GitHub Pages
@@ -150,6 +150,7 @@ permissions:
 
 jobs:
   build:
+    # Only deploy docs on mdt_cli releases (not library-only releases).
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.release.tag_name, 'mdt_cli')


### PR DESCRIPTION
## Summary

- Restrict `docs-pages` workflow to only trigger on `mdt_cli` releases (not `mdt_core`, `mdt_lsp`, `mdt_mcp` releases) using a tag prefix filter
- Remove `enablement: true` from `configure-pages` action which was causing failures (requires admin permissions the workflow token doesn't have)
- Update `docs/src/getting-started/installation.md` library dependency from `mdt = "0.0.0"` to `mdt_core = "0.2.0"`
- Update `docs/src/guide/ci-integration.md` to document the `mdt_cli`-only filter in the mdBook publish section
- Update `CLAUDE.md` to reflect the `mdt` → `mdt_core` rename, add `mdt_mcp` crate description, update package names, and fix publishing info

## Test plan

- [ ] Verify CI passes (lint, test, build)
- [ ] Verify the docs-pages workflow YAML is valid by checking the Actions tab
- [ ] Confirm `mdbook build docs` still succeeds in CI