### PR TITLE
fix(ci): correct manifest path in release workflow and enable pages

### DIFF
--- a/.changeset/fix_ci_workflow_paths.md
+++ b/.changeset/fix_ci_workflow_paths.md
@@ -1,0 +1,8 @@
+---
+mdt_cli: patch
+---
+
+Fix CI workflow paths and GitHub Pages configuration.
+
+- Fix release workflow manifest path from `crates/mdt_cli/Cargo.toml` to `mdt_cli/Cargo.toml`.
+- Enable automatic GitHub Pages configuration in docs-pages workflow.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: setup pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: build mdbook
         run: mdbook build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: mdt
-          manifest-path: crates/mdt_cli/Cargo.toml
+          manifest-path: mdt_cli/Cargo.toml
           ref: refs/tags/${{ env.RELEASE_TAG }}
           archive: mdt-$target-${{ steps.version.outputs.version }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- **release.yml**: Fixed incorrect `manifest-path` from `crates/mdt_cli/Cargo.toml` to `mdt_cli/Cargo.toml`. The `crates/` prefix does not exist in the repository directory structure, causing the release binary upload step to fail.
- **docs-pages.yml**: Added `enablement: true` to the `actions/configure-pages@v5` step so that GitHub Pages is automatically enabled when the workflow runs, preventing failures when Pages has not been manually configured.

## Test plan

- [ ] Verify the `release.yml` workflow succeeds on the next `mdt_cli` release by confirming `manifest-path: mdt_cli/Cargo.toml` resolves correctly
- [ ] Verify the `docs-pages.yml` workflow succeeds by confirming `configure-pages` no longer errors about Pages not being enabled
- [ ] Confirm no other workflow files reference the old `crates/` path prefix