### PR TITLE
fix: add mdt_mcp to workspace members

### DIFF
--- a/.changeset/mdt_mcp_workspace.md
+++ b/.changeset/mdt_mcp_workspace.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add `mdt_mcp` to workspace members so it is built, tested, and published through normal CI workflows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["docs", "mdt_cli", "mdt_core", "mdt_lsp"]
+members = ["docs", "mdt_cli", "mdt_core", "mdt_lsp", "mdt_mcp"]
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
## Summary

- `mdt_mcp` was missing from the `members` list in the root `Cargo.toml` workspace definition. This meant it was not being built, tested, linted, or published as part of normal CI workflows despite being a declared workspace dependency.
- Added `"mdt_mcp"` to the `members` array so it is included in `cargo build`, `cargo test`, `cargo clippy`, and `knope publish` alongside all other crates.

## Test plan

- [x] `cargo build --all-features` compiles successfully with `mdt_mcp` included
- [x] `cargo test` passes all 698 tests (including doc-tests for `mdt_mcp`)
- [x] Changeset file added for release tracking