### PR TITLE
ci: fix release and docs-pages workflows

### DIFF
--- a/.changeset/fix_release_and_docs_workflows.md
+++ b/.changeset/fix_release_and_docs_workflows.md
@@ -1,0 +1,9 @@
+---
+mdt_cli: patch
+---
+
+Fix release and docs-pages CI workflows.
+
+**Release workflow:** Remove the strict version verification step that caused failures when tags were created by knope before version bumps. Add `workflow_dispatch` trigger with a `tag` input so release builds can be manually triggered for any `mdt_cli` tag. Check out the tag ref directly instead of `main` so binaries are built from the tagged commit.
+
+**Docs-pages workflow:** Fix cancellation issue where multiple simultaneous releases caused the valid `mdt_cli` run to be cancelled by a subsequent non-matching release. Changed `cancel-in-progress` to `false` so runs queue instead of cancelling. Add `workflow_dispatch` trigger with an optional `ref` input (tag, branch, or commit SHA) for manually building and deploying docs. Check out the specified ref for both release and manual triggers.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build docs from (tag, branch, or commit SHA). Defaults to the default branch."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,19 +17,22 @@ permissions:
 
 concurrency:
   group: docs-pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
-    # Only deploy docs on mdt_cli releases (not library-only releases).
+    # For release events, only deploy on mdt_cli releases (not library-only).
+    # For workflow_dispatch, always run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.release.tag_name, 'mdt_cli')
+      startsWith(github.event.release.tag_name, 'mdt_cli/')
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
 
       - name: install mdbook
         uses: taiki-e/install-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,15 @@ name: "release"
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. mdt_cli/v0.3.0). Must start with mdt_cli/ and have a matching GitHub release."
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
   cancel-in-progress: true
 
 jobs:
@@ -14,10 +20,14 @@ jobs:
       CARGO_PROFILE_RELEASE_LTO: true
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
       CARGO_PROFILE_RELEASE_STRIP: symbols
+      # Resolve the tag from either the release event or the workflow_dispatch input.
+      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
     permissions:
       contents: write
     # Only build binaries for mdt_cli releases (not the mdt library releases).
-    if: github.repository_owner == 'ifiokjr' && startsWith(github.event.release.tag_name, 'mdt_cli')
+    if: >-
+      github.repository_owner == 'ifiokjr' &&
+      startsWith(inputs.tag || github.event.release.tag_name, 'mdt_cli/')
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +54,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -54,20 +64,7 @@ jobs:
         id: version
         run: echo "version=${TAG#*/}" >> "${GITHUB_OUTPUT}"
         env:
-          TAG: ${{ github.event.release.tag_name }}
-        shell: bash
-
-      - name: verify tag version matches code
-        run: |
-          TAG_VERSION="${TAG#*/v}"
-          CARGO_VERSION=$(cargo metadata --no-deps --format-version=1 \
-            | jq -r '.packages[] | select(.name=="mdt_cli") | .version')
-          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
-            echo "::error::Version mismatch: tag=$TAG_VERSION cargo=$CARGO_VERSION"
-            exit 1
-          fi
-        env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ env.RELEASE_TAG }}
         shell: bash
 
       - name: setup cross toolchain
@@ -91,6 +88,7 @@ jobs:
         with:
           bin: mdt
           manifest-path: crates/mdt_cli/Cargo.toml
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           archive: mdt-$target-${{ steps.version.outputs.version }}
           target: ${{ matrix.target }}
           tar: all


### PR DESCRIPTION
## Summary

- Fix the release workflow failing on new tags ([run #22366423126](https://github.com/ifiokjr/mdt/actions/runs/22366423126))
- Fix the docs-pages workflow being cancelled on releases ([run #22366423121](https://github.com/ifiokjr/mdt/actions/runs/22366423121))
- Add `workflow_dispatch` triggers for manual operation

## Changes

### Release workflow (`release.yml`)

- **Remove strict version verification**: The `verify tag version matches code` step failed because knope creates tags before version bumps are applied. This check is redundant since knope manages versioning.
- **Add `workflow_dispatch`**: New `tag` input (e.g. `mdt_cli/v0.3.0`) allows manually building and uploading release assets for any `mdt_cli` tag.
- **Check out tag ref**: Previously checked out `main`, now checks out the tag itself so binaries are built from the tagged commit.
- **Pass `ref` to upload action**: Ensures the upload action finds the correct release.

### Docs-pages workflow (`docs-pages.yml`)

- **Fix cancellation bug**: Changed `cancel-in-progress: false` so concurrent release events (mdt_core, mdt_cli, mdt_lsp created within seconds) don't cancel each other. Previously, a non-matching release (e.g. `mdt_lsp`) would cancel the valid `mdt_cli` run, then skip itself due to the `if` condition — resulting in no deployment.
- **Add `workflow_dispatch`**: New optional `ref` input (tag, branch, or commit SHA) allows manually building and deploying docs from any ref.
- **Check out specified ref**: Both release and manual triggers now check out the correct ref instead of defaulting to the triggering commit.

## Test plan
- [x] Workflow YAML syntax is valid
- [ ] Verify release workflow succeeds on next `mdt_cli` tag creation
- [ ] Verify docs-pages deploys after release
- [ ] Verify manual `workflow_dispatch` triggers work for both workflows