### PR TITLE
docs: fix broken README rendering and add reusable template blocks

### DIFF
--- a/.changeset/fix_readme_formatting.md
+++ b/.changeset/fix_readme_formatting.md
@@ -1,0 +1,8 @@
+---
+mdt_core: docs
+mdt_cli: docs
+mdt_lsp: docs
+mdt_mcp: docs
+---
+
+Fix broken markdown rendering in all crate READMEs. Badge reference links were collapsed onto a single line, causing them to render as plain text instead of clickable badge images. Each reference link definition now appears on its own line. Also added reusable mdt template blocks for LSP overview, MCP overview, CLI install, and contributing sections. Updated `mdt_core` title from `mdt` to `mdt_core`. Replaced stale `mdt_lsp` README content with mdt template blocks. Updated root README with crate table and streamlined contributing section.

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -1,6 +1,6 @@
 # mdt_cli
 
-> the cli which updates markdown content anywhere using comments as template tags
+> the CLI for mdt (manage markdown templates)
 
 <br />
 
@@ -14,6 +14,16 @@
 
 <!-- {/mdtPackageDocumentation} -->
 
+## Installation
+
+<!-- {=mdtCliInstall} -->
+
+```sh
+cargo install mdt_cli
+```
+
+<!-- {/mdtCliInstall} -->
+
 <!-- {=mdtCliUsage} -->
 
 ### CLI Commands
@@ -26,11 +36,51 @@
 
 <!-- {/mdtCliUsage} -->
 
+<!-- {=mdtTemplateSyntax} -->
+
+### Template Syntax
+
+**Provider tag** (defines a template block in `*.t.md` definition files):
+
+```markdown
+<!-- {@blockName} -->
+
+Content to inject
+
+<!-- {/blockName} -->
+```
+
+**Consumer tag** (marks where content should be injected):
+
+```markdown
+<!-- {=blockName} -->
+
+This content gets replaced
+
+<!-- {/blockName} -->
+```
+
+**Filters and pipes:** Template values support pipe-delimited transformers:
+
+```markdown
+<!-- {=block|prefix:"\n"|indent:"  "} -->
+```
+
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`, `if`.
+
+<!-- {/mdtTemplateSyntax} -->
+
 <!-- {=mdtBadgeLinks:"mdt_cli"} -->
 
+[crate-image]: https://img.shields.io/crates/v/mdt_cli.svg
+[crate-link]: https://crates.io/crates/mdt_cli
+[docs-image]: https://docs.rs/mdt_cli/badge.svg
+[docs-link]: https://docs.rs/mdt_cli/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
 [coverage-image]: https://codecov.io/gh/ifiokjr/mdt/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/mdt
-
-[crate-image]: https://img.shields.io/crates/v/mdt_cli.svg [crate-link]: https://crates.io/crates/mdt_cli [docs-image]: https://docs.rs/mdt_cli/badge.svg [docs-link]: https://docs.rs/mdt_cli/ [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci [unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg [unlicense-link]: https://opensource.org/license/unlicense
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense
 
 <!-- {/mdtBadgeLinks} -->

--- a/mdt_core/readme.md
+++ b/mdt_core/readme.md
@@ -1,6 +1,6 @@
-# mdt
+# mdt_core
 
-> update markdown content anywhere using comments as template tags
+> core library for mdt (manage markdown templates)
 
 <br />
 
@@ -8,11 +8,71 @@
 
 <br />
 
-<!-- {=mdtPackageDocumentation} -->
+<!-- {=mdtCoreOverview} -->
 
-`mdt` is a data-driven template engine for keeping documentation synchronized across your project. It uses comment-based template tags to define content once and distribute it to multiple locations — markdown files, code documentation comments (in any language), READMEs, mdbook docs, and more.
+`mdt_core` is the core library for the [mdt](https://github.com/ifiokjr/mdt) template engine. It provides the lexer, parser, project scanner, and template engine for processing markdown template tags. Content defined once in provider blocks can be distributed to consumer blocks across markdown files, code documentation comments, READMEs, and more.
 
-<!-- {/mdtPackageDocumentation} -->
+## Processing Pipeline
+
+```text
+Markdown / source file
+  → Lexer (tokenizes HTML comments into TokenGroups)
+  → Pattern matcher (validates token sequences)
+  → Parser (classifies groups, extracts names + transformers, matches open/close into Blocks)
+  → Project scanner (walks directory tree, builds provider→content map + consumer list)
+  → Engine (matches consumers to providers, applies transformers, replaces content)
+```
+
+## Modules
+
+- [`config`] — Configuration loading from `mdt.toml`, including data source mappings, exclude/include patterns, and template paths.
+- [`project`] — Project scanning and directory walking. Discovers provider and consumer blocks across all files in a project.
+- [`source_scanner`] — Source file scanning for consumer tags inside code comments (Rust, TypeScript, Python, Go, Java, etc.).
+
+## Key Types
+
+- [`Block`] — A parsed template block (provider or consumer) with its name, type, position, and transformers.
+- [`Transformer`] — A pipe-delimited content filter (e.g., `trim`, `indent`, `linePrefix`) applied during injection.
+- [`ProjectContext`] — A scanned project together with its loaded template data, ready for checking or updating.
+- [`MdtConfig`] — Configuration loaded from `mdt.toml`.
+- [`CheckResult`] — Result of checking a project for stale consumers.
+- [`UpdateResult`] — Result of computing updates for consumer blocks.
+
+## Data Interpolation
+
+Provider content supports [`minijinja`](https://docs.rs/minijinja) template variables populated from project files. The `mdt.toml` config maps source files to namespaces:
+
+```toml
+[data]
+pkg = "package.json"
+cargo = "Cargo.toml"
+```
+
+Then in provider blocks: `{{ pkg.version }}` or `{{ cargo.package.edition }}`.
+
+Supported formats: JSON, TOML, YAML, and KDL.
+
+## Quick Start
+
+```rust,no_run
+use mdt_core::project::scan_project_with_config;
+use mdt_core::{check_project, compute_updates, write_updates};
+use std::path::Path;
+
+let ctx = scan_project_with_config(Path::new(".")).unwrap();
+
+// Check for stale consumers
+let result = check_project(&ctx).unwrap();
+if !result.is_ok() {
+    eprintln!("{} stale consumer(s) found", result.stale.len());
+}
+
+// Update all consumer blocks
+let updates = compute_updates(&ctx).unwrap();
+write_updates(&updates).unwrap();
+```
+
+<!-- {/mdtCoreOverview} -->
 
 ## Installation
 
@@ -27,9 +87,15 @@ mdt_core = "0.5.0"
 
 <!-- {=mdtBadgeLinks:"mdt_core"} -->
 
+[crate-image]: https://img.shields.io/crates/v/mdt_core.svg
+[crate-link]: https://crates.io/crates/mdt_core
+[docs-image]: https://docs.rs/mdt_core/badge.svg
+[docs-link]: https://docs.rs/mdt_core/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
 [coverage-image]: https://codecov.io/gh/ifiokjr/mdt/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/mdt
-
-[crate-image]: https://img.shields.io/crates/v/mdt_core.svg [crate-link]: https://crates.io/crates/mdt_core [docs-image]: https://docs.rs/mdt_core/badge.svg [docs-link]: https://docs.rs/mdt_core/ [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci [unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg [unlicense-link]: https://opensource.org/license/unlicense
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense
 
 <!-- {/mdtBadgeLinks} -->

--- a/mdt_lsp/readme.md
+++ b/mdt_lsp/readme.md
@@ -8,127 +8,32 @@
 
 <br />
 
-## Why?
+<!-- {=mdtLspOverview} -->
 
-Often, while developing a project, you will want to automatically update sections of markdown content in your files. For example:
+`mdt_lsp` is a [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation for the [mdt](https://github.com/ifiokjr/mdt) template engine. It provides real-time editor integration for managing markdown template blocks.
 
-- The `version` has been updated and should be reflected in multiple files.
-- The API has changed and you want to automatically generate documentation that is placed within the `readme.md` file.
+### Capabilities
 
-## Solution
+- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
+- **Completions** — suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
+- **Hover** — shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
+- **Go to definition** — navigates from a consumer block to its provider, or from a provider to all of its consumers.
+- **References** — finds all provider and consumer blocks sharing the same name.
+- **Rename** — renames a block across all provider and consumer tags (both opening and closing) in the workspace.
+- **Document symbols** — lists all provider and consumer blocks in the outline/symbol view.
+- **Code actions** — offers a quick-fix to update stale consumer blocks in place.
 
-This project allows you to wrap the content you want to keep updated in a markdown comment block `<!-- ={exampleBlock} --><!-- {/exampleBlock}-->`. A build command is then run which injects values into the comment tag while preserving the tags. This means that blocks can be updated multiple times with new data.
+### Usage
 
-Blocks can also be checked during continuous integration to ensure that they are up-to-date.
+Start the language server via the CLI:
 
-## Deeper Explanation
-
-Here is a deeper explanation of the `mdt` flow.
-
-### Step 1: Define templates
-
-Define replacement blocks within the markdown content. A replacement block is defined with the following syntax:
-
-#### Opening tag
-
-```markdown
-<!-- ={exampleBlock} -->
+```sh
+mdt lsp
 ```
 
-#### Closing Tag
+The server communicates over stdin/stdout using the Language Server Protocol.
 
-```markdown
-<!-- {/exampleBlock}-->
-```
-
-This markdown content can be anywhere that takes markdown content. For example you might want to keep you `readme.md` up to date with the latest API documentation. You can do this by adding the following to your `readme.md` file:
-
-```markdown
-# my_precious
-
-> does precious things
-
-## API documentation
-
-<!-- ={api} -->
-
-This is automatically replaced with the API documentation.
-
-<!-- {/api}-->
-```
-
-You may also want to reuse code examples in multiple places without having to redefine the multiple times. Below is an example of using the templates in rust files. The same flow can be used for `TypeScript`, `Dart` and other languages that support markdown in their documentation comments.
-
-````rust
-//! This is the API documentation for my_precious
-//!
-//! # Examples
-//!
-//! The block below will automatically be replaced when running the `mdt`
-//! command.
-//!
-//! <!-- ={codeExample} -->
-//! ```rust
-//! use my_precious::be_precious;
-//!
-//! be_precious();
-//! ```
-//! <!-- {/codeExample} -->
-
-pub fn be_precious() {
-	println!("I am precious");
-}
-````
-
-### Step 2: Define definition files
-
-The tags in the previous step are pulling in their content from somewhere. In mdt this is from the `definition` files. A definition file is a markdown file with the following naming convention `*.t.md`.
-
-These file are comprised of template blocks of content where the blocks used in the previous section are defined.
-
-#### Defining a template block
-
-````markdown
-<!-- @{exampleBlock} -->
-
-This content will be injected into any markdown content which has the following tag
-
-```markdown
-<!-- ={exampleBlock} -->
-
-...
-
-<!-- {/exampleBlock} -->`
-```
-
-<!-- {/exampleBlock} -->
-````
-
-#### Defining a template block with template values
-
-In the following example the `{{example.version}}` is a template value. This value will be replaced with the value defined in the configuration when running the `mdt` command.
-
-````markdown
-<!-- @{codeExample} -->
-
-```ts
-import { bePrecious } from "https://deno.land/x/my_precious@{{example.version}}/mod.ts";
-
-bePrecious();
-```
-
-<!-- {/codeExample} -->
-````
-
-### Step 3: Define the template values
-
-The template values can be defined in the following ways.
-
-- `mdt.json`
-- `mdt.yaml`
-- `mdt.kdl`
-- `mdt.toml`
-- `mdt.ts` - recommended (see below)
+<!-- {/mdtLspOverview} -->
 
 ## Installation
 
@@ -143,9 +48,15 @@ mdt_lsp = "0.5.0"
 
 <!-- {=mdtBadgeLinks:"mdt_lsp"} -->
 
+[crate-image]: https://img.shields.io/crates/v/mdt_lsp.svg
+[crate-link]: https://crates.io/crates/mdt_lsp
+[docs-image]: https://docs.rs/mdt_lsp/badge.svg
+[docs-link]: https://docs.rs/mdt_lsp/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
 [coverage-image]: https://codecov.io/gh/ifiokjr/mdt/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/mdt
-
-[crate-image]: https://img.shields.io/crates/v/mdt_lsp.svg [crate-link]: https://crates.io/crates/mdt_lsp [docs-image]: https://docs.rs/mdt_lsp/badge.svg [docs-link]: https://docs.rs/mdt_lsp/ [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci [unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg [unlicense-link]: https://opensource.org/license/unlicense
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense
 
 <!-- {/mdtBadgeLinks} -->

--- a/mdt_mcp/readme.md
+++ b/mdt_mcp/readme.md
@@ -8,28 +8,26 @@
 
 <br />
 
-`mdt_mcp` provides a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the `mdt` template engine. It exposes mdt functionality as MCP tools that can be used by AI assistants and other MCP-compatible clients.
+<!-- {=mdtMcpOverview} -->
 
-## Tools
+`mdt_mcp` is a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [mdt](https://github.com/ifiokjr/mdt) template engine. It exposes mdt functionality as MCP tools that can be used by AI assistants and other MCP-compatible clients.
 
-The server provides the following tools:
+### Tools
 
-- **`mdt_check`** — Verify all consumer blocks are up-to-date
-- **`mdt_update`** — Update all consumer blocks with latest provider content
-- **`mdt_list`** — List all providers and consumers in the project
-- **`mdt_get_block`** — Get the content of a specific block by name
-- **`mdt_preview`** — Preview the result of applying transformers to a block
-- **`mdt_init`** — Initialize a new mdt project with a sample template file
+- **`mdt_check`** — Verify all consumer blocks are up-to-date.
+- **`mdt_update`** — Update all consumer blocks with latest provider content.
+- **`mdt_list`** — List all providers and consumers in the project.
+- **`mdt_get_block`** — Get the content of a specific block by name.
+- **`mdt_preview`** — Preview the result of applying transformers to a block.
+- **`mdt_init`** — Initialize a new mdt project with a sample template file.
 
-## Usage
+### Usage
 
-The MCP server communicates over stdin/stdout and can be launched via the `mdt` CLI:
+Start the MCP server via the CLI:
 
 ```sh
 mdt mcp
 ```
-
-### Configuration
 
 Add the following to your MCP client configuration:
 
@@ -44,6 +42,8 @@ Add the following to your MCP client configuration:
 }
 ```
 
+<!-- {/mdtMcpOverview} -->
+
 ## Installation
 
 <!-- {=mdtMcpInstall} -->
@@ -57,9 +57,15 @@ mdt_mcp = "0.5.0"
 
 <!-- {=mdtBadgeLinks:"mdt_mcp"} -->
 
+[crate-image]: https://img.shields.io/crates/v/mdt_mcp.svg
+[crate-link]: https://crates.io/crates/mdt_mcp
+[docs-image]: https://docs.rs/mdt_mcp/badge.svg
+[docs-link]: https://docs.rs/mdt_mcp/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
 [coverage-image]: https://codecov.io/gh/ifiokjr/mdt/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/mdt
-
-[crate-image]: https://img.shields.io/crates/v/mdt_mcp.svg [crate-link]: https://crates.io/crates/mdt_mcp [docs-image]: https://docs.rs/mdt_mcp/badge.svg [docs-link]: https://docs.rs/mdt_mcp/ [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci [unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg [unlicense-link]: https://opensource.org/license/unlicense
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense
 
 <!-- {/mdtBadgeLinks} -->

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,16 @@
 
 <!-- {/mdtPackageDocumentation} -->
 
+## Installation
+
+<!-- {=mdtCliInstall} -->
+
+```sh
+cargo install mdt_cli
+```
+
+<!-- {/mdtCliInstall} -->
+
 <!-- {=mdtTemplateSyntax} -->
 
 ### Template Syntax
@@ -44,7 +54,7 @@ This content gets replaced
 <!-- {=block|prefix:"\n"|indent:"  "} -->
 ```
 
-Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`.
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`, `if`.
 
 <!-- {/mdtTemplateSyntax} -->
 
@@ -60,26 +70,20 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 
 <!-- {/mdtCliUsage} -->
 
-## LSP
+## Crates
 
-The `mdt_lsp` crate provides a fully implemented language server for editor integration. Start it with `mdt lsp` or run the `mdt-lsp` binary directly. The server communicates over stdin/stdout and supports the following capabilities:
-
-- **Diagnostics** -- reports stale consumer blocks, missing providers with name suggestions, unclosed blocks, unknown transformers, invalid transformer arguments, unused providers, and provider blocks in non-template files.
-- **Completions** -- suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
-- **Hover** -- shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
-- **Go to definition** -- navigates from a consumer block to its provider, or from a provider to all of its consumers.
-- **Document symbols** -- lists all provider and consumer blocks in the outline/symbol view.
-- **Code actions** -- offers a quick-fix to update stale consumer blocks in place.
+| Crate                    | Description                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| [`mdt_core`](./mdt_core) | Core library — lexer, parser, scanner, and template engine                     |
+| [`mdt_cli`](./mdt_cli)   | CLI tool — `mdt` binary for managing templates                                 |
+| [`mdt_lsp`](./mdt_lsp)   | LSP server — editor integration with diagnostics, completions, hover, and more |
+| [`mdt_mcp`](./mdt_mcp)   | MCP server — AI assistant integration via the Model Context Protocol           |
 
 ## Contributing
 
+<!-- {=mdtContributing} -->
+
 [`devenv`](https://devenv.sh/) is used to provide a reproducible development environment for this project. Follow the [getting started instructions](https://devenv.sh/getting-started/).
-
-If you want to use flakes you may need to run the following command after initial setup.
-
-```bash
-echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf
-```
 
 To automatically load the environment you should [install direnv](https://devenv.sh/automatic-shell-activation/) and then load the `direnv`.
 
@@ -89,24 +93,9 @@ To automatically load the environment you should [install direnv](https://devenv
 direnv allow .
 ```
 
-At this point you should see the `nix` commands available in your terminal. Run `install:all` to install all tooling.
+At this point you should see the `nix` commands available in your terminal. Run `install:all` to install all tooling and dependencies.
 
-To setup recommended configuration for your favourite editor run the following commands.
-
-```bash
-setup:vscode # Setup vscode
-setup:helix  # Setup helix configuration
-```
-
-### Upgrading `devenv`
-
-If you have an outdated version of `devenv` you can update it by running the following commands. If you know an easier way, please create a PR and I'll update these docs.
-
-```bash
-nix profile list # find the index of the nix package
-nix profile remove <index>
-nix profile install --accept-flake-config github:cachix/devenv/<version>
-```
+<!-- {/mdtContributing} -->
 
 [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
 [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci

--- a/template.t.md
+++ b/template.t.md
@@ -46,9 +46,96 @@ This content gets replaced
 <!-- {=block|prefix:"\n"|indent:"  "} -->
 ```
 
-Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`.
+Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suffix`, `linePrefix`, `lineSuffix`, `wrap`, `codeBlock`, `code`, `replace`, `if`.
 
 <!-- {/mdtTemplateSyntax} -->
+
+<!-- {@mdtCliInstall} -->
+
+```sh
+cargo install mdt_cli
+```
+
+<!-- {/mdtCliInstall} -->
+
+<!-- {@mdtLspOverview} -->
+
+`mdt_lsp` is a [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation for the [mdt](https://github.com/ifiokjr/mdt) template engine. It provides real-time editor integration for managing markdown template blocks.
+
+### Capabilities
+
+- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
+- **Completions** — suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
+- **Hover** — shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
+- **Go to definition** — navigates from a consumer block to its provider, or from a provider to all of its consumers.
+- **References** — finds all provider and consumer blocks sharing the same name.
+- **Rename** — renames a block across all provider and consumer tags (both opening and closing) in the workspace.
+- **Document symbols** — lists all provider and consumer blocks in the outline/symbol view.
+- **Code actions** — offers a quick-fix to update stale consumer blocks in place.
+
+### Usage
+
+Start the language server via the CLI:
+
+```sh
+mdt lsp
+```
+
+The server communicates over stdin/stdout using the Language Server Protocol.
+
+<!-- {/mdtLspOverview} -->
+
+<!-- {@mdtMcpOverview} -->
+
+`mdt_mcp` is a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [mdt](https://github.com/ifiokjr/mdt) template engine. It exposes mdt functionality as MCP tools that can be used by AI assistants and other MCP-compatible clients.
+
+### Tools
+
+- **`mdt_check`** — Verify all consumer blocks are up-to-date.
+- **`mdt_update`** — Update all consumer blocks with latest provider content.
+- **`mdt_list`** — List all providers and consumers in the project.
+- **`mdt_get_block`** — Get the content of a specific block by name.
+- **`mdt_preview`** — Preview the result of applying transformers to a block.
+- **`mdt_init`** — Initialize a new mdt project with a sample template file.
+
+### Usage
+
+Start the MCP server via the CLI:
+
+```sh
+mdt mcp
+```
+
+Add the following to your MCP client configuration:
+
+```json
+{
+	"mcpServers": {
+		"mdt": {
+			"command": "mdt",
+			"args": ["mcp"]
+		}
+	}
+}
+```
+
+<!-- {/mdtMcpOverview} -->
+
+<!-- {@mdtContributing} -->
+
+[`devenv`](https://devenv.sh/) is used to provide a reproducible development environment for this project. Follow the [getting started instructions](https://devenv.sh/getting-started/).
+
+To automatically load the environment you should [install direnv](https://devenv.sh/automatic-shell-activation/) and then load the `direnv`.
+
+```bash
+# The security mechanism didn't allow to load the `.envrc`.
+# Since we trust it, let's allow it execution.
+direnv allow .
+```
+
+At this point you should see the `nix` commands available in your terminal. Run `install:all` to install all tooling and dependencies.
+
+<!-- {/mdtContributing} -->
 
 <!-- {@mdtCoreInstall} -->
 
@@ -191,9 +278,15 @@ Three types are supported:
 
 <!-- {@mdtBadgeLinks:"crateName"} -->
 
+[crate-image]: https://img.shields.io/crates/v/{{ crateName }}.svg
+[crate-link]: https://crates.io/crates/{{ crateName }}
+[docs-image]: https://docs.rs/{{ crateName }}/badge.svg
+[docs-link]: https://docs.rs/{{ crateName }}/
+[ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg
+[ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci
 [coverage-image]: https://codecov.io/gh/ifiokjr/mdt/branch/main/graph/badge.svg
 [coverage-link]: https://codecov.io/gh/ifiokjr/mdt
-
-[crate-image]: https://img.shields.io/crates/v/{{ crateName }}.svg [crate-link]: https://crates.io/crates/{{ crateName }} [docs-image]: https://docs.rs/{{ crateName }}/badge.svg [docs-link]: https://docs.rs/{{ crateName }}/ [ci-status-image]: https://github.com/ifiokjr/mdt/workflows/ci/badge.svg [ci-status-link]: https://github.com/ifiokjr/mdt/actions?query=workflow:ci [unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg [unlicense-link]: https://opensource.org/license/unlicense
+[unlicense-image]: https://img.shields.io/badge/license-Unlicence-blue.svg
+[unlicense-link]: https://opensource.org/license/unlicense
 
 <!-- {/mdtBadgeLinks} -->


### PR DESCRIPTION
## Summary

- Fix badge reference links that were collapsed onto a single line, causing them to render as plain text instead of clickable badge images on GitHub
- Fix `mdt_core` README title from `mdt` to `mdt_core`
- Replace stale `mdt_lsp` README content with mdt template blocks
- Add new reusable mdt provider blocks: `mdtLspOverview`, `mdtMcpOverview`, `mdtCliInstall`, `mdtContributing`
- Update root README with a crate table and streamlined contributing section
- Update `mdtTemplateSyntax` to include the new `if` transformer

## Test plan

- [x] `mdt check` passes (all consumer blocks are up to date)
- [x] `dprint fmt` produces no changes (stable formatting cycle)
- [x] `cargo clippy --all-features` has no warnings
- [x] All 765 tests pass
- [ ] Verify badge images render correctly on the PR's file view