### PR TITLE
feat(mdt_cli): scaffold mdt.toml configuration in init command

### DIFF
--- a/.changeset/init_config_scaffold.md
+++ b/.changeset/init_config_scaffold.md
@@ -1,0 +1,5 @@
+---
+mdt_cli: minor
+---
+
+Generate a sample `mdt.toml` configuration file when running `mdt init`, providing a helpful starting point with commented-out examples.

--- a/mdt_cli/src/main.rs
+++ b/mdt_cli/src/main.rs
@@ -116,27 +116,49 @@ fn resolve_root(args: &MdtCli) -> PathBuf {
 fn run_init(args: &MdtCli) -> Result<(), Box<dyn std::error::Error>> {
 	let root = resolve_root(args);
 	let template_path = root.join("template.t.md");
+	let config_path = root.join("mdt.toml");
 
-	if template_path.exists() {
+	let template_exists = template_path.exists();
+	let config_exists = config_path.exists();
+
+	if template_exists {
 		println!("Template file already exists: {}", template_path.display());
-		return Ok(());
+	} else {
+		let sample_content = "<!-- {@greeting} -->\n\nHello from mdt! This is a provider \
+		                      block.\n\n<!-- {/greeting} -->\n";
+
+		std::fs::write(&template_path, sample_content)?;
+		println!("Created template file: {}", template_path.display());
 	}
 
-	let sample_content = "<!-- {@greeting} -->\n\nHello from mdt! This is a provider \
-	                      block.\n\n<!-- {/greeting} -->\n";
+	if config_exists {
+		// Skip silently if config already exists.
+	} else {
+		let sample_config =
+			"# mdt configuration\n# See \
+			 https://ifiokjr.github.io/mdt/reference/configuration.html for full reference.\n\n# \
+			 Map data files to template namespaces.\n# Values from these files are available in \
+			 provider blocks as {{ namespace.key }}.\n# [data]\n# pkg = \"package.json\"\n# cargo \
+			 = \"Cargo.toml\"\n\n# Control blank lines between tags and content in source \
+			 files.\n# Recommended when using formatters (rustfmt, prettier, etc.).\n# \
+			 [padding]\n# before = 0\n# after = 0\n";
 
-	std::fs::write(&template_path, sample_content)?;
-	println!("Created template file: {}", template_path.display());
-	println!();
-	println!("Next steps:");
-	println!(
-		"  1. Edit {} to define your template blocks",
-		template_path.display()
-	);
-	println!("  2. Add consumer tags in your markdown files:");
-	println!("     <!-- {{=greeting}} -->");
-	println!("     <!-- {{/greeting}} -->");
-	println!("  3. Run `mdt update` to sync content");
+		std::fs::write(&config_path, sample_config)?;
+		println!("Created mdt.toml");
+	}
+
+	if !template_exists {
+		println!();
+		println!("Next steps:");
+		println!(
+			"  1. Edit {} to define your template blocks",
+			template_path.display()
+		);
+		println!("  2. Add consumer tags in your markdown files:");
+		println!("     <!-- {{=greeting}} -->");
+		println!("     <!-- {{/greeting}} -->");
+		println!("  3. Run `mdt update` to sync content");
+	}
 
 	Ok(())
 }

--- a/mdt_cli/tests/init.rs
+++ b/mdt_cli/tests/init.rs
@@ -11,7 +11,9 @@ fn can_init() -> AnyEmptyResult {
 		.arg(tmp.path())
 		.assert()
 		.success();
-	assert.stdout(predicates::str::contains("Created template file"));
+	assert
+		.stdout(predicates::str::contains("Created template file"))
+		.stdout(predicates::str::contains("Created mdt.toml"));
 
 	let template_path = tmp.path().join("template.t.md");
 	assert!(template_path.exists());
@@ -19,6 +21,13 @@ fn can_init() -> AnyEmptyResult {
 	let content = std::fs::read_to_string(&template_path)?;
 	assert!(content.contains("{@greeting}"));
 	assert!(content.contains("{/greeting}"));
+
+	let config_path = tmp.path().join("mdt.toml");
+	assert!(config_path.exists());
+
+	let config_content = std::fs::read_to_string(&config_path)?;
+	assert!(config_content.contains("[data]"));
+	assert!(config_content.contains("[padding]"));
 
 	Ok(())
 }
@@ -28,6 +37,9 @@ fn init_does_not_overwrite() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 	let template_path = tmp.path().join("template.t.md");
 	std::fs::write(&template_path, "existing content")?;
+
+	let config_path = tmp.path().join("mdt.toml");
+	std::fs::write(&config_path, "existing config")?;
 
 	let mut cmd = Command::cargo_bin("mdt")?;
 	let assert = cmd
@@ -40,6 +52,9 @@ fn init_does_not_overwrite() -> AnyEmptyResult {
 
 	let content = std::fs::read_to_string(&template_path)?;
 	assert_eq!(content, "existing content");
+
+	let config_content = std::fs::read_to_string(&config_path)?;
+	assert_eq!(config_content, "existing config");
 
 	Ok(())
 }
@@ -76,6 +91,66 @@ fn init_shows_next_steps() -> AnyEmptyResult {
 		.success()
 		.stdout(predicates::str::contains("Next steps"))
 		.stdout(predicates::str::contains("mdt update"));
+
+	Ok(())
+}
+
+#[test]
+fn init_creates_both_template_and_config() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	Command::cargo_bin("mdt")?
+		.arg("init")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("Created template file"))
+		.stdout(predicates::str::contains("Created mdt.toml"));
+
+	let template_path = tmp.path().join("template.t.md");
+	let config_path = tmp.path().join("mdt.toml");
+
+	assert!(template_path.exists(), "template.t.md should be created");
+	assert!(config_path.exists(), "mdt.toml should be created");
+
+	// Verify template content
+	let template_content = std::fs::read_to_string(&template_path)?;
+	assert!(template_content.contains("{@greeting}"));
+
+	// Verify config is valid TOML (all lines are comments or blank, so it parses as empty)
+	let config_content = std::fs::read_to_string(&config_path)?;
+	assert!(config_content.contains("# mdt configuration"));
+	assert!(config_content.contains("# [data]"));
+	assert!(config_content.contains("# [padding]"));
+	assert!(config_content.contains("# pkg = \"package.json\""));
+	assert!(config_content.contains("# cargo = \"Cargo.toml\""));
+
+	Ok(())
+}
+
+#[test]
+fn init_creates_config_when_template_exists() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	let template_path = tmp.path().join("template.t.md");
+	std::fs::write(&template_path, "existing template")?;
+
+	Command::cargo_bin("mdt")?
+		.arg("init")
+		.arg("--path")
+		.arg(tmp.path())
+		.assert()
+		.success()
+		.stdout(predicates::str::contains("already exists"))
+		.stdout(predicates::str::contains("Created mdt.toml"));
+
+	// Template should not be modified
+	let content = std::fs::read_to_string(&template_path)?;
+	assert_eq!(content, "existing template");
+
+	// Config should be created
+	let config_path = tmp.path().join("mdt.toml");
+	assert!(config_path.exists());
 
 	Ok(())
 }

--- a/mdt_cli/tests/snapshots/snapshots__init_existing_template.snap
+++ b/mdt_cli/tests/snapshots/snapshots__init_existing_template.snap
@@ -13,5 +13,6 @@ success: true
 exit_code: 0
 ----- stdout -----
 Template file already exists: [TEMP_DIR]/template.t.md
+Created mdt.toml
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__init_fresh_directory.snap
+++ b/mdt_cli/tests/snapshots/snapshots__init_fresh_directory.snap
@@ -13,6 +13,7 @@ success: true
 exit_code: 0
 ----- stdout -----
 Created template file: [TEMP_DIR]/template.t.md
+Created mdt.toml
 
 Next steps:
   1. Edit [TEMP_DIR]/template.t.md to define your template blocks


### PR DESCRIPTION
## Summary

- Extends `mdt init` to also generate a sample `mdt.toml` configuration file alongside `template.t.md`, giving users a helpful starting point with commented-out examples for `[data]` and `[padding]` sections.
- The config file is only created if one does not already exist (same skip-if-exists behavior as the template file).
- Updates existing tests and snapshots, and adds new integration tests verifying both files are created and that neither is overwritten when already present.

## Test plan

- [x] `cargo test -p mdt_cli` passes all 90 tests (init, snapshots, check, update, etc.)
- [x] `dprint check` passes with no formatting issues
- [x] New test `init_creates_both_template_and_config` verifies both files are created with correct content
- [x] New test `init_creates_config_when_template_exists` verifies config is created even when template already exists
- [x] Updated test `init_does_not_overwrite` verifies neither file is overwritten when both exist
- [x] Updated snapshot tests reflect the new "Created mdt.toml" output line