### PR TITLE
docs: add missing transformers to template syntax documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ This content gets replaced
 <!-- {=block|prefix:"\n"|indent:"  "} -->
 ```
 
-Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `wrap`, `codeBlock`, `code`, `replace`.
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`.
 
 <!-- {/mdtTemplateSyntax} -->
 

--- a/template.t.md
+++ b/template.t.md
@@ -46,7 +46,7 @@ This content gets replaced
 <!-- {=block|prefix:"\n"|indent:"  "} -->
 ```
 
-Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `wrap`, `codeBlock`, `code`, `replace`.
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`.
 
 <!-- {/mdtTemplateSyntax} -->
 


### PR DESCRIPTION
## Summary

- Add missing `suffix`, `linePrefix`, and `lineSuffix` transformers to the `mdtTemplateSyntax` provider block in `template.t.md`
- Run `mdt update` to propagate the fix to the consumer block in `readme.md`
- The `mdtTransformerDocs` block already had the complete list; this fix brings `mdtTemplateSyntax` into alignment

## Test plan

- [x] Verified `mdt check` does not report the `mdtTemplateSyntax` block as stale
- [x] Verified `dprint fmt` passes
- [x] Confirmed the 3 pre-existing stale `mdtCoreInstall`/`mdtLspInstall`/`mdtMcpInstall` blocks are unrelated (stale on `main` as well due to workspace version inheritance)