### PR TITLE
feat: improve error display with miette rich diagnostics

### DIFF
--- a/.changeset/miette_error_display.md
+++ b/.changeset/miette_error_display.md
@@ -1,0 +1,9 @@
+---
+mdt_cli: patch
+---
+
+Improve error display using miette for rich, contextual diagnostics.
+
+Errors from mdt now include error codes (e.g., `mdt::unclosed_block`), actionable help text, and visual formatting with Unicode markers when color is enabled. The miette handler respects `--no-color` and the `NO_COLOR` environment variable.
+
+Validation diagnostics (unclosed blocks, unknown transformers, unused providers) are now rendered through miette with severity levels (error vs warning) and context-specific help messages.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "mdt_core",
  "mdt_lsp",
  "mdt_mcp",
+ "miette",
  "notify",
  "owo-colors",
  "predicates",

--- a/mdt_cli/Cargo.toml
+++ b/mdt_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { workspace = true, features = ["derive"], default-features = true }
 mdt_core = { workspace = true }
 mdt_lsp = { workspace = true }
 mdt_mcp = { workspace = true }
+miette = { workspace = true, features = ["fancy"], default-features = true }
 notify = { workspace = true, features = ["macos_fsevent"], default-features = true }
 owo-colors = { workspace = true, features = ["supports-colors"], default-features = true }
 serde_json = { workspace = true, default-features = true }

--- a/mdt_cli/tests/snapshots/snapshots__missing_provider_check.snap
+++ b/mdt_cli/tests/snapshots/snapshots__missing_provider_check.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp55jMRB
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpGUpr0j
     - check
   env:
     NO_COLOR: "1"
@@ -14,5 +14,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: template.t.md:1:1: provider block `other_block` has no consumers
+mdt::unused_provider
+
+  x [template.t.md:1:1] provider block `other_block` has no consumers
+  help: add a consumer block `<!-- {=other_block} -->...<!-- {/other_block}
+        -->` or remove the unused provider
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__missing_provider_update.snap
+++ b/mdt_cli/tests/snapshots/snapshots__missing_provider_update.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpa0JwX5
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpQByGB1
     - update
   env:
     NO_COLOR: "1"
@@ -14,5 +14,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: template.t.md:1:1: provider block `other_block` has no consumers
+mdt::unused_provider
+
+  x [template.t.md:1:1] provider block `other_block` has no consumers
+  help: add a consumer block `<!-- {=other_block} -->...<!-- {/other_block}
+        -->` or remove the unused provider
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__unknown_transformer_check.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unknown_transformer_check.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpQs7P3c
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpkCUd49
     - check
   env:
     NO_COLOR: "1"
@@ -14,5 +14,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: readme.md:3:1: unknown transformer `foobar`
+mdt::unknown_transformer
+
+  x [readme.md:3:1] unknown transformer `foobar`
+  help: available transformers: trim, trimStart, trimEnd, indent, prefix,
+        suffix, linePrefix, lineSuffix, wrap, codeBlock, code, replace
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__unknown_transformer_check_verbose.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unknown_transformer_check_verbose.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpddzV90
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpoeiVZF
     - "--verbose"
     - check
   env:
@@ -18,5 +18,10 @@ Scanned project: 1 provider(s), 1 consumer(s)
     @docs ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-error: readme.md:3:1: unknown transformer `foobar`
+mdt::unknown_transformer
+
+  x [readme.md:3:1] unknown transformer `foobar`
+  help: available transformers: trim, trimStart, trimEnd, indent, prefix,
+        suffix, linePrefix, lineSuffix, wrap, codeBlock, code, replace
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__unknown_transformer_ignore_verbose.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unknown_transformer_ignore_verbose.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpwQVOVK
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp1ryIjg
     - "--ignore-invalid-transformers"
     - "--verbose"
     - check
@@ -19,7 +19,12 @@ Scanned project: 1 provider(s), 1 consumer(s)
     @docs ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-warning: readme.md:3:1: unknown transformer `foobar`
+mdt::unknown_transformer
+
+  ! [readme.md:3:1] unknown transformer `foobar`
+  help: available transformers: trim, trimStart, trimEnd, indent, prefix,
+        suffix, linePrefix, lineSuffix, wrap, codeBlock, code, replace
+
 Stale: block `docs` in readme.md:3:1
 
 1 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/mdt_cli/tests/snapshots/snapshots__unused_provider_check.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unused_provider_check.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpUjDwTJ
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmplU2IYH
     - check
   env:
     NO_COLOR: "1"
@@ -14,5 +14,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: template.t.md:7:1: provider block `orphan_block` has no consumers
+mdt::unused_provider
+
+  x [template.t.md:7:1] provider block `orphan_block` has no consumers
+  help: add a consumer block `<!-- {=orphan_block} -->...<!-- {/orphan_block}
+        -->` or remove the unused provider
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__unused_provider_check_verbose.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unused_provider_check_verbose.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpxFyFJf
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp8LgFiG
     - "--verbose"
     - check
   env:
@@ -19,5 +19,10 @@ Scanned project: 2 provider(s), 1 consumer(s)
     @used_block ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-error: template.t.md:7:1: provider block `orphan_block` has no consumers
+mdt::unused_provider
+
+  x [template.t.md:7:1] provider block `orphan_block` has no consumers
+  help: add a consumer block `<!-- {=orphan_block} -->...<!-- {/orphan_block}
+        -->` or remove the unused provider
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__unused_provider_ignore_flag.snap
+++ b/mdt_cli/tests/snapshots/snapshots__unused_provider_ignore_flag.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpV7eJqC
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpnXSF14
     - "--ignore-unused-blocks"
     - "--verbose"
     - check
@@ -20,7 +20,12 @@ Scanned project: 2 provider(s), 1 consumer(s)
     @used_block ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-warning: template.t.md:7:1: provider block `orphan_block` has no consumers
+mdt::unused_provider
+
+  ! [template.t.md:7:1] provider block `orphan_block` has no consumers
+  help: add a consumer block `<!-- {=orphan_block} -->...<!-- {/orphan_block}
+        -->` or remove the unused provider
+
 Stale: block `used_block` in readme.md:3:1
 
 1 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/mdt_cli/tests/snapshots/snapshots__validation_errors_check.snap
+++ b/mdt_cli/tests/snapshots/snapshots__validation_errors_check.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp1bV4Vj
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpZahckj
     - check
   env:
     NO_COLOR: "1"
@@ -14,5 +14,9 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: unclosed.md:3:1: missing closing tag for block `valid_block`
+mdt::unclosed_block
+
+  x [unclosed.md:3:1] missing closing tag for block `valid_block`
+  help: add `<!-- {/valid_block} -->` to close this block
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__validation_errors_check_verbose.snap
+++ b/mdt_cli/tests/snapshots/snapshots__validation_errors_check_verbose.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpIim4Ws
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpWV5gRg
     - "--verbose"
     - check
   env:
@@ -18,5 +18,9 @@ Scanned project: 1 provider(s), 1 consumer(s)
     @valid_block ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-error: unclosed.md:3:1: missing closing tag for block `valid_block`
+mdt::unclosed_block
+
+  x [unclosed.md:3:1] missing closing tag for block `valid_block`
+  help: add `<!-- {/valid_block} -->` to close this block
+
 error: validation errors found

--- a/mdt_cli/tests/snapshots/snapshots__validation_errors_ignore_verbose.snap
+++ b/mdt_cli/tests/snapshots/snapshots__validation_errors_ignore_verbose.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpsQsZE1
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpJqS1Dk
     - "--ignore-unclosed-blocks"
     - "--verbose"
     - check
@@ -19,7 +19,11 @@ Scanned project: 1 provider(s), 1 consumer(s)
     @valid_block ([TEMP_DIR]/template.t.md)
 
 ----- stderr -----
-warning: unclosed.md:3:1: missing closing tag for block `valid_block`
+mdt::unclosed_block
+
+  ! [unclosed.md:3:1] missing closing tag for block `valid_block`
+  help: add `<!-- {/valid_block} -->` to close this block
+
 Stale: block `valid_block` in valid.md:3:1
 
 1 consumer block(s) are out of date. Run `mdt update` to fix.

--- a/mdt_cli/tests/snapshots/snapshots__validation_errors_update.snap
+++ b/mdt_cli/tests/snapshots/snapshots__validation_errors_update.snap
@@ -4,7 +4,7 @@ info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpes3wf3
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpnnPxzi
     - update
   env:
     NO_COLOR: "1"
@@ -14,5 +14,9 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: unclosed.md:3:1: missing closing tag for block `valid_block`
+mdt::unclosed_block
+
+  x [unclosed.md:3:1] missing closing tag for block `valid_block`
+  help: add `<!-- {/valid_block} -->` to close this block
+
 error: validation errors found


### PR DESCRIPTION
## Summary

- Add `miette` dependency to `mdt_cli` with the `fancy` feature
- Install miette's handler early in `main()`, respecting color settings
- Render `MdtError` through miette for rich output with error codes and help text
- Convert `ProjectDiagnostic` to miette reports with severity levels, error codes, and actionable help messages
- All diagnostics now show: error code, visual markers, context-specific help

**Example output (with color):**
```
mdt::unknown_transformer

  × [readme.md:3:1] unknown transformer `foobar`
  help: available transformers: trim, trimStart, trimEnd, indent, prefix,
        suffix, linePrefix, lineSuffix, wrap, codeBlock, code, replace
```

## Test plan

- [x] All 605 tests pass
- [x] Snapshot tests updated for new miette output format
- [x] `dprint check` passes