### PR TITLE
fix: show all errors in mdt check instead of failing on first

### DIFF
--- a/.changeset/check_show_all_errors.md
+++ b/.changeset/check_show_all_errors.md
@@ -1,0 +1,10 @@
+---
+mdt: patch
+mdt_cli: patch
+---
+
+Show all errors in `mdt check` instead of stopping at the first failure.
+
+Previously, `check_project` would abort on the first template render error (e.g., invalid minijinja syntax). Now it collects all render errors alongside stale consumer entries and reports everything in a single pass.
+
+The `CheckResult` struct has a new `render_errors` field containing `RenderError` entries. The CLI and MCP server both display these errors before the stale block list.

--- a/mdt_cli/tests/snapshots/snapshots__check_format_json_stale.snap
+++ b/mdt_cli/tests/snapshots/snapshots__check_format_json_stale.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpVdLKST
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpRDuiO3
     - check
     - "--format"
     - json
@@ -14,6 +14,6 @@ info:
 success: false
 exit_code: 1
 ----- stdout -----
-{"ok":false,"stale":[{"block":"intro","column":1,"file":"readme.md","line":3},{"block":"version","column":10,"file":"readme.md","line":9}]}
+{"errors":[],"ok":false,"stale":[{"block":"intro","column":1,"file":"readme.md","line":3},{"block":"version","column":10,"file":"readme.md","line":9}]}
 
 ----- stderr -----

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -145,6 +145,20 @@ impl MdtMcpServer {
 
 		let mut parts = Vec::new();
 
+		if !result.render_errors.is_empty() {
+			parts.push(format!(
+				"{} template render error(s):",
+				result.render_errors.len()
+			));
+			for err in &result.render_errors {
+				let rel = make_relative(&err.file, &root);
+				parts.push(format!(
+					"  - `{}` in {rel}: {}",
+					err.block_name, err.message
+				));
+			}
+		}
+
 		if !result.stale.is_empty() {
 			parts.push(format!(
 				"{} consumer block(s) are stale:",


### PR DESCRIPTION
## Summary

- `check_project` now collects template render errors alongside stale consumer entries instead of aborting on the first `render_template` failure
- New `RenderError` type and `render_errors` field on `CheckResult`
- CLI displays render errors before stale blocks in all output formats (text, JSON, GitHub)
- MCP server also reports render errors in check results

## Test plan

- [x] All 605 tests pass
- [x] Snapshot tests updated for new JSON output format (`errors` field)
- [x] `dprint check` passes