### PR TITLE
feat(mdt_cli): add --watch flag to mdt check command

### DIFF
--- a/.changeset/check-watch-mode.md
+++ b/.changeset/check-watch-mode.md
@@ -1,0 +1,5 @@
+---
+mdt_cli: minor
+---
+
+Add `--watch` flag to `mdt check` command. When enabled, the check command monitors the project directory for file changes and automatically re-runs the check whenever files are modified or created. Uses 200ms debouncing to avoid redundant checks during rapid file changes. Unlike single-run mode, watch mode does not exit with a non-zero status code on stale consumers -- it prints the results and continues watching.

--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -79,6 +79,11 @@ pub enum Commands {
 		/// GitHub Actions annotations that appear inline on PRs.
 		#[arg(long, value_enum, default_value_t = OutputFormat::Text)]
 		format: OutputFormat,
+
+		/// Watch for file changes and re-run checks automatically. Monitors
+		/// template files and consumer files for modifications.
+		#[arg(long, default_value_t = false)]
+		watch: bool,
 	},
 	/// Update all consumer blocks with the latest provider content.
 	///


### PR DESCRIPTION
## Summary

- Add `--watch` flag to `mdt check` command, matching the existing `--watch` support on `mdt update`
- Refactor `run_check` into `run_check_once` (single execution returning stale status) and `run_check` (wrapper handling watch loop and exit codes)
- In watch mode, stale consumers are reported without `process::exit(1)` so the loop continues monitoring for file changes
- Uses the `notify` crate with 200ms debounce, filtering for `Modify` and `Create` events (same pattern as `mdt update --watch`)

## Test plan

- [x] New test `check_watch_flag_is_accepted_by_cli_parser` verifies `--watch` is parsed correctly by clap and defaults to `false`
- [x] New test `check_watch_flag_accepted_by_binary` verifies the binary accepts `--watch`, prints the initial check result and "Watching for file changes" message
- [x] All 94 existing `mdt_cli` tests continue to pass
- [x] Full workspace test suite passes (`cargo test`)
- [x] `cargo clippy --all-features` passes with no new warnings
- [x] `dprint fmt` passes