### PR TITLE
feat(mdt_core)!: harden public API and improve crate docs

### DIFF
--- a/.changeset/api_hardening_and_docs.md
+++ b/.changeset/api_hardening_and_docs.md
@@ -1,0 +1,22 @@
+---
+mdt_core: major
+mdt_cli: patch
+mdt_lsp: minor
+mdt_mcp: minor
+---
+
+Harden public API and improve crate documentation.
+
+**Breaking (`mdt_core`):** Add `#[non_exhaustive]` to all 9 public enums (`MdtError`, `ParseDiagnostic`, `Argument`, `TransformerType`, `BlockType`, `PaddingValue`, `CodeBlockFilter`, `Token`, `DiagnosticKind`). This prevents downstream exhaustive pattern matching and allows new variants to be added in future minor releases without breaking changes. Downstream code matching on these enums must add a wildcard (`_`) arm.
+
+**Breaking (`mdt_core`):** Make `source_scanner` module public (`pub mod source_scanner`). Previously it was private with items re-exported at the crate root via `pub use source_scanner::*`. The module is now directly accessible, fixing rustdoc link warnings for `[`source_scanner`]` references in crate-level documentation.
+
+**`mdt_lsp`:** Add crate-level documentation using the `mdtLspOverview` template block, providing an overview of LSP capabilities and usage instructions directly in `lib.rs`.
+
+**`mdt_mcp`:** Add crate-level documentation using the `mdtMcpOverview` template block, providing an overview of MCP tools and configuration directly in `lib.rs`.
+
+**`mdt_cli`:** Add wildcard arms to `DiagnosticKind` match statements for forward compatibility with new diagnostic kinds.
+
+**All crates:** Replace `tokio` `features = ["full"]` with minimal required feature sets — `mdt_cli` uses `["rt-multi-thread"]`, `mdt_lsp` uses `["rt-multi-thread", "macros", "sync", "io-std"]`, `mdt_mcp` uses `["rt-multi-thread", "macros"]`. This makes dependency requirements explicit.
+
+**Config:** Remove stale data entries from `mdt.toml` (`cargo_mdt_core`, `cargo_mdt_cli`, `cargo_mdt_lsp`, `cargo_mdt_mcp`) that referenced individual crate `Cargo.toml` files no longer needed since crates use `version = { workspace = true }`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,16 +1199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,16 +1599,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,16 +1638,6 @@ checksum = "ec62a949bda7f15800481a711909f946e1204f2460f89210eaf7f57730f88f86"
 dependencies = [
  "thiserror 1.0.69",
  "unicode_categories",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1810,14 +1780,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
- "libc",
- "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/mdt.toml
+++ b/mdt.toml
@@ -4,10 +4,6 @@ after = 0
 
 [data]
 cargo = "Cargo.toml"
-cargo_mdt_core = "mdt_core/Cargo.toml"
-cargo_mdt_cli = "mdt_cli/Cargo.toml"
-cargo_mdt_lsp = "mdt_lsp/Cargo.toml"
-cargo_mdt_mcp = "mdt_mcp/Cargo.toml"
 
 [exclude]
 patterns = [

--- a/mdt_cli/Cargo.toml
+++ b/mdt_cli/Cargo.toml
@@ -26,7 +26,7 @@ notify = { workspace = true, features = ["macos_fsevent"], default-features = tr
 owo-colors = { workspace = true, features = ["supports-colors"], default-features = true }
 serde_json = { workspace = true, default-features = true }
 similar = { workspace = true, default-features = true }
-tokio = { workspace = true, features = ["full"], default-features = true }
+tokio = { workspace = true, features = ["rt-multi-thread"], default-features = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true, default-features = true }

--- a/mdt_cli/src/main.rs
+++ b/mdt_cli/src/main.rs
@@ -637,12 +637,14 @@ fn diagnostic_to_report(
 				 unused provider"
 			)
 		}
+		_ => diag.message(),
 	};
 	let code = match &diag.kind {
 		DiagnosticKind::UnclosedBlock { .. } => "mdt::unclosed_block",
 		DiagnosticKind::UnknownTransformer { .. } => "mdt::unknown_transformer",
 		DiagnosticKind::InvalidTransformerArgs { .. } => "mdt::invalid_transformer_args",
 		DiagnosticKind::UnusedProvider { .. } => "mdt::unused_provider",
+		_ => "mdt::diagnostic",
 	};
 
 	let diag_value = miette::MietteDiagnostic::new(message)

--- a/mdt_core/src/config.rs
+++ b/mdt_core/src/config.rs
@@ -77,6 +77,7 @@ pub struct MdtConfig {
 /// blank lines include the comment prefix to maintain valid syntax.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 #[allow(variant_size_differences)]
 pub enum PaddingValue {
 	/// `false` disables padding (inline). `true` is treated as 1 blank line.
@@ -139,6 +140,7 @@ fn default_max_file_size() -> u64 {
 ///   **any** of the given strings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum CodeBlockFilter {
 	/// `true` to skip all code blocks, `false` to process normally.
 	Bool(bool),

--- a/mdt_core/src/error.rs
+++ b/mdt_core/src/error.rs
@@ -2,6 +2,7 @@ use miette::Diagnostic;
 use thiserror::Error;
 
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum MdtError {
 	#[error(transparent)]
 	#[diagnostic(code(mdt::io_error))]

--- a/mdt_core/src/lib.rs
+++ b/mdt_core/src/lib.rs
@@ -79,7 +79,7 @@ mod parser;
 pub(crate) mod patterns;
 mod position;
 pub mod project;
-mod source_scanner;
+pub mod source_scanner;
 pub(crate) mod tokens;
 
 #[cfg(test)]

--- a/mdt_core/src/parser.rs
+++ b/mdt_core/src/parser.rs
@@ -16,6 +16,7 @@ use crate::tokens::TokenGroup;
 /// A diagnostic produced during parsing. These are issues that don't prevent
 /// parsing from completing but indicate problems in the source content.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ParseDiagnostic {
 	/// A block was opened but never closed.
 	UnclosedBlock {
@@ -671,6 +672,7 @@ pub struct Transformer {
 /// - **Boolean** — `true` or `false`
 /// <!-- {/mdtArgumentDocs} -->
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Argument {
 	/// A quoted string value, e.g. `"hello"` or `'world'`.
 	String(String),
@@ -698,6 +700,7 @@ impl std::fmt::Display for OrderedFloat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TransformerType {
 	/// Trim all whitespace from the start and end of the content.
 	Trim,
@@ -751,6 +754,7 @@ impl std::fmt::Display for TransformerType {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockType {
 	/// These are the blocks that are used to provide a value to any consumers.
 	/// Their names can be referenced by consumers to hoist content. They should

--- a/mdt_core/src/project.rs
+++ b/mdt_core/src/project.rs
@@ -107,6 +107,7 @@ pub struct ValidationOptions {
 
 /// The kind of diagnostic produced during project scanning and validation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum DiagnosticKind {
 	/// A block was opened but never closed.
 	UnclosedBlock { name: String },

--- a/mdt_core/src/tokens.rs
+++ b/mdt_core/src/tokens.rs
@@ -15,6 +15,7 @@ use crate::Position;
 
 /// Only tokenize the blocks, not the content inside them or anything else.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Token {
 	/// `\n`
 	Newline,

--- a/mdt_lsp/Cargo.toml
+++ b/mdt_lsp/Cargo.toml
@@ -15,7 +15,7 @@ description = "LSP server for mdt (manage markdown templates)"
 [dependencies]
 mdt_core = { workspace = true }
 serde_json = { workspace = true, default-features = true }
-tokio = { workspace = true, features = ["full"], default-features = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "io-std"], default-features = true }
 tower-lsp-server = { workspace = true, features = ["proposed"], default-features = true }
 
 [dev-dependencies]

--- a/mdt_mcp/Cargo.toml
+++ b/mdt_mcp/Cargo.toml
@@ -17,7 +17,7 @@ mdt_core = { workspace = true }
 rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
 serde = { workspace = true, features = ["derive"], default-features = true }
 serde_json = { workspace = true, default-features = true }
-tokio = { workspace = true, features = ["full"], default-features = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"], default-features = true }
 
 [dev-dependencies]
 tempfile = { workspace = true, default-features = true }

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -1,3 +1,37 @@
+//! <!-- {=mdtMcpOverview|trim|linePrefix:"//! ":true} -->
+//! `mdt_mcp` is a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for the [mdt](https://github.com/ifiokjr/mdt) template engine. It exposes mdt functionality as MCP tools that can be used by AI assistants and other MCP-compatible clients.
+//!
+//! ### Tools
+//!
+//! - **`mdt_check`** — Verify all consumer blocks are up-to-date.
+//! - **`mdt_update`** — Update all consumer blocks with latest provider content.
+//! - **`mdt_list`** — List all providers and consumers in the project.
+//! - **`mdt_get_block`** — Get the content of a specific block by name.
+//! - **`mdt_preview`** — Preview the result of applying transformers to a block.
+//! - **`mdt_init`** — Initialize a new mdt project with a sample template file.
+//!
+//! ### Usage
+//!
+//! Start the MCP server via the CLI:
+//!
+//! ```sh
+//! mdt mcp
+//! ```
+//!
+//! Add the following to your MCP client configuration:
+//!
+//! ```json
+//! {
+//! 	"mcpServers": {
+//! 		"mdt": {
+//! 			"command": "mdt",
+//! 			"args": ["mcp"]
+//! 		}
+//! 	}
+//! }
+//! ```
+//! <!-- {/mdtMcpOverview} -->
+
 use std::path::Path;
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary

- **Add `#[non_exhaustive]` to all 9 public enums** in `mdt_core` (`MdtError`, `ParseDiagnostic`, `Argument`, `TransformerType`, `BlockType`, `PaddingValue`, `CodeBlockFilter`, `Token`, `DiagnosticKind`) — allows new variants in future minor releases without breaking downstream code
- **Make `source_scanner` module public** — fixes rustdoc link warnings for `[source_scanner]` references in crate-level docs
- **Add crate-level docs** to `mdt_lsp` and `mdt_mcp` via `mdtLspOverview` and `mdtMcpOverview` template blocks
- **Optimize tokio features** — replace `"full"` with minimal required features per crate (`rt-multi-thread`, `macros`, `sync`, `io-std`)
- **Remove stale `mdt.toml` data entries** — `cargo_mdt_core`, `cargo_mdt_cli`, `cargo_mdt_lsp`, `cargo_mdt_mcp` are no longer needed since crates use `version = { workspace = true }`
- **Add wildcard arms** in `mdt_cli` and `mdt_lsp` for forward compatibility with new enum variants

## Test plan

- [x] All 771 tests pass (`cargo nextest run`)
- [x] `cargo clippy --all-features` clean (only pre-existing `implicit_hasher` warning)
- [x] `dprint check` passes
- [x] `mdt check` passes — all consumer blocks up to date
- [x] `cargo build --all-features` succeeds