### PR TITLE
feat(cli): add json output mode for mdt info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "owo-colors",
  "predicates",
  "rstest",
+ "serde",
  "serde_json",
  "similar",
  "similar-asserts",

--- a/mdt_cli/Cargo.toml
+++ b/mdt_cli/Cargo.toml
@@ -24,6 +24,7 @@ mdt_mcp = { workspace = true }
 miette = { workspace = true, features = ["fancy"], default-features = true }
 notify = { workspace = true, features = ["macos_fsevent"], default-features = true }
 owo-colors = { workspace = true, features = ["supports-colors"], default-features = true }
+serde = { workspace = true, features = ["derive"], default-features = true }
 serde_json = { workspace = true, default-features = true }
 similar = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["rt-multi-thread"], default-features = true }

--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -110,12 +110,17 @@ pub enum Commands {
 	/// found across the project, along with file paths and block names. Useful
 	/// for auditing template coverage and discovering orphaned consumers.
 	List,
-	/// Print a human-readable diagnostic summary of the current project.
+	/// Print a diagnostic summary of the current project.
 	///
 	/// Shows discovered providers/consumers, orphan and unused counts,
 	/// data namespaces from config, template file overview, and diagnostic
 	/// totals (errors, warnings, and missing providers).
-	Info,
+	Info {
+		/// Output format for info results. Use `text` for human-readable
+		/// output or `json` for programmatic consumption.
+		#[arg(long, value_enum, default_value_t = InfoOutputFormat::Text)]
+		format: InfoOutputFormat,
+	},
 	/// Start the mdt language server (LSP).
 	///
 	/// Communicates over stdin/stdout using the Language Server Protocol.
@@ -147,4 +152,12 @@ pub enum OutputFormat {
 	/// GitHub Actions annotation format. Emits `::warning` or `::error`
 	/// annotations that appear inline on pull request diffs.
 	Github,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum InfoOutputFormat {
+	/// Human-readable text output with colors and formatting.
+	Text,
+	/// JSON output for programmatic consumption.
+	Json,
 }

--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use mdt_cli::Commands;
+use mdt_cli::InfoOutputFormat;
 use mdt_cli::MdtCli;
 use mdt_core::AnyEmptyResult;
 use predicates::prelude::PredicateBooleanExt;
@@ -313,7 +314,17 @@ fn info_command_is_accepted_by_cli_parser() {
 
 	let cli = MdtCli::parse_from(["mdt", "info"]);
 	match cli.command {
-		Some(Commands::Info) => {}
+		Some(Commands::Info { format }) => {
+			assert!(matches!(format, InfoOutputFormat::Text));
+		}
+		_ => panic!("expected Info command"),
+	}
+
+	let cli = MdtCli::parse_from(["mdt", "info", "--format", "json"]);
+	match cli.command {
+		Some(Commands::Info { format }) => {
+			assert!(matches!(format, InfoOutputFormat::Json));
+		}
 		_ => panic!("expected Info command"),
 	}
 }

--- a/mdt_cli/tests/snapshots.rs
+++ b/mdt_cli/tests/snapshots.rs
@@ -177,6 +177,35 @@ fn info_project() -> AnyEmptyResult {
 	Ok(())
 }
 
+#[test]
+fn info_empty_project_json() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!(
+			"info_empty_project_json",
+			mdt_cmd(tmp.path()).arg("info").arg("--format").arg("json")
+		);
+	});
+
+	Ok(())
+}
+
+#[test]
+fn info_project_json() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("info_project", tmp.path());
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!(
+			"info_project_json",
+			mdt_cmd(tmp.path()).arg("info").arg("--format").arg("json")
+		);
+	});
+
+	Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // check output formats: text (default), json, github
 // ---------------------------------------------------------------------------

--- a/mdt_cli/tests/snapshots/snapshots__info_empty_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_empty_project_json.snap
@@ -1,0 +1,53 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 185
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpXXVXV2
+    - info
+    - "--format"
+    - json
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "project": {
+    "root": "[TEMP_DIR]",
+    "resolved_config": "none"
+  },
+  "blocks": {
+    "providers": 0,
+    "consumers": 0,
+    "orphan_consumers": 0,
+    "unused_providers": 0
+  },
+  "data": {
+    "namespace_count": 0,
+    "namespaces": []
+  },
+  "templates": {
+    "file_count": 0,
+    "configured_dirs": [],
+    "canonical_hints": [
+      ".templates/",
+      "docs/templates/",
+      "shared/templates/",
+      "templates/"
+    ],
+    "discovered_files": []
+  },
+  "diagnostics": {
+    "total": 0,
+    "errors": 0,
+    "warnings": 0,
+    "missing_provider_count": 0,
+    "missing_provider_names": []
+  }
+}
+
+----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
@@ -1,0 +1,74 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 203
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpnMBFFI
+    - info
+    - "--format"
+    - json
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "project": {
+    "root": "[TEMP_DIR]",
+    "resolved_config": "[TEMP_DIR]/mdt.toml"
+  },
+  "blocks": {
+    "providers": 2,
+    "consumers": 2,
+    "orphan_consumers": 1,
+    "unused_providers": 1
+  },
+  "data": {
+    "namespace_count": 2,
+    "namespaces": [
+      {
+        "namespace": "meta",
+        "path": "meta.toml",
+        "format": "toml",
+        "explicit_format": false
+      },
+      {
+        "namespace": "pkg",
+        "path": "package.json",
+        "format": "json",
+        "explicit_format": false
+      }
+    ]
+  },
+  "templates": {
+    "file_count": 2,
+    "configured_dirs": [
+      "shared/templates",
+      "templates"
+    ],
+    "canonical_hints": [
+      ".templates/",
+      "docs/templates/",
+      "shared/templates/",
+      "templates/"
+    ],
+    "discovered_files": [
+      "templates/extra.t.md",
+      "templates/main.t.md"
+    ]
+  },
+  "diagnostics": {
+    "total": 1,
+    "errors": 1,
+    "warnings": 0,
+    "missing_provider_count": 1,
+    "missing_provider_names": [
+      "missing_block"
+    ]
+  }
+}
+
+----- stderr -----


### PR DESCRIPTION
## Summary
Implements the first Phase 5 item from #74 by adding structured JSON output for `mdt info` (#75), while preserving the current text output as the default.

## Problem
`mdt info` was text-only, which made automation and tool integration rely on fragile text parsing.

## What changed
### 1) CLI command model
- Updated `Commands::Info` to accept a `format` argument:
  - `mdt info` (default text)
  - `mdt info --format json`
- Added `InfoOutputFormat` enum with:
  - `text`
  - `json`

### 2) `mdt info` output implementation
- Refactored `run_info` to build a structured report model and render either:
  - human-readable text (existing behavior retained)
  - pretty-printed JSON for machine consumption
- Added format metadata for each data namespace in JSON output:
  - inferred format from extension when not explicitly configured
  - `explicit_format` boolean

### 3) Data/config summary improvements
- Extended CLI-side config summary with structured `DataSourceSummary` entries:
  - namespace
  - path
  - format
  - explicit/inferred source

### 4) Tests
- CLI parser coverage (`mdt_cli/tests/check.rs`):
  - verifies `mdt info` defaults to `text`
  - verifies `mdt info --format json` parses as `json`
- Added new e2e snapshot tests (`mdt_cli/tests/snapshots.rs`):
  - `info_empty_project_json`
  - `info_project_json`

### 5) Dependency update
- Added `serde` derive dependency in `mdt_cli` to serialize JSON report structs.

## JSON shape
The new JSON response includes:
- `project`: root and resolved config
- `blocks`: provider/consumer/orphan/unused counts
- `data`: namespace count + per-namespace metadata
- `templates`: configured dirs, discovered files, canonical hints
- `diagnostics`: totals + missing provider names

## Backward compatibility
- `mdt info` remains text by default.
- No behavioral changes to `check`/`update` scanning logic.

## Validation run locally
- `cargo test -p mdt_cli -q`
- `cargo test -q`
- `dprint check`
- `cargo run --bin mdt -- check`

All passed.

## Related issues
- Closes #75
- Part of #74
