### PR TITLE
docs: add advanced topics, troubleshooting, and FAQ

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,9 +21,19 @@
 - [Source File Support](./guide/source-files.md)
 - [CI Integration](./guide/ci-integration.md)
 
+# Advanced Topics
+
+- [Monorepo & Multi-Project Setups](./advanced/monorepos.md)
+- [Block Arguments](./advanced/block-arguments.md)
+
 # Reference
 
 - [CLI](./reference/cli.md)
 - [Template Syntax](./reference/template-syntax.md)
 - [Transformer Reference](./reference/transformers.md)
 - [Configuration Reference](./reference/configuration.md)
+
+# Help
+
+- [Troubleshooting](./troubleshooting.md)
+- [FAQ](./faq.md)

--- a/docs/src/advanced/block-arguments.md
+++ b/docs/src/advanced/block-arguments.md
@@ -1,0 +1,191 @@
+# Block Arguments
+
+Block arguments let you create parameterized provider blocks. Instead of defining a separate provider for each variation, you define one provider with parameters and pass different values from each consumer.
+
+## Syntax
+
+### Provider: declare parameters
+
+Add `:"param_name"` after the block name to declare parameters:
+
+```
+<!-- {@badges:"crate_name"} -->
+
+[![crates.io](https://img.shields.io/crates/v/{{ crate_name }})](https://crates.io/crates/{{ crate_name }})
+[![docs.rs](https://docs.rs/{{ crate_name }}/badge.svg)](https://docs.rs/{{ crate_name }}/)
+
+<!-- {/badges} -->
+```
+
+The parameter name `crate_name` becomes a template variable available in the provider content via `{{ crate_name }}`.
+
+### Consumer: pass values
+
+Consumers pass string values in the same position:
+
+```
+<!-- {=badges:"mdt_core"} -->
+<!-- {/badges} -->
+```
+
+When mdt renders this consumer, `{{ crate_name }}` in the provider content is replaced with `mdt_core`.
+
+## Multiple arguments
+
+Providers can declare multiple parameters:
+
+```
+<!-- {@installCmd:"pkg_manager":"pkg_name":"version"} -->
+
+{{ pkg_manager }} install {{ pkg_name }}@{{ version }}
+
+<!-- {/installCmd} -->
+```
+
+Consumers pass values in the same order:
+
+```
+<!-- {=installCmd:"npm":"my-lib":"1.2.3"} -->
+<!-- {/installCmd} -->
+
+<!-- {=installCmd:"yarn":"my-lib":"2.0.0"} -->
+<!-- {/installCmd} -->
+```
+
+After `mdt update`, the first consumer contains `npm install my-lib@1.2.3` and the second contains `yarn install my-lib@2.0.0`.
+
+## Combining arguments with other features
+
+### With transformers
+
+Arguments and transformers work together. Transformers come after the arguments, separated by `|`:
+
+```
+<!-- {=badges:"mdt_core"|trim} -->
+<!-- {/badges} -->
+```
+
+### With data interpolation
+
+Block arguments and data interpolation variables coexist in the same provider content. Arguments are resolved alongside the data context:
+
+```toml
+# mdt.toml
+[data]
+cargo = "Cargo.toml"
+```
+
+```
+<!-- {@crateInfo:"crate_name"} -->
+
+**{{ crate_name }}** v{{ cargo.workspace.package.version }}
+
+<!-- {/crateInfo} -->
+```
+
+Here `{{ crate_name }}` comes from the consumer's argument, while `{{ cargo.workspace.package.version }}` comes from the data file.
+
+### With single quotes
+
+Both single and double quotes work for argument values:
+
+```
+<!-- {@tmpl:'param'} -->
+<!-- {=tmpl:'value'} -->
+```
+
+## Use cases
+
+### Badge links for multiple crates
+
+A common monorepo pattern where each crate needs the same badge markup with different crate names:
+
+```
+<!-- {@badgeLinks:"crateName"} -->
+
+[crate-image]: https://img.shields.io/crates/v/{{ crateName }}.svg
+[crate-link]: https://crates.io/crates/{{ crateName }}
+[docs-image]: https://docs.rs/{{ crateName }}/badge.svg
+[docs-link]: https://docs.rs/{{ crateName }}/
+
+<!-- {/badgeLinks} -->
+```
+
+Each crate's README passes its own name:
+
+```
+<!-- {=badgeLinks:"mdt_core"} -->
+<!-- {/badgeLinks} -->
+```
+
+```
+<!-- {=badgeLinks:"mdt_cli"} -->
+<!-- {/badgeLinks} -->
+```
+
+### Versioned install snippets
+
+Generate install instructions that pull the crate name from an argument and the version from a data file:
+
+```
+<!-- {@addDep:"dep_name"} -->
+
+Install via cargo: `cargo add {{ dep_name }}`
+
+Or add to Cargo.toml: `{{ dep_name }} = "{{ cargo.workspace.package.version }}"`
+
+<!-- {/addDep} -->
+```
+
+### Platform-specific instructions
+
+```
+<!-- {@buildCmd:"platform":"toolchain"} -->
+
+To build on {{ platform }}, install {{ toolchain }} first,
+then run: {{ toolchain }} build --release
+
+<!-- {/buildCmd} -->
+```
+
+## Argument count mismatch
+
+The number of consumer arguments must match the number of provider parameters. If they don't match, mdt reports a render error:
+
+```
+error: argument count mismatch: provider `badges` declares 1 parameter(s),
+       but consumer passes 2 argument(s)
+```
+
+- `mdt check` reports the mismatch as an error.
+- `mdt update` skips the mismatched consumer and continues with the rest.
+
+### Zero arguments on consumer
+
+A consumer referencing a parameterized provider without arguments also triggers a mismatch. If the provider declares parameters, every consumer must supply values:
+
+```
+<!-- Provider expects 1 argument -->
+<!-- {@greeting:"name"} -->
+Hello, {{ name }}!
+<!-- {/greeting} -->
+
+<!-- This consumer is missing the argument — mdt reports an error -->
+<!-- {=greeting} -->
+<!-- {/greeting} -->
+```
+
+### Zero parameters on provider
+
+If a provider has no parameters, consumers should not pass arguments. Passing arguments to a parameter-less provider is a mismatch:
+
+```
+<!-- Provider has no parameters -->
+<!-- {@simpleBlock} -->
+Static content.
+<!-- {/simpleBlock} -->
+
+<!-- This consumer has an unexpected argument — mdt reports an error -->
+<!-- {=simpleBlock:"unused"} -->
+<!-- {/simpleBlock} -->
+```

--- a/docs/src/advanced/monorepos.md
+++ b/docs/src/advanced/monorepos.md
@@ -1,0 +1,166 @@
+# Monorepo & Multi-Project Setups
+
+mdt supports monorepos where each package manages its own templates independently. The key mechanism is **sub-project boundaries**: any directory containing its own `mdt.toml` is treated as a separate mdt project.
+
+## How sub-project boundaries work
+
+When mdt scans a directory tree, it stops descending into any subdirectory that contains an `mdt.toml` file. That subdirectory becomes its own isolated scope with its own providers, consumers, data files, and configuration.
+
+```
+my-monorepo/
+  mdt.toml              # root project
+  template.t.md         # root providers
+  readme.md             # root consumers
+  packages/
+    lib-a/
+      mdt.toml          # lib-a is a separate project
+      template.t.md     # lib-a providers
+      readme.md         # lib-a consumers
+    lib-b/
+      mdt.toml          # lib-b is a separate project
+      template.t.md     # lib-b providers
+      readme.md         # lib-b consumers
+    lib-c/
+      readme.md         # NO mdt.toml — belongs to root project
+```
+
+Running `mdt update` from the monorepo root updates consumers in `readme.md` and `packages/lib-c/readme.md`, but **not** in `packages/lib-a/` or `packages/lib-b/`. Those are separate projects.
+
+To update `lib-a`, run `mdt update` from inside `packages/lib-a/`, or use the `--path` flag:
+
+```sh
+mdt update --path packages/lib-a
+```
+
+## Setting up a monorepo
+
+### Step 1: Create an `mdt.toml` in each package
+
+Each package that needs its own template scope gets an `mdt.toml`. Even an empty file is enough to establish a boundary:
+
+```toml
+# packages/lib-a/mdt.toml
+```
+
+Add configuration as needed:
+
+```toml
+# packages/lib-a/mdt.toml
+[data]
+cargo = "Cargo.toml"
+```
+
+### Step 2: Create template files per package
+
+Each sub-project has its own `*.t.md` files with its own provider blocks:
+
+```
+<!-- packages/lib-a/template.t.md -->
+
+<!-- {@install} -->
+
+cargo add lib-a
+
+<!-- {/install} -->
+```
+
+```
+<!-- packages/lib-b/template.t.md -->
+
+<!-- {@install} -->
+
+cargo add lib-b
+
+<!-- {/install} -->
+```
+
+Provider names only need to be unique **within** a project scope. Both `lib-a` and `lib-b` can have an `{@install}` provider without conflict.
+
+### Step 3: Run updates per package or use a script
+
+Update each package individually:
+
+```sh
+mdt update --path packages/lib-a
+mdt update --path packages/lib-b
+```
+
+Or use a script to update all packages:
+
+```sh
+#!/bin/sh
+for dir in packages/*/; do
+  if [ -f "$dir/mdt.toml" ]; then
+    mdt update --path "$dir"
+  fi
+done
+```
+
+## Shared templates across packages
+
+Sub-project boundaries are strict. A provider in the root `template.t.md` is **not visible** to consumers inside `packages/lib-a/`. Each scope is fully isolated.
+
+If you need shared content across packages, you have a few options:
+
+### Option 1: Use block arguments for parameterized content
+
+Define a parameterized provider at the root level and use it for files that belong to the root scope:
+
+```
+<!-- {@badge:"crate_name"} -->
+
+[![crates.io](https://img.shields.io/crates/v/{{ crate_name }})](https://crates.io/crates/{{ crate_name }})
+
+<!-- {/badge} -->
+```
+
+For sub-projects, duplicate the provider in each sub-project's template file. This is intentional — each project is self-contained.
+
+### Option 2: Duplicate providers where needed
+
+Copy the provider block into each sub-project's template file. While this creates duplication in template files, the consumer blocks throughout each project stay in sync with their local provider — which is mdt's primary guarantee.
+
+### Option 3: Keep shared content at the root scope
+
+If files consuming shared content don't live inside a sub-project directory, they can all reference the root-level providers. Structure your project so that shared docs live outside sub-project boundaries.
+
+## CI checks in a monorepo
+
+Run `mdt check` for each sub-project in CI:
+
+```yaml
+- name: check root docs
+  run: mdt check
+
+- name: check lib-a docs
+  run: mdt check --path packages/lib-a
+
+- name: check lib-b docs
+  run: mdt check --path packages/lib-b
+```
+
+Or iterate over all directories that contain `mdt.toml`:
+
+```yaml
+- name: check all mdt projects
+  run: |
+    for dir in . packages/*/; do
+      if [ -f "$dir/mdt.toml" ]; then
+        echo "Checking $dir"
+        mdt check --path "$dir"
+      fi
+    done
+```
+
+## Data isolation
+
+Each sub-project loads its own data files relative to its own `mdt.toml`. A `[data]` section in `packages/lib-a/mdt.toml` resolves paths relative to `packages/lib-a/`:
+
+```toml
+# packages/lib-a/mdt.toml
+[data]
+cargo = "Cargo.toml" # resolves to packages/lib-a/Cargo.toml
+package = "package.json" # resolves to packages/lib-a/package.json
+```
+
+This means `{{ cargo.package.name }}` in `lib-a`'s templates refers to `lib-a`'s `Cargo.toml`, not the root workspace `Cargo.toml`.

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -1,0 +1,130 @@
+# FAQ
+
+## Can I use mdt with non-markdown files?
+
+Yes. mdt scans source code files for consumer tags inside code comments. Supported languages include Rust, TypeScript, JavaScript, Python, Go, Java, Kotlin, Swift, C/C++, and C#. The consumer tag syntax (`<!-- {=name} -->` / `<!-- {/name} -->`) is the same — it just appears within the file's comment syntax.
+
+For example, in a Rust file:
+
+```rust
+//! <!-- {=packageDocs|trim} -->
+//! Documentation content injected here.
+//! <!-- {/packageDocs} -->
+```
+
+See [Source File Support](./guide/source-files.md) for the full list of languages and examples.
+
+## What happens if a provider is deleted?
+
+Consumers referencing the deleted provider become **orphaned**. Their content is left unchanged — mdt does not clear or modify orphaned consumers.
+
+- `mdt check` warns about orphaned consumers.
+- `mdt list` shows orphaned consumers with the `[orphan]` status.
+- `mdt update` skips orphaned consumers and proceeds with the rest.
+
+To fix orphaned consumers, either restore the provider or remove the consumer tags from the files that referenced it.
+
+## Can multiple providers have the same name?
+
+No. Provider names must be unique within a project scope. If two `*.t.md` files define a provider with the same name, mdt reports an error:
+
+```
+error: duplicate provider `install`: defined in `docs.t.md` and `api.t.md`
+```
+
+In a monorepo, provider names only need to be unique within each sub-project (each directory with its own `mdt.toml`). Two different sub-projects can both have an `{@install}` provider without conflict.
+
+## How do I keep formatters from mangling template content?
+
+Formatters can interfere with mdt by reformatting content inside consumer blocks. The main strategies are:
+
+1. **Exclude `*.t.md` files** from your formatter so the source-of-truth content is never altered.
+2. **Use ignore comments** (e.g., `<!-- dprint-ignore -->`) before consumer blocks in markdown files.
+3. **Set `[padding]`** in `mdt.toml` to control whitespace precisely, reducing formatter conflicts.
+4. **Match transformer output** to what the formatter expects (e.g., use the same indentation style).
+
+See [Troubleshooting > Formatter interference](./troubleshooting.md#formatter-interference) for detailed solutions.
+
+## Can I use conditional logic in templates?
+
+Yes. mdt uses [minijinja](https://docs.rs/minijinja) for template rendering, which supports conditionals, loops, and filters.
+
+### Conditionals
+
+```
+<!-- {@platformInstall} -->
+
+{% if cargo.package.name %}
+cargo add {{ cargo.package.name }}
+{% endif %}
+
+{% if package.name %}
+npm install {{ package.name }}
+{% endif %}
+
+<!-- {/platformInstall} -->
+```
+
+### Loops
+
+```
+<!-- {@featureList} -->
+
+{% for feature in config.features %}
+- {{ feature }}
+{% endfor %}
+
+<!-- {/featureList} -->
+```
+
+### Filters
+
+minijinja's built-in filters work in provider content:
+
+```
+{{ package.name | upper }}
+{{ package.description | truncate(80) }}
+```
+
+See [Data Interpolation](./guide/data-interpolation.md) for full details on template syntax.
+
+## Can consumers appear inside other consumers?
+
+No. mdt does not support nested blocks. Each consumer block is a flat, non-overlapping region. If you need to compose content, define separate providers and place their consumers sequentially:
+
+```markdown
+<!-- {=header} -->
+<!-- {/header} -->
+
+<!-- {=body} -->
+<!-- {/body} -->
+
+<!-- {=footer} -->
+<!-- {/footer} -->
+```
+
+## Do tags affect rendered markdown?
+
+No. mdt tags are HTML comments (`<!-- ... -->`), which are invisible when markdown is rendered to HTML. Readers of your documentation never see the template machinery.
+
+## Can I use mdt without a config file?
+
+Yes. `mdt.toml` is optional. Without it, mdt still scans for `*.t.md` template files and processes provider/consumer blocks. You only need a config file for:
+
+- Data interpolation (`[data]` section)
+- Custom exclude/include patterns
+- Template search path restrictions
+- Block padding configuration
+
+## How does mdt handle binary files?
+
+mdt only scans text files with recognized extensions (`.md`, `.mdx`, `.markdown`, `.t.md`, and supported source code extensions). Binary files and unrecognized file types are ignored. A `max_file_size` limit (default 10 MB) prevents accidentally reading very large files.
+
+## Can I run mdt on a subset of files?
+
+Not directly — mdt always scans the full project to build the provider map. However, you can control the scan scope:
+
+- Use `--path` to target a specific sub-project directory.
+- Use `[include]` patterns in `mdt.toml` to restrict which source files are scanned.
+- Use `[exclude]` patterns to skip specific files or directories.
+- Use `[templates] paths` to limit where mdt looks for `*.t.md` files.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,0 +1,235 @@
+# Troubleshooting
+
+This page covers common errors, debugging techniques, and solutions for issues you might encounter with mdt.
+
+## Common errors
+
+### Consumer references a missing provider
+
+```
+warning: consumer `installGuide` in readme.md has no matching provider
+```
+
+**Cause:** The consumer tag references a provider name that doesn't exist in any `*.t.md` file.
+
+**Solutions:**
+
+- Check for typos in the block name. Names are case-sensitive — `installGuide` and `installguide` are different.
+- Verify the provider is in a `*.t.md` file. Provider tags in regular `.md` files are ignored.
+- If you're in a monorepo, confirm the provider is in the same project scope. Providers from a parent or sibling project are not visible across `mdt.toml` boundaries. See [Monorepo setups](./advanced/monorepos.md).
+- Run `mdt list` to see all discovered providers and consumers.
+
+### Argument count mismatch
+
+```
+error: argument count mismatch: provider `badges` declares 1 parameter(s),
+       but consumer passes 2 argument(s)
+```
+
+**Cause:** The consumer passes a different number of arguments than the provider declares.
+
+**Solutions:**
+
+- Count the `:"value"` segments on both the provider and consumer tags.
+- If the provider declares `<!-- {@badges:"crate_name"} -->` (1 parameter), every consumer must pass exactly 1 argument: `<!-- {=badges:"mdt_core"} -->`.
+- See [Block Arguments](./advanced/block-arguments.md) for details.
+
+### Duplicate provider name
+
+```
+error: duplicate provider `install`: defined in `docs.t.md` and `api.t.md`
+```
+
+**Cause:** Two `*.t.md` files define a provider with the same name. Provider names must be unique within a project scope.
+
+**Solution:** Rename one of the providers, or consolidate them into a single template file.
+
+### Stale blocks after editing templates
+
+After editing a provider's content in a template file, all consumers referencing that provider become stale. `mdt check` reports them:
+
+```
+Consumer block `install` in readme.md is out of date.
+Consumer block `install` in src/lib.rs is out of date.
+```
+
+**Solution:** Run `mdt update` to sync all consumers. During development, use `mdt update --watch` to auto-sync on file changes.
+
+## Debugging techniques
+
+### Use `mdt check --verbose`
+
+Verbose mode shows the full scan results — how many files were scanned, which providers and consumers were found, and which blocks are stale:
+
+```sh
+mdt check --verbose
+```
+
+### Use `mdt list` to see all blocks
+
+`mdt list` displays every provider and consumer in the project, their file locations, and their link status:
+
+```sh
+mdt list
+```
+
+```
+Providers:
+  @installGuide template.t.md (2 consumer(s))
+  @apiDocs template.t.md (3 consumer(s))
+
+Consumers:
+  =installGuide readme.md [linked]
+  =installGuide crates/my-lib/readme.md [linked]
+  =apiDocs readme.md [linked]
+  =orphanBlock docs/old.md [orphan]
+```
+
+Orphaned consumers (`[orphan]`) indicate missing providers. Providers with `(0 consumer(s))` might be unused.
+
+### Use `mdt check --diff`
+
+When blocks are stale, `--diff` shows exactly what changed:
+
+```sh
+mdt check --diff
+```
+
+This produces a unified diff for each stale block, making it easy to see whether the change is expected.
+
+### Use `mdt update --dry-run`
+
+Preview what `mdt update` would change without modifying any files:
+
+```sh
+mdt update --dry-run
+```
+
+```
+Dry run: would update 3 block(s) in 2 file(s):
+  readme.md
+  src/lib.rs
+```
+
+## Formatter interference
+
+Code formatters like dprint, Prettier, and rustfmt can reformat content inside template tags, causing mdt to see the blocks as stale even when the provider hasn't changed.
+
+### Symptoms
+
+- `mdt check` reports stale blocks after running a formatter.
+- Running `mdt update` followed by the formatter followed by `mdt check` always shows stale blocks.
+- Whitespace or indentation changes inside consumer blocks.
+
+### Solutions
+
+#### Exclude template files from formatters
+
+Template files (`*.t.md`) contain the source-of-truth content. Formatters should not touch them.
+
+**dprint:** Add to `dprint.json`:
+
+```json
+{
+	"excludes": ["**/*.t.md"]
+}
+```
+
+**Prettier:** Add to `.prettierignore`:
+
+```
+*.t.md
+```
+
+#### Use `<!-- dprint-ignore -->` for consumer blocks
+
+If a formatter is reformatting content inside a consumer block in a markdown file, add a dprint ignore comment before the block:
+
+```markdown
+<!-- dprint-ignore -->
+<!-- {=codeExample} -->
+
+    indented code that formatters want to change
+
+<!-- {/codeExample} -->
+```
+
+#### Set padding to minimize whitespace differences
+
+Use `[padding]` in `mdt.toml` to control the exact whitespace between tags and content. This reduces the surface area for formatter conflicts:
+
+```toml
+[padding]
+before = 0
+after = 0
+```
+
+See [Configuration](./guide/configuration.md) for details on padding values.
+
+#### Match transformer output to formatter expectations
+
+If a formatter enforces specific indentation, configure your transformers to produce output that already matches. For example, if your formatter expects tabs:
+
+```
+<!-- {=docs|trim|indent:"\t"} -->
+<!-- {/docs} -->
+```
+
+## CI integration issues
+
+### `mdt` command not found
+
+If your CI environment doesn't have mdt installed globally, install it first:
+
+```yaml
+- name: install mdt
+  run: cargo install mdt_cli
+```
+
+Or run directly from your workspace without installing:
+
+```yaml
+- name: check docs
+  run: cargo run --bin mdt -- check
+```
+
+The `cargo run` approach is slower (it compiles on every run) but avoids installation steps. For faster CI, cache the cargo install or use a pre-built binary.
+
+### Check fails but works locally
+
+**Common causes:**
+
+- **Different working directory.** mdt resolves paths relative to where it's run. Use `--path` to be explicit:
+
+  ```yaml
+  - run: mdt check --path ./my-project
+  ```
+
+- **Files not checked out.** If your CI does a shallow clone, data files referenced in `mdt.toml` might be missing. Ensure a full checkout:
+
+  ```yaml
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+  ```
+
+- **Formatter ran after templates changed.** If CI runs `dprint fmt` before `mdt check`, the formatter might alter consumer content. Run `mdt update` after formatting, or exclude template content from the formatter.
+
+### Recommended CI order
+
+When both formatting and mdt checks are in your pipeline, run them in this order:
+
+```yaml
+- name: format
+  run: dprint fmt
+
+- name: sync templates
+  run: mdt update
+
+- name: verify everything is clean
+  run: |
+    mdt check
+    git diff --exit-code
+```
+
+This ensures formatting and template sync are both applied, and the final `git diff` catches any uncommitted changes.


### PR DESCRIPTION
## Summary

- Add **Advanced Topics** section with two new pages:
  - **Monorepo & Multi-Project Setups** — covers sub-project boundaries via nested `mdt.toml` files, project isolation, shared templates strategies, CI checks for monorepos, and data file resolution
  - **Block Arguments** — covers parameterized provider blocks with `:"param"` syntax, multiple arguments, combining arguments with transformers/data interpolation, use cases (badge links, versioned install snippets), and argument count mismatch errors
- Add **Troubleshooting** page covering common errors (missing provider, argument mismatch, duplicate provider, stale blocks), debugging techniques (`mdt check --verbose`, `mdt list`, `--diff`, `--dry-run`), formatter interference solutions, and CI integration issues
- Add **FAQ** page with answers to common questions: non-markdown file support, deleted providers, duplicate provider names, formatter conflicts, conditional logic in templates, nested blocks, invisible tags, config-free usage, binary files, and subset scanning
- Update `SUMMARY.md` with new "Advanced Topics" and "Help" sections

## Test plan

- [x] `mdbook build docs` succeeds
- [x] `dprint check` passes on all new files
- [ ] Review rendered mdbook output for formatting and link correctness