### PR TITLE
fix(mdt_lsp): migrate from deprecated root_uri to workspace_folders

### DIFF
--- a/.changeset/fix_deprecated_lsp_api.md
+++ b/.changeset/fix_deprecated_lsp_api.md
@@ -1,0 +1,5 @@
+---
+mdt_lsp: patch
+---
+
+Migrate from deprecated `root_uri` to `workspace_folders` in LSP initialization, with fallback to `root_uri` for older clients.


### PR DESCRIPTION
## Summary

- Replaces the deprecated `root_uri` field with the modern `workspace_folders` API for determining the workspace root during LSP initialization
- Adds a graceful fallback to `root_uri` (scoped `#[allow(deprecated)]`) for older LSP clients that don't support `workspace_folders`
- Includes a changeset for the `mdt_lsp` patch release

## Test plan

- [x] All 111 existing `mdt_lsp` tests pass (`cargo test -p mdt_lsp`)
- [x] `cargo clippy --all-features -p mdt_lsp` shows no new warnings (only pre-existing warnings in `mdt_core`)
- [x] Code formatted with `dprint fmt`