### PR TITLE
feat(mdt_core): add file ignore support with .gitignore integration

### DIFF
--- a/.changeset/add_ignore_and_gitignore_support.md
+++ b/.changeset/add_ignore_and_gitignore_support.md
@@ -1,0 +1,25 @@
+---
+mdt_core: major
+---
+
+Add file ignore support with `.gitignore` integration.
+
+**New `[ignore]` config section:** The `mdt.toml` configuration file now supports an `[ignore]` section with gitignore-style patterns for skipping files and directories during scanning. These patterns follow `.gitignore` syntax and are applied on top of any `.gitignore` rules.
+
+```toml
+[ignore]
+patterns = ["build/", "dist/", "*.generated.md"]
+```
+
+**`.gitignore` integration:** By default, mdt now respects `.gitignore` files in the project root. Files that would be ignored by git are automatically skipped during scanning. This eliminates the need to manually exclude common build artifacts, dependencies, and other generated files.
+
+**`disable_gitignore` setting:** A new top-level `disable_gitignore` boolean setting disables `.gitignore` integration when set to `true`. This is useful when working outside a git repository or when full control over file filtering is needed.
+
+```toml
+disable_gitignore = true
+
+[ignore]
+patterns = ["build/", "dist/"]
+```
+
+**Breaking change:** The `scan_project_with_options()` function signature now requires two additional parameters: `ignore_patterns: &[String]` and `disable_gitignore: bool`. The `MdtConfig` struct has two new fields: `ignore: IgnoreConfig` and `disable_gitignore: bool`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +656,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +913,7 @@ dependencies = [
  "derive_more",
  "float-cmp",
  "globset",
+ "ignore",
  "insta",
  "kdl",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ derive_more = { version = "2", features = ["deref", "deref_mut"], default-featur
 doc-comment = { default-features = false, version = "^0.3" }
 float-cmp = { default-features = false, version = "^0.10" }
 globset = { default-features = false, version = "^0.4" }
+ignore = { default-features = false, version = "^0.4" }
 insta = { default-features = false, version = "^1" }
 insta-cmd = { default-features = false, version = "^0.6" }
 kdl = { default-features = false, version = "^6" }

--- a/crates/mdt_core/Cargo.toml
+++ b/crates/mdt_core/Cargo.toml
@@ -16,6 +16,7 @@ description = "update markdown content anywhere using comments as template tags"
 derive_more = { workspace = true, default-features = true }
 float-cmp = { workspace = true, default-features = true }
 globset = { workspace = true, default-features = true }
+ignore = { workspace = true, default-features = true }
 kdl = { workspace = true, default-features = true }
 logos = { workspace = true, default-features = true }
 markdown = { workspace = true, default-features = true }

--- a/crates/mdt_core/src/config.rs
+++ b/crates/mdt_core/src/config.rs
@@ -23,8 +23,13 @@ pub const DEFAULT_MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 /// [include]
 /// patterns = ["docs/**/*.rs"]
 ///
+/// [ignore]
+/// patterns = ["build/**", "dist/**"]
+///
 /// [templates]
 /// paths = ["shared/templates"]
+///
+/// disable_gitignore = false
 /// ```
 #[derive(Debug, Deserialize)]
 pub struct MdtConfig {
@@ -37,6 +42,9 @@ pub struct MdtConfig {
 	/// Inclusion configuration — additional glob patterns to scan.
 	#[serde(default)]
 	pub include: IncludeConfig,
+	/// Ignore configuration — gitignore-style patterns for files to skip.
+	#[serde(default)]
+	pub ignore: IgnoreConfig,
 	/// Template paths — additional directories to search for `*.t.md` files.
 	#[serde(default)]
 	pub templates: TemplatesConfig,
@@ -50,6 +58,13 @@ pub struct MdtConfig {
 	/// leading/trailing newlines. Defaults to `false`.
 	#[serde(default)]
 	pub pad_blocks: bool,
+	/// When true, `.gitignore` files are not used for filtering. By default
+	/// (`false`), mdt respects `.gitignore` patterns and skips files that
+	/// would be ignored by git. Set to `true` when working outside a git
+	/// repository or when you want full control over which files are
+	/// scanned — in that case, use `[ignore]` patterns instead.
+	#[serde(default)]
+	pub disable_gitignore: bool,
 }
 
 fn default_max_file_size() -> u64 {
@@ -70,6 +85,19 @@ pub struct ExcludeConfig {
 pub struct IncludeConfig {
 	/// Additional glob patterns for files to scan.
 	/// These are relative to the project root.
+	#[serde(default)]
+	pub patterns: Vec<String>,
+}
+
+/// Configuration for ignoring files using gitignore-style patterns.
+///
+/// These patterns follow the same syntax as `.gitignore` files and are applied
+/// on top of any `.gitignore` rules (unless `disable_gitignore` is set).
+#[derive(Debug, Default, Deserialize)]
+pub struct IgnoreConfig {
+	/// Gitignore-style patterns for files and directories to skip.
+	/// These are relative to the project root and follow `.gitignore` syntax
+	/// (e.g., `build/`, `*.generated.md`, `!important.md`).
 	#[serde(default)]
 	pub patterns: Vec<String>,
 }


### PR DESCRIPTION
## Summary

- Add `[ignore]` config section to `mdt.toml` with gitignore-style patterns for skipping files/directories during scanning
- Integrate `.gitignore` support — files ignored by git are now automatically skipped during scanning (enabled by default)
- Add `disable_gitignore` top-level setting to opt out of `.gitignore` integration
- Use the `ignore` crate's `GitignoreBuilder`/`Gitignore` for pattern matching (supports negation patterns like `!important.md`)

## Breaking changes

- `scan_project_with_options()` now requires `ignore_patterns: &[String]` and `disable_gitignore: bool` parameters
- `MdtConfig` has new fields: `ignore: IgnoreConfig` and `disable_gitignore: bool`

## Test plan

- [x] Custom ignore patterns skip matching files
- [x] Custom ignore glob patterns skip matching files (e.g., `*.generated.md`)
- [x] `.gitignore` is respected by default (files in gitignored dirs are skipped)
- [x] `disable_gitignore = true` causes all files to be scanned regardless of `.gitignore`
- [x] Combined `.gitignore` + custom ignore patterns work together
- [x] Negation patterns (`!output/important.md`) re-include files
- [x] `scan_project_with_options` accepts ignore parameters directly
- [x] Config parsing for new `[ignore]` section and `disable_gitignore` field
- [x] Config defaults (empty patterns, `disable_gitignore = false`)
- [x] All 200 existing + new tests pass