### PR TITLE
docs: document disable_gitignore configuration option

### DIFF
--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -131,6 +131,24 @@ max_file_size = 10485760 # 10 MB
 
 If omitted, mdt uses a default of `10 MB`.
 
+### `disable_gitignore` — Disable `.gitignore` integration
+
+By default, mdt respects `.gitignore` rules when scanning for files, skipping anything that git would ignore. Set `disable_gitignore = true` to turn off this behavior:
+
+```toml
+disable_gitignore = true
+```
+
+When this option is enabled, mdt scans all files regardless of `.gitignore` rules. You can still control which files are scanned using the `[exclude]` and `[include]` sections.
+
+**When to use this:**
+
+- **Generated files with mdt blocks** — If your build output or generated files contain consumer blocks that need updating, those files are typically listed in `.gitignore` but still need to be scanned by mdt.
+- **Working outside a git repository** — If the project is not a git repo, `.gitignore` resolution can cause unnecessary overhead or errors. Disabling it avoids those issues.
+- **Full control over scanning** — When you prefer to manage file inclusion/exclusion entirely through `[exclude]` and `[include]` patterns rather than relying on `.gitignore`.
+
+If omitted, defaults to `false` (`.gitignore` rules are respected).
+
 ## Sub-project boundaries
 
 If mdt encounters a directory containing its own `mdt.toml`, it treats that directory as a separate project and skips it. This is useful in monorepos where each package manages its own templates:
@@ -156,6 +174,7 @@ Running `mdt update` from the root updates only the root project's consumers. Ea
 # mdt.toml
 
 max_file_size = 10485760
+disable_gitignore = false
 
 # Ensure content is properly separated from tags in source files
 [padding]

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -191,6 +191,27 @@ If a scanned file exceeds this value, mdt returns an error instead of reading it
 
 Default value: `10485760` (10 MB).
 
+### `disable_gitignore`
+
+Disables `.gitignore` integration when scanning for files.
+
+```toml
+disable_gitignore = true
+```
+
+| Value             | Behavior                                                                 |
+| ----------------- | ------------------------------------------------------------------------ |
+| `false` (default) | mdt respects `.gitignore` patterns and skips files that git would ignore |
+| `true`            | mdt ignores `.gitignore` rules and scans all files                       |
+
+When set to `true`, file filtering is controlled entirely by the `[exclude]` and `[include]` sections. The built-in exclusions (hidden directories, `node_modules/`, `target/`, sub-project boundaries) still apply.
+
+Use this when scanning generated files or build output that contains mdt consumer blocks, when working outside a git repository, or when you want full control over file scanning via `[exclude]` and `[include]` patterns.
+
+**Type:** `bool`
+
+**Default:** `false`
+
 ## Complete example
 
 ```toml
@@ -198,6 +219,9 @@ Default value: `10485760` (10 MB).
 
 # Refuse to scan files larger than 10 MB
 max_file_size = 10485760
+
+# Respect .gitignore rules (default behavior)
+disable_gitignore = false
 
 # Ensure content is properly separated from tags (recommended for source files)
 [padding]
@@ -248,3 +272,4 @@ If `mdt.toml` doesn't exist, mdt uses defaults:
 - Templates found anywhere in the project tree
 - No padding (content is not adjusted between tags)
 - `max_file_size` defaults to 10 MB
+- `.gitignore` rules are respected (`disable_gitignore` defaults to `false`)


### PR DESCRIPTION
## Summary

- Add documentation for the `disable_gitignore` configuration option to the user guide (`docs/src/guide/configuration.md`) with usage examples and explanation of when to use it (generated files, non-git repos, full scanning control).
- Add documentation for `disable_gitignore` to the configuration reference (`docs/src/reference/configuration.md`) with type, default value, value table, and description.
- Update the "Full example" and "Complete example" TOML blocks in both files to include the option.
- Add `disable_gitignore` to the "No config" defaults list in the reference.

## Test plan

- [ ] Verify `mdbook build` succeeds for the docs
- [ ] Review rendered documentation for correctness and formatting