### PR TITLE
feat(mcp): add reusable block discovery guidance

### DIFF
--- a/mdt_mcp/readme.md
+++ b/mdt_mcp/readme.md
@@ -17,6 +17,7 @@
 - **`mdt_check`** — Verify all consumer blocks are up-to-date.
 - **`mdt_update`** — Update all consumer blocks with latest provider content.
 - **`mdt_list`** — List all providers and consumers in the project.
+- **`mdt_find_reuse`** — Find similar providers and where they are already consumed in markdown and source files to encourage reuse.
 - **`mdt_get_block`** — Get the content of a specific block by name.
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
 - **`mdt_init`** — Initialize a new mdt project with a sample template file.

--- a/template.t.md
+++ b/template.t.md
@@ -86,6 +86,7 @@ The server communicates over stdin/stdout using the Language Server Protocol.
 - **`mdt_check`** — Verify all consumer blocks are up-to-date.
 - **`mdt_update`** — Update all consumer blocks with latest provider content.
 - **`mdt_list`** — List all providers and consumers in the project.
+- **`mdt_find_reuse`** — Find similar providers and where they are already consumed in markdown and source files to encourage reuse.
 - **`mdt_get_block`** — Get the content of a specific block by name.
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
 - **`mdt_init`** — Initialize a new mdt project with a sample template file.


### PR DESCRIPTION
## Summary
- add new MCP tool `mdt_find_reuse` to discover similar providers and reuse candidates
- include markdown/code consumer locations per candidate to encourage project-wide block reuse
- update MCP server instructions to explicitly recommend reuse discovery before creating new providers
- update MCP overview docs/tool list

## Tests
- cargo test -p mdt_mcp -q
- cargo clippy -p mdt_mcp --all-features
- cargo run --bin mdt -- update
- cargo run --bin mdt -- check
- dprint check
