### PR TITLE
feat: add validation diagnostics with file location reporting

### DIFF
--- a/.changeset/add_validation_diagnostics.md
+++ b/.changeset/add_validation_diagnostics.md
@@ -1,0 +1,25 @@
+---
+mdt_core: minor
+mdt_cli: minor
+---
+
+Add comprehensive validation diagnostics with file location reporting.
+
+**`mdt_core` changes:**
+
+- Add `ProjectDiagnostic` and `DiagnosticKind` types for reporting validation issues during project scanning, including unclosed blocks, unknown transformers, invalid transformer arguments, and unused providers.
+- Add `ValidationOptions` struct to control which diagnostics are treated as errors vs warnings.
+- Add `parse_with_diagnostics()` function that collects parse issues as diagnostics instead of hard-erroring, enabling lenient parsing for editor tooling and better error reporting.
+- Add `parse_source_with_diagnostics()` for source file scanning with diagnostic collection.
+- Add `line` and `column` fields to `StaleEntry` for precise location reporting in check results.
+- Project scanning now collects diagnostics for all validation issues and attaches file/line/column context.
+
+**`mdt_cli` changes:**
+
+- Add `--ignore-unclosed-blocks` flag to suppress unclosed block errors during validation.
+- Add `--ignore-unused-blocks` flag to suppress warnings about providers with no consumers.
+- Add `--ignore-invalid-names` flag to suppress invalid block name errors.
+- Add `--ignore-invalid-transformers` flag to suppress unknown transformer and invalid argument errors.
+- Error and check output now includes `file:line:column` location information.
+- JSON check output now includes `line` and `column` fields in stale entries.
+- GitHub Actions annotation format now includes `line` and `col` parameters.

--- a/crates/mdt_cli/src/lib.rs
+++ b/crates/mdt_cli/src/lib.rs
@@ -31,6 +31,23 @@ pub struct MdtCli {
 	/// Disable colored output.
 	#[arg(long, global = true, default_value_t = false)]
 	pub no_color: bool,
+
+	/// Ignore unclosed block errors during validation.
+	#[arg(long, global = true, default_value_t = false)]
+	pub ignore_unclosed_blocks: bool,
+
+	/// Ignore unused provider blocks (providers with no consumers).
+	#[arg(long, global = true, default_value_t = false)]
+	pub ignore_unused_blocks: bool,
+
+	/// Ignore invalid block name errors.
+	#[arg(long, global = true, default_value_t = false)]
+	pub ignore_invalid_names: bool,
+
+	/// Ignore unknown transformer names and invalid transformer argument
+	/// errors.
+	#[arg(long, global = true, default_value_t = false)]
+	pub ignore_invalid_transformers: bool,
 }
 
 #[derive(Subcommand)]

--- a/crates/mdt_core/src/engine.rs
+++ b/crates/mdt_core/src/engine.rs
@@ -34,6 +34,10 @@ pub struct StaleEntry {
 	pub current_content: String,
 	/// The expected content after applying provider content and transformers.
 	pub expected_content: String,
+	/// 1-indexed line number of the consumer's opening tag.
+	pub line: usize,
+	/// 1-indexed column number of the consumer's opening tag.
+	pub column: usize,
 }
 
 /// Result of updating a project.
@@ -96,6 +100,8 @@ pub fn check_project(ctx: &ProjectContext) -> MdtResult<CheckResult> {
 				block_name: consumer.block.name.clone(),
 				current_content: consumer.content.clone(),
 				expected_content: expected,
+				line: consumer.block.opening.start.line,
+				column: consumer.block.opening.start.column,
 			});
 		}
 	}

--- a/crates/mdt_core/src/source_scanner.rs
+++ b/crates/mdt_core/src/source_scanner.rs
@@ -6,7 +6,9 @@ use crate::MdtResult;
 use crate::lexer::memstr;
 use crate::lexer::tokenize;
 use crate::parser::Block;
+use crate::parser::ParseDiagnostic;
 use crate::parser::build_blocks_from_groups_lenient;
+use crate::parser::build_blocks_from_groups_with_diagnostics;
 
 /// Parse source code content (non-markdown) for mdt blocks by extracting HTML
 /// comments directly from the raw text.
@@ -14,6 +16,15 @@ pub fn parse_source(content: &str) -> MdtResult<Vec<Block>> {
 	let html_nodes = extract_html_comments(content);
 	let token_groups = tokenize(html_nodes)?;
 	build_blocks_from_groups_lenient(&token_groups)
+}
+
+/// Parse source code content and return blocks together with diagnostics.
+pub fn parse_source_with_diagnostics(
+	content: &str,
+) -> MdtResult<(Vec<Block>, Vec<ParseDiagnostic>)> {
+	let html_nodes = extract_html_comments(content);
+	let token_groups = tokenize(html_nodes)?;
+	build_blocks_from_groups_with_diagnostics(&token_groups)
 }
 
 /// Pre-computed table of line-start byte offsets for efficient offset-to-point


### PR DESCRIPTION
## Summary

- Add comprehensive validation during project scanning that reports unclosed blocks, unknown transformers, invalid transformer arguments, and unused providers with precise `file:line:column` context
- Add `ProjectDiagnostic`, `DiagnosticKind`, and `ValidationOptions` types to `mdt_core` for structured diagnostic reporting
- Add `parse_with_diagnostics()` and `parse_source_with_diagnostics()` functions for lenient parsing that collects issues instead of hard-erroring
- Add `line` and `column` fields to `StaleEntry` for location info in check output (text, JSON, and GitHub annotations)
- Add four global CLI flags: `--ignore-unclosed-blocks`, `--ignore-unused-blocks`, `--ignore-invalid-names`, `--ignore-invalid-transformers`
- Add 8 new tests covering all diagnostic scenarios

## Test plan

- [x] All 220 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-features`)
- [ ] CI passes