### PR TITLE
feat(mdt_lsp): switch to incremental text document sync

### DIFF
--- a/.changeset/lsp_incremental_sync.md
+++ b/.changeset/lsp_incremental_sync.md
@@ -1,0 +1,5 @@
+---
+mdt_lsp: patch
+---
+
+Switch LSP text document synchronization from full to incremental mode. The server now receives only changed text ranges instead of the entire document content on each edit, improving performance for large files. Includes proper UTF-16 offset handling for LSP position conversion.


### PR DESCRIPTION
## Summary

- Change the LSP server's text document sync mode from `FULL` to `INCREMENTAL`, so the server receives only changed text ranges instead of the entire document on every edit.
- Add `lsp_position_to_offset` helper that correctly converts LSP positions (line + UTF-16 character offset) to byte offsets in the document string, including proper handling of multi-byte UTF-8 characters and surrogate pairs.
- Update the `did_change` handler to apply all content changes sequentially to the stored document, with fallback to full-content replacement when `range` is `None`.
- Add comprehensive tests for position-to-offset conversion (ASCII, multi-byte, surrogate pairs, edge cases) and incremental change application (insert, delete, replace, multi-line, sequential changes).

## Test plan

- [x] All 153 existing + new `mdt_lsp` tests pass
- [x] Full workspace test suite passes (`cargo test --all-features`)
- [x] `cargo clippy --all-features` reports no warnings for `mdt_lsp`
- [x] `dprint check` passes with no formatting issues
- [x] Changeset file included for release tracking