### PR TITLE
docs: update README to reflect implemented LSP capabilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,14 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `wra
 
 ## LSP
 
-Language server protocol support is planned via the `mdt_lsp` crate. This will provide editor integration for template validation and auto-completion.
+The `mdt_lsp` crate provides a fully implemented language server for editor integration. Start it with `mdt lsp` or run the `mdt-lsp` binary directly. The server communicates over stdin/stdout and supports the following capabilities:
+
+- **Diagnostics** -- reports stale consumer blocks, missing providers with name suggestions, unclosed blocks, unknown transformers, invalid transformer arguments, unused providers, and provider blocks in non-template files.
+- **Completions** -- suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
+- **Hover** -- shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
+- **Go to definition** -- navigates from a consumer block to its provider, or from a provider to all of its consumers.
+- **Document symbols** -- lists all provider and consumer blocks in the outline/symbol view.
+- **Code actions** -- offers a quick-fix to update stale consumer blocks in place.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Updated the root `readme.md` LSP section which incorrectly described the language server as "planned" when it is fully implemented in the `mdt_lsp` crate.
- Replaced the single-sentence placeholder with an accurate description of all six implemented LSP capabilities: diagnostics, completions, hover, go-to-definition, document symbols, and code actions.
- Checked `mdt_lsp/readme.md` -- it does not contain a similar "planned" claim, so no changes were needed there.

## Test plan

- [x] Ran `dprint fmt` to verify formatting
- [x] Ran `mdt check` to confirm no mdt blocks were broken by this change (the 3 pre-existing stale install blocks are unrelated to this PR)
- [x] Visual review of the updated LSP section against the actual `mdt_lsp/src/lib.rs` implementation