### PR TITLE
feat(lsp): flag duplicate provider names across templates

### DIFF
--- a/mdt_lsp/readme.md
+++ b/mdt_lsp/readme.md
@@ -14,7 +14,7 @@
 
 ### Capabilities
 
-- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
+- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), duplicate providers, unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
 - **Completions** — suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
 - **Hover** — shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
 - **Go to definition** — navigates from a consumer block to its provider, or from a provider to all of its consumers.

--- a/template.t.md
+++ b/template.t.md
@@ -56,7 +56,7 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 
 ### Capabilities
 
-- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
+- **Diagnostics** — reports stale consumer blocks, missing providers (with name suggestions), duplicate providers, unclosed blocks, unknown transformers, invalid arguments, unused providers, and provider blocks in non-template files.
 - **Completions** — suggests block names after `{=`, `{@`, and `{/` tags, and transformer names after `|`.
 - **Hover** — shows provider source, rendered content, transformer chain, and consumer count when hovering over a block tag.
 - **Go to definition** — navigates from a consumer block to its provider, or from a provider to all of its consumers.


### PR DESCRIPTION
## Summary\n- add LSP diagnostics for duplicate provider names (global provider namespace)\n- detect duplicates across open template documents and cached project providers\n- emit error diagnostics and suppress unused-provider warnings when duplicate conflicts exist\n- update generated/readme docs for LSP diagnostics capability\n\n## Tests\n- cargo run --bin mdt -- update\n- cargo run --bin mdt -- check\n- dprint check\n- cargo test -p mdt_lsp -q\n