### PR TITLE
docs: add comprehensive doc comments to mdt_core API and enrich CLI help

### DIFF
--- a/.changeset/doc-comments-and-cli-help.md
+++ b/.changeset/doc-comments-and-cli-help.md
@@ -1,0 +1,24 @@
+---
+mdt_core: docs
+mdt_cli: docs
+---
+
+Add comprehensive doc comments to `mdt_core` public API types and enrich CLI help text for all `mdt_cli` commands.
+
+**mdt_core:**
+
+- Expand crate-level documentation with processing pipeline diagram, module overview, key types reference, data interpolation guide, and quick start code example.
+- Add struct/enum-level doc comments for `Block`, `Transformer`, and `Argument` explaining their role in the template system.
+- Add field-level doc comments for `Block`, `Transformer`, `Argument`, and `StaleEntry` fields.
+- Add doc comments for internal types `TokenGroup`, `DynamicRange`, and `GetDynamicRange` in the tokens module.
+- Add provider blocks to `template.t.md` for `mdtCoreOverview`, `mdtBlockDocs`, `mdtTransformerDocs`, and `mdtArgumentDocs` for potential use by markdown consumers.
+
+**mdt_cli:**
+
+- Expand `Init` help with details about what file is created and no-op behavior.
+- Expand `Check` help with CI usage guidance, `--diff` and `--format` tips.
+- Expand `Update` help with template rendering flow, `--dry-run` and `--watch` details.
+- Expand `List` help with output format description.
+- Expand `Lsp` help with diagnostics and auto-completion features.
+- Expand `Mcp` help with available tools description.
+- Enrich `OutputFormat` variant docs and field-level docs for `Check` and `Update` args.

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -36,55 +36,86 @@ pub struct MdtCli {
 #[derive(Subcommand)]
 pub enum Commands {
 	/// Initialize mdt in a project by creating a sample template file.
+	///
+	/// Creates a `template.t.md` file in the project root with example provider
+	/// blocks and usage instructions. If the file already exists, this command
+	/// is a no-op and exits successfully.
 	Init,
 	/// Check that all consumer blocks are up to date.
 	///
-	/// Exits with a non-zero status code if any consumer blocks are stale.
-	/// Use this in CI to ensure documentation stays synchronized.
+	/// Scans all files in the project for consumer blocks and compares their
+	/// current content against what the matching provider would produce. Exits
+	/// with a non-zero status code if any consumer blocks are stale.
+	///
+	/// Ideal for CI pipelines to enforce documentation synchronization. Use
+	/// `--diff` to see exactly what changed and `--format` to control the
+	/// output style.
 	Check {
-		/// Show a diff for each stale consumer block.
+		/// Show a unified diff for each stale consumer block, highlighting
+		/// the differences between current and expected content.
 		#[arg(long, default_value_t = false)]
 		diff: bool,
 
-		/// Output format for check results.
+		/// Output format for check results. Use `text` for human-readable
+		/// output, `json` for programmatic consumption, or `github` for
+		/// GitHub Actions annotations that appear inline on PRs.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Text)]
 		format: OutputFormat,
 	},
 	/// Update all consumer blocks with the latest provider content.
 	///
-	/// Reads provider blocks from *.t.md template files and replaces
-	/// matching consumer blocks in all scanned files.
+	/// Reads provider blocks from `*.t.md` template files, renders any
+	/// template variables using data from `mdt.toml`, applies transformers,
+	/// and replaces matching consumer block content in all scanned files.
+	///
+	/// Use `--dry-run` to preview changes without writing to disk, or
+	/// `--watch` to automatically re-run whenever source files change.
 	Update {
-		/// Show what would change without writing files.
+		/// Preview changes without writing files. Prints which files would
+		/// be modified and shows the updated content.
 		#[arg(long, default_value_t = false)]
 		dry_run: bool,
 
-		/// Watch for file changes and re-run updates automatically.
+		/// Watch for file changes and re-run updates automatically. Monitors
+		/// template files and consumer files for modifications.
 		#[arg(long, default_value_t = false)]
 		watch: bool,
 	},
 	/// List all provider and consumer blocks in the project.
+	///
+	/// Displays every provider block (from `*.t.md` files) and consumer block
+	/// found across the project, along with file paths and block names. Useful
+	/// for auditing template coverage and discovering orphaned consumers.
 	List,
 	/// Start the mdt language server (LSP).
 	///
 	/// Communicates over stdin/stdout using the Language Server Protocol.
 	/// Configure your editor to run `mdt lsp` as the language server
 	/// command for markdown and template files.
+	///
+	/// Provides diagnostics for stale consumers, auto-completion of block
+	/// names, hover information, and go-to-definition from consumers to
+	/// their providers.
 	Lsp,
 	/// Start the mdt MCP (Model Context Protocol) server.
 	///
 	/// Communicates over stdin/stdout using the Model Context Protocol.
 	/// Configure your AI assistant to run `mdt mcp` as an MCP server
 	/// to give it structured access to mdt's template system.
+	///
+	/// Exposes tools for checking, updating, and listing template blocks,
+	/// allowing AI assistants to manage documentation synchronization.
 	Mcp,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum OutputFormat {
-	/// Human-readable text output.
+	/// Human-readable text output with colors and formatting.
 	Text,
-	/// JSON output for programmatic consumption.
+	/// JSON output for programmatic consumption. Each stale entry includes
+	/// the file path, block name, current content, and expected content.
 	Json,
-	/// GitHub Actions annotation format.
+	/// GitHub Actions annotation format. Emits `::warning` or `::error`
+	/// annotations that appear inline on pull request diffs.
 	Github,
 }

--- a/crates/mdt_core/src/engine.rs
+++ b/crates/mdt_core/src/engine.rs
@@ -26,9 +26,13 @@ impl CheckResult {
 /// A consumer entry that is out of date.
 #[derive(Debug)]
 pub struct StaleEntry {
+	/// Path to the file containing the stale consumer.
 	pub file: PathBuf,
+	/// Name of the block that is out of date.
 	pub block_name: String,
+	/// The current content between the consumer's tags.
 	pub current_content: String,
+	/// The expected content after applying provider content and transformers.
 	pub expected_content: String,
 }
 

--- a/crates/mdt_core/src/lib.rs
+++ b/crates/mdt_core/src/lib.rs
@@ -1,8 +1,83 @@
-//! `mdt` is a data-driven template engine for keeping documentation
-//! synchronized across your project. It uses comment-based template tags to
-//! define content once and distribute it to multiple locations — markdown
-//! files, code documentation comments (in any language), READMEs, mdbook docs,
-//! and more.
+//! `mdt_core` is the core library for the [mdt](https://github.com/ifiokjr/mdt)
+//! template engine. It provides the lexer, parser, project scanner, and
+//! template engine for processing markdown template tags. Content defined once
+//! in provider blocks can be distributed to consumer blocks across markdown
+//! files, code documentation comments, READMEs, and more.
+//!
+//! ## Processing Pipeline
+//!
+//! ```text
+//! Markdown / source file
+//!   → Lexer (tokenizes HTML comments into TokenGroups)
+//!   → Pattern matcher (validates token sequences)
+//!   → Parser (classifies groups, extracts names + transformers,
+//!             matches open/close into Blocks)
+//!   → Project scanner (walks directory tree, builds provider→content
+//!                       map + consumer list)
+//!   → Engine (matches consumers to providers, applies transformers,
+//!             replaces content)
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`config`] — Configuration loading from `mdt.toml`, including data source
+//!   mappings, exclude/include patterns, and template paths.
+//! - [`project`] — Project scanning and directory walking. Discovers provider
+//!   and consumer blocks across all files in a project.
+//! - Source scanner ([`parse_source`]) — Source file scanning for consumer tags
+//!   inside code comments (Rust, TypeScript, Python, Go, Java, etc.).
+//!
+//! ## Key Types
+//!
+//! - [`Block`] — A parsed template block (provider or consumer) with its name,
+//!   type, position, and transformers.
+//! - [`Transformer`] — A pipe-delimited content filter (e.g., `trim`, `indent`,
+//!   `linePrefix`) applied during injection.
+//! - [`ProjectContext`] — A scanned project together with its loaded template
+//!   data, ready for checking or updating.
+//! - [`MdtConfig`] — Configuration loaded from `mdt.toml`.
+//! - [`CheckResult`] — Result of checking a project for stale consumers.
+//! - [`UpdateResult`] — Result of computing updates for consumer blocks.
+//!
+//! ## Data Interpolation
+//!
+//! Provider content supports [`minijinja`](https://docs.rs/minijinja) template
+//! variables populated from project files. The `mdt.toml` config maps source
+//! files to namespaces:
+//!
+//! ```toml
+//! [data]
+//! pkg = "package.json"
+//! cargo = "Cargo.toml"
+//! ```
+//!
+//! Then in provider blocks: `{{ pkg.version }}` or
+//! `{{ cargo.package.edition }}`.
+//!
+//! Supported formats: JSON, TOML, YAML, and KDL.
+//!
+//! ## Quick Start
+//!
+//! ```rust,no_run
+//! use std::path::Path;
+//!
+//! use mdt_core::check_project;
+//! use mdt_core::compute_updates;
+//! use mdt_core::project::scan_project_with_config;
+//! use mdt_core::write_updates;
+//!
+//! let ctx = scan_project_with_config(Path::new(".")).unwrap();
+//!
+//! // Check for stale consumers
+//! let result = check_project(&ctx).unwrap();
+//! if !result.is_ok() {
+//! 	eprintln!("{} stale consumer(s) found", result.stale.len());
+//! }
+//!
+//! // Update all consumer blocks
+//! let updates = compute_updates(&ctx).unwrap();
+//! write_updates(&updates).unwrap();
+//! ```
 
 pub use config::*;
 pub use engine::*;

--- a/crates/mdt_core/src/parser.rs
+++ b/crates/mdt_core/src/parser.rs
@@ -302,26 +302,82 @@ impl BlockCreator {
 	}
 }
 
+/// A parsed template block representing either a provider or consumer.
+///
+/// Provider blocks are defined in `*.t.md` template files using
+/// `<!-- {@name} -->...<!-- {/name} -->` syntax. They supply content that gets
+/// distributed to matching consumers.
+///
+/// Consumer blocks appear in any scanned file using
+/// `<!-- {=name} -->...<!-- {/name} -->` syntax. Their content is replaced with
+/// the matching provider's content (after applying any transformers) when
+/// `mdt update` is run.
+///
+/// Each block tracks its [`name`](Block::name) for provider-consumer matching,
+/// its [`BlockType`], the [`Position`] of its opening and closing tags, and any
+/// [`Transformer`]s to apply during content injection.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Block {
 	/// The name of the block used for matching providers to consumers.
 	pub name: String,
+	/// Whether this is a provider or consumer block.
 	pub r#type: BlockType,
+	/// Position of the opening tag (e.g., `<!-- {@name} -->` or `<!-- {=name}
+	/// -->`).
 	pub opening: Position,
+	/// Position of the closing tag (`<!-- {/name} -->`).
 	pub closing: Position,
+	/// Transformers to apply when injecting provider content into this
+	/// consumer.
 	pub transformers: Vec<Transformer>,
 }
 
+/// A content transformer applied to provider content during injection into a
+/// consumer block.
+///
+/// Transformers are specified using pipe-delimited syntax after the block name
+/// in a consumer tag:
+///
+/// ```markdown
+/// <!-- {=blockName|trim|indent:"  "|linePrefix:"/// "} -->
+/// ```
+///
+/// Transformers are applied in left-to-right order. Each transformer has a
+/// [`TransformerType`] and zero or more [`Argument`]s passed via
+/// colon-delimited syntax (e.g., `indent:"  "`).
+///
+/// Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`,
+/// `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`,
+/// `replace`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Transformer {
+	/// The kind of transformation to apply (e.g., `Trim`, `Indent`,
+	/// `LinePrefix`).
 	pub r#type: TransformerType,
+	/// Arguments passed to the transformer via colon-delimited syntax.
 	pub args: Vec<Argument>,
 }
 
+/// An argument value passed to a [`Transformer`].
+///
+/// Arguments are specified after the transformer name using colon-delimited
+/// syntax:
+///
+/// ```markdown
+/// <!-- {=block|replace:"old":"new"|indent:"  "} -->
+/// ```
+///
+/// Three types are supported:
+/// - **String** — Quoted text, e.g. `"hello"` or `'hello'`
+/// - **Number** — Integer or floating-point, e.g. `42` or `3.14`
+/// - **Boolean** — `true` or `false`
 #[derive(Debug, Clone, PartialEq)]
 pub enum Argument {
+	/// A quoted string value, e.g. `"hello"` or `'world'`.
 	String(String),
+	/// A numeric value (integer or float), e.g. `42` or `3.14`.
 	Number(OrderedFloat),
+	/// A boolean value: `true` or `false`.
 	Boolean(bool),
 }
 

--- a/crates/mdt_core/src/tokens.rs
+++ b/crates/mdt_core/src/tokens.rs
@@ -129,9 +129,16 @@ impl Display for Token {
 	}
 }
 
+/// A group of tokens extracted from a single HTML comment node.
+///
+/// Each HTML comment in the source (e.g., `<!-- {=name|trim} -->`) is
+/// tokenized into a `TokenGroup` containing its individual tokens and the
+/// position of the comment in the original file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TokenGroup {
+	/// The sequence of tokens parsed from the HTML comment.
 	pub tokens: Vec<Token>,
+	/// The position of the HTML comment in the source file.
 	pub position: Position,
 }
 
@@ -164,6 +171,8 @@ impl TokenGroup {
 	}
 }
 
+/// A wrapper around a `RangeBounds<usize>` that provides uniform access to
+/// start and end bounds, normalizing inclusive/exclusive/unbounded variants.
 #[derive(Deref, DerefMut)]
 pub struct DynamicRange<B>(
 	#[deref]
@@ -202,6 +211,7 @@ where
 	}
 }
 
+/// Trait for converting various range types into a [`DynamicRange`].
 pub trait GetDynamicRange {
 	type Range: RangeBounds<usize>;
 	fn get_dynamic_range(&self) -> DynamicRange<Self::Range>;

--- a/template.t.md
+++ b/template.t.md
@@ -76,3 +76,115 @@ mdt_mcp = "{{ cargo.workspace.package.version }}"
 ```
 
 <!-- {/mdtMcpInstall} -->
+
+<!-- {@mdtCoreOverview} -->
+
+`mdt_core` is the core library for the [mdt](https://github.com/ifiokjr/mdt) template engine. It provides the lexer, parser, project scanner, and template engine for processing markdown template tags. Content defined once in provider blocks can be distributed to consumer blocks across markdown files, code documentation comments, READMEs, and more.
+
+## Processing Pipeline
+
+```text
+Markdown / source file
+  → Lexer (tokenizes HTML comments into TokenGroups)
+  → Pattern matcher (validates token sequences)
+  → Parser (classifies groups, extracts names + transformers, matches open/close into Blocks)
+  → Project scanner (walks directory tree, builds provider→content map + consumer list)
+  → Engine (matches consumers to providers, applies transformers, replaces content)
+```
+
+## Modules
+
+- [`config`] — Configuration loading from `mdt.toml`, including data source mappings, exclude/include patterns, and template paths.
+- [`project`] — Project scanning and directory walking. Discovers provider and consumer blocks across all files in a project.
+- [`source_scanner`] — Source file scanning for consumer tags inside code comments (Rust, TypeScript, Python, Go, Java, etc.).
+
+## Key Types
+
+- [`Block`] — A parsed template block (provider or consumer) with its name, type, position, and transformers.
+- [`Transformer`] — A pipe-delimited content filter (e.g., `trim`, `indent`, `linePrefix`) applied during injection.
+- [`ProjectContext`] — A scanned project together with its loaded template data, ready for checking or updating.
+- [`MdtConfig`] — Configuration loaded from `mdt.toml`.
+- [`CheckResult`] — Result of checking a project for stale consumers.
+- [`UpdateResult`] — Result of computing updates for consumer blocks.
+
+## Data Interpolation
+
+Provider content supports [`minijinja`](https://docs.rs/minijinja) template variables populated from project files. The `mdt.toml` config maps source files to namespaces:
+
+```toml
+[data]
+pkg = "package.json"
+cargo = "Cargo.toml"
+```
+
+Then in provider blocks: `{{ "{{" }} pkg.version {{ "}}" }}` or `{{ "{{" }} cargo.package.edition {{ "}}" }}`.
+
+Supported formats: JSON, TOML, YAML, and KDL.
+
+## Quick Start
+
+```rust,no_run
+use mdt_core::project::scan_project_with_config;
+use mdt_core::{check_project, compute_updates, write_updates};
+use std::path::Path;
+
+let ctx = scan_project_with_config(Path::new(".")).unwrap();
+
+// Check for stale consumers
+let result = check_project(&ctx).unwrap();
+if !result.is_ok() {
+    eprintln!("{} stale consumer(s) found", result.stale.len());
+}
+
+// Update all consumer blocks
+let updates = compute_updates(&ctx).unwrap();
+write_updates(&updates).unwrap();
+```
+
+<!-- {/mdtCoreOverview} -->
+
+<!-- {@mdtBlockDocs} -->
+
+A parsed template block representing either a provider or consumer.
+
+Provider blocks are defined in `*.t.md` template files using `<!-- {@name} -->...<!-- {/name} -->` syntax. They supply content that gets distributed to matching consumers.
+
+Consumer blocks appear in any scanned file using `<!-- {=name} -->...<!-- {/name} -->` syntax. Their content is replaced with the matching provider's content (after applying any transformers) when `mdt update` is run.
+
+Each block tracks its [`name`](Block::name) for provider-consumer matching, its [`BlockType`], the [`Position`] of its opening and closing tags, and any [`Transformer`]s to apply during content injection.
+
+<!-- {/mdtBlockDocs} -->
+
+<!-- {@mdtTransformerDocs} -->
+
+A content transformer applied to provider content during injection into a consumer block.
+
+Transformers are specified using pipe-delimited syntax after the block name in a consumer tag:
+
+```markdown
+<!-- {=blockName|trim|indent:"  "|linePrefix:"/// "} -->
+```
+
+Transformers are applied in left-to-right order. Each transformer has a [`TransformerType`] and zero or more [`Argument`]s passed via colon-delimited syntax (e.g., `indent:"  "`).
+
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`.
+
+<!-- {/mdtTransformerDocs} -->
+
+<!-- {@mdtArgumentDocs} -->
+
+An argument value passed to a [`Transformer`].
+
+Arguments are specified after the transformer name using colon-delimited syntax:
+
+```markdown
+<!-- {=block|replace:"old":"new"|indent:"  "} -->
+```
+
+Three types are supported:
+
+- **String** — Quoted text, e.g. `"hello"` or `'hello'`
+- **Number** — Integer or floating-point, e.g. `42` or `3.14`
+- **Boolean** — `true` or `false`
+
+<!-- {/mdtArgumentDocs} -->


### PR DESCRIPTION
## Summary

- Expand `mdt_core` crate-level documentation with processing pipeline diagram, module overview, key types reference, data interpolation guide, and quick start code example
- Add struct/enum/field-level doc comments for `Block`, `Transformer`, `Argument`, `StaleEntry`, `TokenGroup`, `DynamicRange`, and `GetDynamicRange`
- Enrich CLI `--help` text for all `mdt_cli` commands (`Init`, `Check`, `Update`, `List`, `Lsp`, `Mcp`) and their arguments with more descriptive explanations
- Add provider blocks to `template.t.md` (`mdtCoreOverview`, `mdtBlockDocs`, `mdtTransformerDocs`, `mdtArgumentDocs`) for potential use by markdown consumers

## Test plan

- [x] `cargo nextest run` — all 208 tests pass
- [x] `cargo test --doc -p mdt_core` — doc test passes (quick start example compiles)
- [x] `dprint check` — formatting clean
- [x] `cargo clippy --all-features` — no new warnings
- [x] `cargo doc --no-deps -p mdt_core` — rustdoc builds, intra-doc links resolve
- [x] `mdt update` — all consumer blocks up to date