### PR TITLE
feat(mdt_core): add pad_blocks setting to prevent content mangling

### DIFF
--- a/.changeset/add_pad_blocks_setting.md
+++ b/.changeset/add_pad_blocks_setting.md
@@ -1,0 +1,11 @@
+---
+mdt: minor
+---
+
+Add `pad_blocks` configuration setting to prevent content mangling in source code comments.
+
+When `pad_blocks = true` is set in `mdt.toml`, mdt ensures a newline always separates the opening tag from the content and the content from the closing tag. This prevents transformers like `trim` from causing content to merge directly into surrounding comment tags, which would break code structure in languages like Rust (`//!`, `///`), TypeScript (JSDoc), Python, Go, Java, C/C++, C#, Kotlin, and Swift.
+
+The `pad_content_preserving_suffix` function preserves the trailing comment prefix from the original consumer content (e.g., `//!` before a closing tag) so that closing tags remain properly formatted after updates.
+
+Also fixes a bug in the `Token::String` Display implementation where the `u8` delimiter byte was formatted as its numeric value (e.g., `34`) instead of the corresponding character (`"`), causing incorrect position offsets for blocks with string arguments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,16 @@ Then in provider blocks: `Version: {{ pkg.version }}` or `Edition: {{ cargo.pack
 
 Supported data file formats: `.json`, `.toml`, `.yaml`/`.yml`, `.kdl`.
 
+### Block Padding
+
+When using consumer blocks in source files (`.rs`, `.ts`, etc.), enable `pad_blocks` in `mdt.toml` to prevent content from running directly into the tags:
+
+```toml
+pad_blocks = true
+```
+
+This ensures a newline always separates the opening/closing tags from the content after transformers are applied. Without it, `trim|linePrefix:"//! ":true` could produce mangled output where content merges with the surrounding tags.
+
 ## Toolchain
 
 - **Rust:** 1.87.0 (stable), edition 2024, MSRV 1.86.0

--- a/crates/mdt_core/src/__fixtures.rs
+++ b/crates/mdt_core/src/__fixtures.rs
@@ -53,8 +53,8 @@ pub fn consumer_token_group_with_arguments() -> TokenGroup {
 			},
 			end: Point {
 				line: 1,
-				column: 45,
-				offset: 44,
+				column: 43,
+				offset: 42,
 			},
 		},
 	}

--- a/crates/mdt_core/src/config.rs
+++ b/crates/mdt_core/src/config.rs
@@ -44,6 +44,12 @@ pub struct MdtConfig {
 	/// Defaults to 10 MB.
 	#[serde(default = "default_max_file_size")]
 	pub max_file_size: u64,
+	/// When true, ensure a newline always separates the opening tag from the
+	/// content and the content from the closing tag. This prevents content
+	/// from running into tags when transformers produce output without
+	/// leading/trailing newlines. Defaults to `false`.
+	#[serde(default)]
+	pub pad_blocks: bool,
 }
 
 fn default_max_file_size() -> u64 {

--- a/crates/mdt_core/src/project.rs
+++ b/crates/mdt_core/src/project.rs
@@ -118,6 +118,9 @@ pub struct ProjectContext {
 	pub project: Project,
 	/// Template data loaded from files referenced in `mdt.toml`.
 	pub data: HashMap<String, serde_json::Value>,
+	/// When true, ensure a newline always separates the opening tag from the
+	/// content and the content from the closing tag.
+	pub pad_blocks: bool,
 }
 
 impl ProjectContext {
@@ -184,12 +187,17 @@ pub fn scan_project_with_config(root: &Path) -> MdtResult<ProjectContext> {
 		template_paths,
 		max_file_size,
 	)?;
+	let pad_blocks = config.as_ref().is_some_and(|c| c.pad_blocks);
 	let data = match config {
 		Some(config) => config.load_data(root)?,
 		None => HashMap::new(),
 	};
 
-	Ok(ProjectContext { project, data })
+	Ok(ProjectContext {
+		project,
+		data,
+		pad_blocks,
+	})
 }
 
 /// Build a `GlobSet` from a list of glob pattern strings.

--- a/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_parse_consumer_with_all_transformers.snap
+++ b/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_parse_consumer_with_all_transformers.snap
@@ -6,7 +6,7 @@ expression: blocks
     Block {
         name: "block",
         type: Consumer,
-        opening: 1:1-1:123 (0-122),
+        opening: 1:1-1:111 (0-110),
         closing: 3:1-3:18 (115-132),
         transformers: [
             Transformer {

--- a/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_parse_full_document.snap
+++ b/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_parse_full_document.snap
@@ -20,7 +20,7 @@ expression: blocks
     Block {
         name: "docs",
         type: Consumer,
-        opening: 17:1-17:36 (143-178),
+        opening: 17:1-17:34 (143-176),
         closing: 21:1-21:17 (188-204),
         transformers: [
             Transformer {

--- a/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_tokenize_consumer.snap
+++ b/crates/mdt_core/src/snapshots/mdt_core____tests__snapshot_tokenize_consumer.snap
@@ -32,6 +32,6 @@ expression: groups
             ),
             HtmlCommentClose,
         ],
-        position: 1:1-1:45 (0-44),
+        position: 1:1-1:43 (0-42),
     },
 ]

--- a/crates/mdt_core/src/tokens.rs
+++ b/crates/mdt_core/src/tokens.rs
@@ -121,7 +121,10 @@ impl Display for Token {
 			Token::BraceClose => write!(f, "}}"),
 			Token::Pipe => write!(f, "|"),
 			Token::ArgumentDelimiter => write!(f, ":"),
-			Token::String(string, ch) => write!(f, "{ch}{string}{ch}"),
+			Token::String(string, ch) => {
+				let ch = *ch as char;
+				write!(f, "{ch}{string}{ch}")
+			}
 			Token::Ident(ident) => write!(f, "{ident}"),
 			Token::Int(number) => write!(f, "{number}"),
 			Token::Float(number) => write!(f, "{number}"),

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -77,6 +77,18 @@ paths = ["templates", "shared/docs"]
 
 When set, only `*.t.md` files within these directories are recognized as template files.
 
+### `pad_blocks` — Block content padding
+
+When enabled, mdt ensures a newline always separates the opening tag from the content and the content from the closing tag. This is recommended when using consumer blocks in source code files.
+
+```toml
+pad_blocks = true
+```
+
+Without this setting, transformers like `trim` can cause content to merge directly into the surrounding tags, breaking the structure of code comments.
+
+If omitted, defaults to `false`.
+
 ### `max_file_size` — Safety limit for scanned files
 
 Set the maximum file size (in bytes) that mdt will scan. Files larger than this limit return an error.
@@ -110,6 +122,9 @@ Running `mdt update` from the root updates only the root project's consumers. Ea
 
 ```toml
 # mdt.toml
+
+# Ensure proper padding between tags and content in source files
+pad_blocks = true
 
 [data]
 package = "package.json"

--- a/docs/src/guide/source-files.md
+++ b/docs/src/guide/source-files.md
@@ -81,6 +81,31 @@ def main():
 package mylib
 ```
 
+## Recommended: Enable `pad_blocks`
+
+When using consumer blocks in source files, add `pad_blocks = true` to your `mdt.toml`:
+
+```toml
+pad_blocks = true
+```
+
+This ensures a newline always separates the opening/closing tags from the content, preventing transformers like `trim` from causing the content to merge directly with the tags.
+
+Without `pad_blocks`, a consumer with `trim|linePrefix:"//! ":true` could produce:
+
+```rust
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->//! Content here.<!-- {/docs}
+//! -->
+```
+
+With `pad_blocks = true`, the output is properly structured:
+
+```rust
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//! Content here.
+//! <!-- {/docs} -->
+```
+
 ## Key differences from markdown
 
 ### Lenient parsing

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -94,6 +94,33 @@ paths = ["templates", "shared/docs"]
 
 By default (when this section is absent), mdt finds `*.t.md` files anywhere in the project tree.
 
+### `pad_blocks`
+
+When set to `true`, mdt ensures a newline always separates the opening tag from the content and the content from the closing tag. This prevents content from running directly into tags when transformers produce output without leading or trailing newlines.
+
+```toml
+pad_blocks = true
+```
+
+This is especially important for **source code files** (`.rs`, `.ts`, `.py`, `.go`, etc.) where consumer blocks appear inside code comments. Without padding, transformers like `trim` followed by `linePrefix` can produce content that merges with the surrounding tags, breaking the code structure.
+
+**Example:** A Rust file with `pad_blocks = true`:
+
+```rust
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//! This content stays properly formatted.
+//! <!-- {/docs} -->
+```
+
+Without `pad_blocks`, the same setup might produce:
+
+```rust
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->This content merges with the
+//! tag.<!-- {/docs} -->
+```
+
+Default value: `false`.
+
 ### `max_file_size`
 
 Maximum file size in bytes that mdt will scan.
@@ -110,6 +137,9 @@ Default value: `10485760` (10 MB).
 
 ```toml
 # mdt.toml
+
+# Ensure newlines separate tags from content (recommended for source files)
+pad_blocks = true
 
 # Map data files to namespaces for template variables
 [data]
@@ -154,4 +184,5 @@ If `mdt.toml` doesn't exist, mdt uses defaults:
 - No extra exclusions (only built-in exclusions apply)
 - No include filtering (all scannable files are scanned)
 - Templates found anywhere in the project tree
+- `pad_blocks` defaults to `false`
 - `max_file_size` defaults to 10 MB


### PR DESCRIPTION
## Summary

- Add `pad_blocks` configuration setting to `mdt.toml` that ensures newlines always separate opening/closing tags from content, preventing transformers like `trim` from merging content into surrounding comment tags in source code files
- Fix `Token::String` Display bug where the `u8` delimiter byte was formatted as its numeric value (e.g., `34`) instead of the corresponding character (`"`), causing incorrect position offsets for blocks with string arguments
- Add `pad_content_preserving_suffix()` that preserves trailing comment prefixes (e.g., `//! `) from original consumer content so closing tags remain properly formatted after updates

## Test plan

- [x] 17 new tests covering pad_blocks across 10+ languages (Rust `//!`, Rust `///`, TypeScript JSDoc, Python, Go, Java Javadoc, C, C++, C#, Kotlin KDoc, Swift)
- [x] Tests for idempotency (running update twice produces same result)
- [x] Tests for check detection (stale blocks detected correctly with padding)
- [x] Tests for disabled padding (pad_blocks=false preserves existing behavior)
- [x] Updated snapshot tests for Token::String Display fix
- [x] All 239 tests passing