### PR TITLE
feat(mdt_cli): add CLI integration snapshot tests with insta-cmd

### DIFF
--- a/.changeset/add_cli_integration_snapshots.md
+++ b/.changeset/add_cli_integration_snapshots.md
@@ -1,0 +1,18 @@
+---
+mdt: minor
+mdt_cli: minor
+---
+
+Add comprehensive CLI integration tests using `insta-cmd` snapshot testing.
+
+19 new integration tests covering `mdt check`, `mdt update`, and `mdt update --dry-run` across multiple scenarios:
+
+- **pad_blocks with Rust doc comments**: Verifies `//!` and `///` doc comments are not mangled after update, with check/update/idempotency/diff snapshots.
+- **pad_blocks with multiple languages**: Tests Rust, TypeScript (JSDoc), Python, and Go source files with data interpolation from `package.json`, ensuring all comment styles are preserved correctly.
+- **Validation diagnostics**: Snapshots error output for unclosed blocks and verifies `--ignore-unclosed-blocks` bypasses the error.
+- **includeEmpty on linePrefix**: Verifies the difference between `linePrefix` with and without `includeEmpty:true` — blank lines get the prefix when enabled.
+- **TypeScript workspace**: Adds snapshot coverage for the existing fixture, including file content verification after update.
+
+Also adds extra blank line padding in `pad_blocks` mode: when a comment prefix is present (e.g., `//!`, `///`, `*`), an additional blank line using that prefix is inserted between the opening tag and the content, and between the content and the closing tag.
+
+Sorts file paths in `mdt update --dry-run` and `--verbose` output for deterministic ordering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta-cmd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+dependencies = [
+ "insta",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +855,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "insta",
+ "insta-cmd",
  "mdt_core",
  "mdt_lsp",
  "mdt_mcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ doc-comment = { default-features = false, version = "^0.3" }
 float-cmp = { default-features = false, version = "^0.10" }
 globset = { default-features = false, version = "^0.4" }
 insta = { default-features = false, version = "^1" }
+insta-cmd = { default-features = false, version = "^0.6" }
 kdl = { default-features = false, version = "^6" }
 logos = { default-features = false, version = "^0.14" }
 markdown = { default-features = false, version = "^1" }

--- a/crates/mdt_cli/Cargo.toml
+++ b/crates/mdt_cli/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["full"], default-features = true }
 [dev-dependencies]
 assert_cmd = { workspace = true, default-features = true }
 insta = { workspace = true, default-features = true }
+insta-cmd = { workspace = true, default-features = true }
 predicates = { workspace = true, default-features = true }
 rstest = { workspace = true, default-features = true }
 similar-asserts = { workspace = true, default-features = true }

--- a/crates/mdt_cli/src/main.rs
+++ b/crates/mdt_cli/src/main.rs
@@ -319,7 +319,9 @@ fn run_update_once(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::erro
 			updates.updated_count,
 			updates.updated_files.len()
 		);
-		for path in updates.updated_files.keys() {
+		let mut paths: Vec<_> = updates.updated_files.keys().collect();
+		paths.sort();
+		for path in paths {
 			let rel = make_relative(path, &root);
 			println!("  {rel}");
 		}
@@ -332,7 +334,9 @@ fn run_update_once(args: &MdtCli, dry_run: bool) -> Result<(), Box<dyn std::erro
 		);
 
 		if args.verbose {
-			for path in updates.updated_files.keys() {
+			let mut paths: Vec<_> = updates.updated_files.keys().collect();
+			paths.sort();
+			for path in paths {
 				let rel = make_relative(path, &root);
 				println!("  {rel}");
 			}

--- a/crates/mdt_cli/tests/fixtures/include_empty/lib.rs
+++ b/crates/mdt_cli/tests/fixtures/include_empty/lib.rs
@@ -1,0 +1,5 @@
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//! Old content.
+//! <!-- {/docs} -->
+
+pub struct Lib;

--- a/crates/mdt_cli/tests/fixtures/include_empty/mdt.toml
+++ b/crates/mdt_cli/tests/fixtures/include_empty/mdt.toml
@@ -1,0 +1,1 @@
+pad_blocks = true

--- a/crates/mdt_cli/tests/fixtures/include_empty/no_include_empty.rs
+++ b/crates/mdt_cli/tests/fixtures/include_empty/no_include_empty.rs
@@ -1,0 +1,4 @@
+/// <!-- {=docs|trim|linePrefix:"/// "} -->
+/// Old content.
+/// <!-- {/docs} -->
+pub fn example() {}

--- a/crates/mdt_cli/tests/fixtures/include_empty/template.t.md
+++ b/crates/mdt_cli/tests/fixtures/include_empty/template.t.md
@@ -1,0 +1,7 @@
+<!-- {@docs} -->
+
+First paragraph.
+
+Second paragraph.
+
+<!-- {/docs} -->

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/mdt.toml
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/mdt.toml
@@ -1,0 +1,4 @@
+pad_blocks = true
+
+[data]
+package = "package.json"

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/package.json
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "my-tool",
+  "version": "2.0.0",
+  "description": "A multi-language tool"
+}

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/index.ts
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * <!-- {=api_docs|trim|linePrefix:" * ":true} -->
+ * Old TypeScript docs.
+ * <!-- {/api_docs} -->
+ */
+export function configure() {
+	return {};
+}

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/lib.rs
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/lib.rs
@@ -1,0 +1,5 @@
+//! <!-- {=api_docs|trim|linePrefix:"//! ":true} -->
+//! Old Rust docs.
+//! <!-- {/api_docs} -->
+
+pub struct Config;

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/main.go
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/main.go
@@ -1,0 +1,6 @@
+package main
+
+// <!-- {=api_docs|trim|linePrefix:"// ":true} -->
+// Old Go docs.
+// <!-- {/api_docs} -->
+func Configure() {}

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/main.py
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/src/main.py
@@ -1,0 +1,6 @@
+# <!-- {=api_docs|trim|linePrefix:"# ":true} -->
+# Old Python docs.
+# <!-- {/api_docs} -->
+
+def configure():
+    pass

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/template.t.md
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_multi_lang/template.t.md
@@ -1,0 +1,11 @@
+<!-- {@api_docs} -->
+
+{{ package.name }} v{{ package.version }}
+
+{{ package.description }}.
+
+## Getting Started
+
+Use the default configuration to get started quickly.
+
+<!-- {/api_docs} -->

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_rust/lib.rs
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_rust/lib.rs
@@ -1,0 +1,10 @@
+//! <!-- {=crate_docs|trim|linePrefix:"//! ":true} -->
+//! Old crate docs here.
+//! <!-- {/crate_docs} -->
+
+/// <!-- {=fn_greet|trim|linePrefix:"/// ":true} -->
+/// Old function docs.
+/// <!-- {/fn_greet} -->
+pub fn greet(name: &str) {
+	println!("Hello, {name}!");
+}

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_rust/mdt.toml
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_rust/mdt.toml
@@ -1,0 +1,1 @@
+pad_blocks = true

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_rust/readme.md
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_rust/readme.md
@@ -1,0 +1,7 @@
+# My Crate
+
+<!-- {=crate_docs} -->
+
+Old readme content.
+
+<!-- {/crate_docs} -->

--- a/crates/mdt_cli/tests/fixtures/pad_blocks_rust/template.t.md
+++ b/crates/mdt_cli/tests/fixtures/pad_blocks_rust/template.t.md
@@ -1,0 +1,24 @@
+<!-- {@crate_docs} -->
+
+# My Crate
+
+A powerful library for doing things.
+
+## Features
+
+- Fast and efficient
+- Easy to use
+
+<!-- {/crate_docs} -->
+
+<!-- {@fn_greet} -->
+
+Greets the user by name.
+
+## Examples
+
+```rust
+greet("Alice");
+```
+
+<!-- {/fn_greet} -->

--- a/crates/mdt_cli/tests/fixtures/validation_errors/template.t.md
+++ b/crates/mdt_cli/tests/fixtures/validation_errors/template.t.md
@@ -1,0 +1,5 @@
+<!-- {@valid_block} -->
+
+Some content.
+
+<!-- {/valid_block} -->

--- a/crates/mdt_cli/tests/fixtures/validation_errors/unclosed.md
+++ b/crates/mdt_cli/tests/fixtures/validation_errors/unclosed.md
@@ -1,0 +1,5 @@
+# Unclosed Block
+
+<!-- {=valid_block} -->
+
+Content without a closing tag.

--- a/crates/mdt_cli/tests/fixtures/validation_errors/valid.md
+++ b/crates/mdt_cli/tests/fixtures/validation_errors/valid.md
@@ -1,0 +1,7 @@
+# Valid Consumer
+
+<!-- {=valid_block} -->
+
+Old content.
+
+<!-- {/valid_block} -->

--- a/crates/mdt_cli/tests/snapshots.rs
+++ b/crates/mdt_cli/tests/snapshots.rs
@@ -1,0 +1,433 @@
+use std::path::Path;
+use std::process::Command;
+
+use insta_cmd::assert_cmd_snapshot;
+use insta_cmd::get_cargo_bin;
+use mdt_core::AnyEmptyResult;
+
+fn copy_fixture(name: &str, dest: &Path) {
+	let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+		.join("tests/fixtures")
+		.join(name);
+	copy_dir_recursive(&fixture, dest);
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+	std::fs::create_dir_all(dst)
+		.unwrap_or_else(|e| panic!("create_dir_all {}: {e}", dst.display()));
+	for entry in
+		std::fs::read_dir(src).unwrap_or_else(|e| panic!("read_dir {}: {e}", src.display()))
+	{
+		let entry = entry.unwrap_or_else(|e| panic!("entry: {e}"));
+		let src_path = entry.path();
+		let dst_path = dst.join(entry.file_name());
+
+		if src_path.is_dir() {
+			copy_dir_recursive(&src_path, &dst_path);
+		} else {
+			std::fs::copy(&src_path, &dst_path).unwrap_or_else(|e| {
+				panic!("copy {} -> {}: {e}", src_path.display(), dst_path.display())
+			});
+		}
+	}
+}
+
+fn mdt_cmd(path: &Path) -> Command {
+	let mut cmd = Command::new(get_cargo_bin("mdt"));
+	cmd.env("NO_COLOR", "1");
+	cmd.arg("--path");
+	cmd.arg(path);
+	cmd
+}
+
+// ---------------------------------------------------------------------------
+// pad_blocks_rust: Rust doc comments with pad_blocks enabled
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pad_blocks_rust_check_stale() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_rust", tmp.path());
+
+	assert_cmd_snapshot!(
+		"pad_blocks_rust_check_stale",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_rust_check_stale_diff() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_rust", tmp.path());
+
+	assert_cmd_snapshot!(
+		"pad_blocks_rust_check_stale_diff",
+		mdt_cmd(tmp.path()).arg("check").arg("--diff")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_rust_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_rust", tmp.path());
+
+	assert_cmd_snapshot!("pad_blocks_rust_update", mdt_cmd(tmp.path()).arg("update"));
+
+	// Verify the Rust file was updated correctly — no mangled doc comments
+	let lib_rs = std::fs::read_to_string(tmp.path().join("lib.rs"))?;
+	insta::assert_snapshot!("pad_blocks_rust_update_lib_rs", lib_rs);
+
+	// Verify the readme was updated
+	let readme = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	insta::assert_snapshot!("pad_blocks_rust_update_readme_md", readme);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_rust_check_after_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_rust", tmp.path());
+
+	// First update
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "update should succeed");
+
+	// Then check — should pass
+	assert_cmd_snapshot!(
+		"pad_blocks_rust_check_after_update",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_rust_update_idempotent() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_rust", tmp.path());
+
+	// First update
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "first update should succeed");
+
+	// Capture state after first update
+	let lib_after_first = std::fs::read_to_string(tmp.path().join("lib.rs"))?;
+
+	// Second update — should be a no-op
+	assert_cmd_snapshot!(
+		"pad_blocks_rust_update_idempotent",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	// File should be unchanged
+	let lib_after_second = std::fs::read_to_string(tmp.path().join("lib.rs"))?;
+	similar_asserts::assert_eq!(lib_after_first, lib_after_second);
+
+	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// pad_blocks_multi_lang: multiple source languages + data interpolation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pad_blocks_multi_lang_check_stale() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_multi_lang", tmp.path());
+
+	assert_cmd_snapshot!(
+		"pad_blocks_multi_lang_check_stale",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_multi_lang_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_multi_lang", tmp.path());
+
+	assert_cmd_snapshot!(
+		"pad_blocks_multi_lang_update",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	// Verify each source file — no mangled comments
+	let lib_rs = std::fs::read_to_string(tmp.path().join("src/lib.rs"))?;
+	insta::assert_snapshot!("pad_blocks_multi_lang_update_lib_rs", lib_rs);
+
+	let index_ts = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+	insta::assert_snapshot!("pad_blocks_multi_lang_update_index_ts", index_ts);
+
+	let main_py = std::fs::read_to_string(tmp.path().join("src/main.py"))?;
+	insta::assert_snapshot!("pad_blocks_multi_lang_update_main_py", main_py);
+
+	let main_go = std::fs::read_to_string(tmp.path().join("src/main.go"))?;
+	insta::assert_snapshot!("pad_blocks_multi_lang_update_main_go", main_go);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_multi_lang_check_after_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_multi_lang", tmp.path());
+
+	// Update first
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "update should succeed");
+
+	// Check should pass
+	assert_cmd_snapshot!(
+		"pad_blocks_multi_lang_check_after_update",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_multi_lang_update_idempotent() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_multi_lang", tmp.path());
+
+	// First update
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "first update should succeed");
+
+	let lib_rs_first = std::fs::read_to_string(tmp.path().join("src/lib.rs"))?;
+	let index_ts_first = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+
+	// Second update — no-op
+	assert_cmd_snapshot!(
+		"pad_blocks_multi_lang_update_idempotent",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	let lib_rs_second = std::fs::read_to_string(tmp.path().join("src/lib.rs"))?;
+	let index_ts_second = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+
+	similar_asserts::assert_eq!(lib_rs_first, lib_rs_second);
+	similar_asserts::assert_eq!(index_ts_first, index_ts_second);
+
+	Ok(())
+}
+
+#[test]
+fn pad_blocks_multi_lang_dry_run() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("pad_blocks_multi_lang", tmp.path());
+
+	let lib_rs_before = std::fs::read_to_string(tmp.path().join("src/lib.rs"))?;
+
+	assert_cmd_snapshot!(
+		"pad_blocks_multi_lang_dry_run",
+		mdt_cmd(tmp.path()).arg("update").arg("--dry-run")
+	);
+
+	// Files should NOT have changed
+	let lib_rs_after = std::fs::read_to_string(tmp.path().join("src/lib.rs"))?;
+	similar_asserts::assert_eq!(lib_rs_before, lib_rs_after);
+
+	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// validation_errors: unclosed blocks produce error diagnostics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validation_errors_check() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("validation_errors", tmp.path());
+
+	assert_cmd_snapshot!("validation_errors_check", mdt_cmd(tmp.path()).arg("check"));
+
+	Ok(())
+}
+
+#[test]
+fn validation_errors_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("validation_errors", tmp.path());
+
+	assert_cmd_snapshot!(
+		"validation_errors_update",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn validation_errors_ignore_flag() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("validation_errors", tmp.path());
+
+	assert_cmd_snapshot!(
+		"validation_errors_ignore_flag",
+		mdt_cmd(tmp.path())
+			.arg("--ignore-unclosed-blocks")
+			.arg("check")
+	);
+
+	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// include_empty: linePrefix with and without includeEmpty
+// ---------------------------------------------------------------------------
+
+#[test]
+fn include_empty_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("include_empty", tmp.path());
+
+	assert_cmd_snapshot!("include_empty_update", mdt_cmd(tmp.path()).arg("update"));
+
+	// With includeEmpty:true — blank lines get the prefix
+	let lib_rs = std::fs::read_to_string(tmp.path().join("lib.rs"))?;
+	insta::assert_snapshot!("include_empty_update_lib_rs", lib_rs);
+
+	// Without includeEmpty — blank lines stay empty
+	let no_include = std::fs::read_to_string(tmp.path().join("no_include_empty.rs"))?;
+	insta::assert_snapshot!("include_empty_update_no_include_empty_rs", no_include);
+
+	Ok(())
+}
+
+#[test]
+fn include_empty_check_after_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("include_empty", tmp.path());
+
+	// Update first
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "update should succeed");
+
+	// Check should pass
+	assert_cmd_snapshot!(
+		"include_empty_check_after_update",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// typescript_workspace: snapshot the existing fixture (was only using asserts)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typescript_workspace_check_stale() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("typescript_workspace", tmp.path());
+
+	assert_cmd_snapshot!(
+		"typescript_workspace_check_stale",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn typescript_workspace_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("typescript_workspace", tmp.path());
+
+	assert_cmd_snapshot!(
+		"typescript_workspace_update",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	let readme = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	insta::assert_snapshot!("typescript_workspace_update_readme_md", readme);
+
+	let index_ts = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+	insta::assert_snapshot!("typescript_workspace_update_index_ts", index_ts);
+
+	Ok(())
+}
+
+#[test]
+fn typescript_workspace_check_after_update() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("typescript_workspace", tmp.path());
+
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "update should succeed");
+
+	assert_cmd_snapshot!(
+		"typescript_workspace_check_after_update",
+		mdt_cmd(tmp.path()).arg("check")
+	);
+
+	Ok(())
+}
+
+#[test]
+fn typescript_workspace_update_idempotent() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("typescript_workspace", tmp.path());
+
+	let status = Command::new(get_cargo_bin("mdt"))
+		.env("NO_COLOR", "1")
+		.arg("--path")
+		.arg(tmp.path())
+		.arg("update")
+		.status()?;
+	assert!(status.success(), "first update should succeed");
+
+	let readme_first = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	let index_ts_first = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+
+	assert_cmd_snapshot!(
+		"typescript_workspace_update_idempotent",
+		mdt_cmd(tmp.path()).arg("update")
+	);
+
+	let readme_second = std::fs::read_to_string(tmp.path().join("readme.md"))?;
+	let index_ts_second = std::fs::read_to_string(tmp.path().join("src/index.ts"))?;
+
+	similar_asserts::assert_eq!(readme_first, readme_second);
+	similar_asserts::assert_eq!(index_ts_first, index_ts_second);
+
+	Ok(())
+}

--- a/crates/mdt_cli/tests/snapshots/snapshots__include_empty_check_after_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__include_empty_check_after_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp4YckhT
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpERyo5D
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Updated 2 block(s) in 2 file(s).
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update_lib_rs.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update_lib_rs.snap
@@ -1,0 +1,13 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: lib_rs
+---
+//! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//! 
+//! First paragraph.
+//! 
+//! Second paragraph.
+//! 
+//! <!-- {/docs} -->
+
+pub struct Lib;

--- a/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update_no_include_empty_rs.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__include_empty_update_no_include_empty_rs.snap
@@ -1,0 +1,12 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: no_include
+---
+/// <!-- {=docs|trim|linePrefix:"/// "} -->
+/// 
+/// First paragraph.
+
+/// Second paragraph.
+/// 
+/// <!-- {/docs} -->
+pub fn example() {}

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_check_after_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_check_after_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpAx84f9
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_check_stale.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_check_stale.snap
@@ -1,0 +1,22 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpA17H6o
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Stale: block `api_docs` in src/index.ts:2:4
+Stale: block `api_docs` in src/lib.rs:1:5
+Stale: block `api_docs` in src/main.go:3:4
+Stale: block `api_docs` in src/main.py:1:3
+
+4 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_dry_run.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_dry_run.snap
@@ -1,0 +1,22 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpYMaSBo
+    - update
+    - "--dry-run"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Dry run: would update 4 block(s) in 4 file(s):
+  src/index.ts
+  src/lib.rs
+  src/main.go
+  src/main.py
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpQKEiTk
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Updated 4 block(s) in 4 file(s).
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_idempotent.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_idempotent.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpEisXyl
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are already up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_index_ts.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_index_ts.snap
@@ -1,0 +1,20 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: index_ts
+---
+/**
+ * <!-- {=api_docs|trim|linePrefix:" * ":true} -->
+ * 
+ * my-tool v2.0.0
+ * 
+ * A multi-language tool.
+ * 
+ * ## Getting Started
+ * 
+ * Use the default configuration to get started quickly.
+ * 
+ * <!-- {/api_docs} -->
+ */
+export function configure() {
+	return {};
+}

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_lib_rs.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_lib_rs.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: lib_rs
+---
+//! <!-- {=api_docs|trim|linePrefix:"//! ":true} -->
+//! 
+//! my-tool v2.0.0
+//! 
+//! A multi-language tool.
+//! 
+//! ## Getting Started
+//! 
+//! Use the default configuration to get started quickly.
+//! 
+//! <!-- {/api_docs} -->
+
+pub struct Config;

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_main_go.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_main_go.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: main_go
+---
+package main
+
+// <!-- {=api_docs|trim|linePrefix:"// ":true} -->
+// 
+// my-tool v2.0.0
+// 
+// A multi-language tool.
+// 
+// ## Getting Started
+// 
+// Use the default configuration to get started quickly.
+// 
+// <!-- {/api_docs} -->
+func Configure() {}

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_main_py.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_multi_lang_update_main_py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: main_py
+---
+# <!-- {=api_docs|trim|linePrefix:"# ":true} -->
+# 
+# my-tool v2.0.0
+# 
+# A multi-language tool.
+# 
+# ## Getting Started
+# 
+# Use the default configuration to get started quickly.
+# 
+# <!-- {/api_docs} -->
+
+def configure():
+    pass

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_after_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_after_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmprewbA6
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_stale.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_stale.snap
@@ -1,0 +1,21 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpwgmOMV
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Stale: block `crate_docs` in lib.rs:1:5
+Stale: block `fn_greet` in lib.rs:5:5
+Stale: block `crate_docs` in readme.md:3:1
+
+3 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_stale_diff.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_check_stale_diff.snap
@@ -1,0 +1,59 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpwU1yjw
+    - check
+    - "--diff"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Stale: block `crate_docs` in lib.rs:1:5
+   
+  -//! Old crate docs here.
+  +//! 
+  +//! # My Crate
+  +//! 
+  +//! A powerful library for doing things.
+  +//! 
+  +//! ## Features
+  +//! 
+  +//! - Fast and efficient
+  +//! - Easy to use
+  +//! 
+   //! 
+Stale: block `fn_greet` in lib.rs:5:5
+   
+  -/// Old function docs.
+  +/// 
+  +/// Greets the user by name.
+  +/// 
+  +/// ## Examples
+  +/// 
+  +/// ```rust
+  +/// greet("Alice");
+  +/// ```
+  +/// 
+   /// 
+Stale: block `crate_docs` in readme.md:3:1
+   
+   
+  -Old readme content.
+  +# My Crate
+  +
+  +A powerful library for doing things.
+  +
+  +## Features
+  +
+  +- Fast and efficient
+  +- Easy to use
+   
+
+3 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpMhLwjB
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Updated 3 block(s) in 2 file(s).
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_idempotent.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_idempotent.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpewUz4H
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are already up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_lib_rs.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_lib_rs.snap
@@ -1,0 +1,31 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: lib_rs
+---
+//! <!-- {=crate_docs|trim|linePrefix:"//! ":true} -->
+//! 
+//! # My Crate
+//! 
+//! A powerful library for doing things.
+//! 
+//! ## Features
+//! 
+//! - Fast and efficient
+//! - Easy to use
+//! 
+//! <!-- {/crate_docs} -->
+
+/// <!-- {=fn_greet|trim|linePrefix:"/// ":true} -->
+/// 
+/// Greets the user by name.
+/// 
+/// ## Examples
+/// 
+/// ```rust
+/// greet("Alice");
+/// ```
+/// 
+/// <!-- {/fn_greet} -->
+pub fn greet(name: &str) {
+	println!("Hello, {name}!");
+}

--- a/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_readme_md.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__pad_blocks_rust_update_readme_md.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: readme
+---
+# My Crate
+
+<!-- {=crate_docs} -->
+
+# My Crate
+
+A powerful library for doing things.
+
+## Features
+
+- Fast and efficient
+- Easy to use
+
+<!-- {/crate_docs} -->

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_check_after_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_check_after_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp9wt93I
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_check_stale.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_check_stale.snap
@@ -1,0 +1,21 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpNCp5vO
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Stale: block `installGuide` in readme.md:7:1
+Stale: block `apiDocs` in readme.md:15:1
+Stale: block `apiDocs` in src/index.ts:2:4
+
+3 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpWMMdyl
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Updated 3 block(s) in 2 file(s).
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_idempotent.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_idempotent.snap
@@ -1,0 +1,17 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmprHHEXu
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All consumer blocks are already up to date.
+
+----- stderr -----

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_index_ts.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_index_ts.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: index_ts
+---
+/**
+ * <!-- {=apiDocs|trim|indent:" * "} --> * A sample TypeScript library.
+
+ * ## Usage
+
+ * ```ts
+ * import { createClient } from "my-lib";
+
+ * const client = createClient();
+ * ```<!-- {/apiDocs} -->
+ */
+export function createClient() {
+	return {};
+}

--- a/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_readme_md.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__typescript_workspace_update_readme_md.snap
@@ -1,0 +1,33 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+expression: readme
+---
+# My Lib
+
+> A TypeScript library
+
+## Installation
+
+<!-- {=installGuide} -->
+
+Install `my-lib` (v1.2.3):
+
+```sh
+npm install my-lib
+```
+<!-- {/installGuide} -->
+
+## API
+
+<!-- {=apiDocs} -->
+
+A sample TypeScript library.
+
+## Usage
+
+```ts
+import { createClient } from "my-lib";
+
+const client = createClient();
+```
+<!-- {/apiDocs} -->

--- a/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_check.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_check.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp1bV4Vj
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+error: unclosed.md:3:1: missing closing tag for block `valid_block`
+error: validation errors found

--- a/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_ignore_flag.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_ignore_flag.snap
@@ -1,0 +1,20 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpHS98fY
+    - "--ignore-unclosed-blocks"
+    - check
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Stale: block `valid_block` in valid.md:3:1
+
+1 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_update.snap
+++ b/crates/mdt_cli/tests/snapshots/snapshots__validation_errors_update.snap
@@ -1,0 +1,18 @@
+---
+source: crates/mdt_cli/tests/snapshots.rs
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpes3wf3
+    - update
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+error: unclosed.md:3:1: missing closing tag for block `valid_block`
+error: validation errors found

--- a/crates/mdt_core/src/__tests.rs
+++ b/crates/mdt_core/src/__tests.rs
@@ -2593,12 +2593,14 @@ fn pad_blocks_rust_doc_comments() -> MdtResult<()> {
 	});
 	// After trim: "Hello from mdt."
 	// After linePrefix "//! " with includeEmpty: "//! Hello from mdt."
-	// After pad_blocks: "\n//! Hello from mdt.\n"
+	// After pad_blocks: "\n//! \n//! Hello from mdt.\n//! \n//! "
 	assert_eq!(
 		content.as_str(),
 		concat!(
 			"//! <!-- {=docs|trim|linePrefix:\"//! \":true} -->\n",
+			"//! \n",
 			"//! Hello from mdt.\n",
+			"//! \n",
 			"//! <!-- {/docs} -->\n",
 			"\n",
 			"pub fn main() {}\n",
@@ -2650,11 +2652,13 @@ fn pad_blocks_rust_doc_comments_multiline() -> MdtResult<()> {
 	});
 	// After trim: "# My Library\n\nThis is a great library.\n\n## Usage\n\nJust use
 	// it." After linePrefix "//! " with includeEmpty=true on each line
-	// After pad_blocks: \n prepended, \n appended
+	// After pad_blocks: extra blank prefix line before content and before closing
+	// tag
 	assert_eq!(
 		content.as_str(),
 		concat!(
 			"//! <!-- {=docs|trim|linePrefix:\"//! \":true} -->\n",
+			"//! \n",
 			"//! # My Library\n",
 			"//! \n",
 			"//! This is a great library.\n",
@@ -2662,6 +2666,7 @@ fn pad_blocks_rust_doc_comments_multiline() -> MdtResult<()> {
 			"//! ## Usage\n",
 			"//! \n",
 			"//! Just use it.\n",
+			"//! \n",
 			"//! <!-- {/docs} -->\n",
 			"\n",
 			"pub fn main() {}\n",
@@ -2702,7 +2707,9 @@ fn pad_blocks_rust_triple_slash_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"/// <!-- {=fn_docs|trim|linePrefix:\"/// \":true} -->\n",
+			"/// \n",
 			"/// Does something useful.\n",
+			"/// \n",
 			"/// <!-- {/fn_docs} -->\n",
 			"pub fn do_something() {}\n",
 		)
@@ -2745,7 +2752,9 @@ fn pad_blocks_typescript_jsdoc() -> MdtResult<()> {
 		concat!(
 			"/**\n",
 			" * <!-- {=jsdocs|trim|linePrefix:\" * \":true} -->\n",
+			" * \n",
 			" * Greets the user.\n",
+			" * \n",
 			" * <!-- {/jsdocs} -->\n",
 			" */\n",
 			"export function greet() {}\n",
@@ -2787,7 +2796,9 @@ fn pad_blocks_python_hash_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"# <!-- {=pydocs|trim|linePrefix:\"# \":true} -->\n",
+			"# \n",
 			"# Python docs here.\n",
+			"# \n",
 			"# <!-- {/pydocs} -->\n",
 			"def main():\n",
 			"    pass\n",
@@ -2828,7 +2839,9 @@ fn pad_blocks_go_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"// <!-- {=godocs|trim|linePrefix:\"// \":true} -->\n",
+			"// \n",
 			"// Go function docs.\n",
+			"// \n",
 			"// <!-- {/godocs} -->\n",
 			"func main() {}\n",
 		)
@@ -2871,7 +2884,9 @@ fn pad_blocks_java_comments() -> MdtResult<()> {
 		concat!(
 			"/**\n",
 			" * <!-- {=javadocs|trim|linePrefix:\" * \":true} -->\n",
+			" * \n",
 			" * Java method docs.\n",
+			" * \n",
 			" * <!-- {/javadocs} -->\n",
 			" */\n",
 			"public class Main {}\n",
@@ -2912,7 +2927,9 @@ fn pad_blocks_c_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"// <!-- {=cdocs|trim|linePrefix:\"// \":true} -->\n",
+			"// \n",
 			"// C function docs.\n",
+			"// \n",
 			"// <!-- {/cdocs} -->\n",
 			"int main() { return 0; }\n",
 		)
@@ -3064,6 +3081,7 @@ fn pad_blocks_rust_multiline_preserves_blank_lines() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"//! <!-- {=api|trim|linePrefix:\"//! \":true} -->\n",
+			"//! \n",
 			"//! # API\n",
 			"//! \n",
 			"//! Create a new instance:\n",
@@ -3073,6 +3091,7 @@ fn pad_blocks_rust_multiline_preserves_blank_lines() -> MdtResult<()> {
 			"//! ```\n",
 			"//! \n",
 			"//! Then call methods on it.\n",
+			"//! \n",
 			"//! <!-- {/api} -->\n",
 			"\n",
 			"pub struct Foo;\n",
@@ -3116,7 +3135,9 @@ fn pad_blocks_kotlin_comments() -> MdtResult<()> {
 		concat!(
 			"/**\n",
 			" * <!-- {=ktdocs|trim|linePrefix:\" * \":true} -->\n",
+			" * \n",
 			" * Kotlin function docs.\n",
+			" * \n",
 			" * <!-- {/ktdocs} -->\n",
 			" */\n",
 			"fun main() {}\n",
@@ -3157,7 +3178,9 @@ fn pad_blocks_swift_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"/// <!-- {=swiftdocs|trim|linePrefix:\"/// \":true} -->\n",
+			"/// \n",
 			"/// Swift function docs.\n",
+			"/// \n",
 			"/// <!-- {/swiftdocs} -->\n",
 			"func greet() {}\n",
 		)
@@ -3197,7 +3220,9 @@ fn pad_blocks_cpp_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"// <!-- {=cppdocs|trim|linePrefix:\"// \":true} -->\n",
+			"// \n",
 			"// C++ function docs.\n",
+			"// \n",
 			"// <!-- {/cppdocs} -->\n",
 			"int main() { return 0; }\n",
 		)
@@ -3237,7 +3262,9 @@ fn pad_blocks_csharp_comments() -> MdtResult<()> {
 		content.as_str(),
 		concat!(
 			"/// <!-- {=csdocs|trim|linePrefix:\"/// \":true} -->\n",
+			"/// \n",
 			"/// C# method docs.\n",
+			"/// \n",
 			"/// <!-- {/csdocs} -->\n",
 			"public static void Main() {}\n",
 		)

--- a/crates/mdt_core/src/engine.rs
+++ b/crates/mdt_core/src/engine.rs
@@ -329,6 +329,10 @@ pub fn pad_content(content: &str) -> String {
 /// consumer content. When the closing tag is preceded by a comment prefix
 /// (e.g., `//! ` or `/// `) that prefix is part of the content range and must
 /// be preserved after replacement.
+///
+/// Adds an extra blank line (using the trailing prefix) between the opening
+/// tag and the content and between the content and the closing tag. This
+/// ensures the content is visually separated from the surrounding tags.
 fn pad_content_preserving_suffix(new_content: &str, original_content: &str) -> String {
 	// Extract the trailing prefix from the original content — everything after
 	// the last newline. For example, in "\n//! old\n//! " the trailing prefix
@@ -338,12 +342,24 @@ fn pad_content_preserving_suffix(new_content: &str, original_content: &str) -> S
 		.map(|idx| &original_content[idx + 1..])
 		.unwrap_or("");
 
-	let mut result = String::with_capacity(new_content.len() + trailing_prefix.len() + 2);
+	let mut result = String::with_capacity(new_content.len() + trailing_prefix.len() * 3 + 4);
+	// Leading newline
 	if !new_content.starts_with('\n') {
 		result.push('\n');
 	}
+	// Extra blank line between opening tag and content, using the comment prefix
+	if !trailing_prefix.is_empty() {
+		result.push_str(trailing_prefix);
+		result.push('\n');
+	}
 	result.push_str(new_content);
+	// Trailing newline
 	if !new_content.ends_with('\n') {
+		result.push('\n');
+	}
+	// Extra blank line between content and closing tag, using the comment prefix
+	if !trailing_prefix.is_empty() {
+		result.push_str(trailing_prefix);
 		result.push('\n');
 	}
 	result.push_str(trailing_prefix);

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -79,7 +79,7 @@ When set, only `*.t.md` files within these directories are recognized as templat
 
 ### `pad_blocks` — Block content padding
 
-When enabled, mdt ensures a newline always separates the opening tag from the content and the content from the closing tag. This is recommended when using consumer blocks in source code files.
+When enabled, mdt ensures a blank line separates the opening tag from the content and the content from the closing tag. In source code files, the extra blank lines use the same comment prefix as the surrounding lines (e.g., `//!`, `///`, `*`). This is recommended when using consumer blocks in source code files.
 
 ```toml
 pad_blocks = true

--- a/docs/src/guide/source-files.md
+++ b/docs/src/guide/source-files.md
@@ -89,7 +89,7 @@ When using consumer blocks in source files, add `pad_blocks = true` to your `mdt
 pad_blocks = true
 ```
 
-This ensures a newline always separates the opening/closing tags from the content, preventing transformers like `trim` from causing the content to merge directly with the tags.
+This ensures a blank line (using the same comment prefix) separates the opening/closing tags from the content, preventing transformers like `trim` from causing the content to merge directly with the tags.
 
 Without `pad_blocks`, a consumer with `trim|linePrefix:"//! ":true` could produce:
 
@@ -102,7 +102,9 @@ With `pad_blocks = true`, the output is properly structured:
 
 ```rust
 //! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//!
 //! Content here.
+//!
 //! <!-- {/docs} -->
 ```
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -96,7 +96,7 @@ By default (when this section is absent), mdt finds `*.t.md` files anywhere in t
 
 ### `pad_blocks`
 
-When set to `true`, mdt ensures a newline always separates the opening tag from the content and the content from the closing tag. This prevents content from running directly into tags when transformers produce output without leading or trailing newlines.
+When set to `true`, mdt ensures a blank line separates the opening tag from the content and the content from the closing tag. In source code files, the extra blank lines use the same comment prefix as the surrounding lines (e.g., `//!`, `///`, `*`). This prevents content from running directly into tags when transformers produce output without leading or trailing newlines.
 
 ```toml
 pad_blocks = true
@@ -108,7 +108,9 @@ This is especially important for **source code files** (`.rs`, `.ts`, `.py`, `.g
 
 ```rust
 //! <!-- {=docs|trim|linePrefix:"//! ":true} -->
+//!
 //! This content stays properly formatted.
+//!
 //! <!-- {/docs} -->
 ```
 


### PR DESCRIPTION
## Summary

- Add 19 integration tests using `insta-cmd` for snapshot testing of `mdt check`, `mdt update`, and `mdt update --dry-run` across 5 fixture scenarios
- Add extra blank line padding in `pad_blocks` mode: when a comment prefix is present (e.g., `//!`, `///`, ` * `), an additional blank line using that prefix is inserted between opening tag/content and content/closing tag
- Sort file paths in `--dry-run` and `--verbose` output for deterministic ordering

### Test fixtures and what they cover

| Fixture | Tests | Verifies |
|---------|-------|----------|
| `pad_blocks_rust` | 5 | `//!` and `///` doc comments are not mangled; check/update/idempotency/diff |
| `pad_blocks_multi_lang` | 5 | Rust, TypeScript (JSDoc), Python, Go with data interpolation; dry-run |
| `validation_errors` | 3 | Unclosed block errors, `--ignore-unclosed-blocks` flag |
| `include_empty` | 2 | `linePrefix` with and without `includeEmpty:true` |
| `typescript_workspace` | 4 | Existing fixture with snapshot coverage; file content after update |

### Snapshot types

- **CLI output snapshots** (`assert_cmd_snapshot!`): Capture stdout, stderr, and exit code for `mdt check`/`mdt update`
- **File content snapshots** (`insta::assert_snapshot!`): Capture the exact file contents after `mdt update` to verify no mangling of source code comments
- **Idempotency checks**: Run update twice and verify second run is a no-op with `similar_asserts::assert_eq!`

## Test plan

- [x] 19 new integration tests all passing
- [x] 191 existing mdt_core unit tests still passing
- [x] 44 existing CLI tests still passing
- [x] Clippy clean
- [x] dprint formatted