### PR TITLE
feat(cli): add mdt doctor project health command

### DIFF
--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -14,7 +14,8 @@ use clap::ValueEnum;
 	              template tags to define content once and distribute it to multiple locations — \
 	              markdown files, code comments, READMEs, and more.\n\nQuick start:\n  mdt init    \
 	              Create a template file\n  mdt update  Sync all consumer blocks\n  mdt check   \
-	              Verify everything is up to date\n  mdt info    Inspect project diagnostics"
+	              Verify everything is up to date\n  mdt info    Inspect project diagnostics\n  \
+	              mdt doctor  Run project health checks"
 )]
 #[allow(clippy::struct_excessive_bools)]
 pub struct MdtCli {
@@ -121,6 +122,17 @@ pub enum Commands {
 		#[arg(long, value_enum, default_value_t = InfoOutputFormat::Text)]
 		format: InfoOutputFormat,
 	},
+	/// Run project health checks with actionable remediation hints.
+	///
+	/// Evaluates config discovery, data loading, provider/consumer linkage,
+	/// template directory conventions, and parser diagnostics. Exits with a
+	/// non-zero code when failing checks are present.
+	Doctor {
+		/// Output format for doctor results. Use `text` for human-readable
+		/// output or `json` for programmatic consumption.
+		#[arg(long, value_enum, default_value_t = DoctorOutputFormat::Text)]
+		format: DoctorOutputFormat,
+	},
 	/// Start the mdt language server (LSP).
 	///
 	/// Communicates over stdin/stdout using the Language Server Protocol.
@@ -156,6 +168,14 @@ pub enum OutputFormat {
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum InfoOutputFormat {
+	/// Human-readable text output with colors and formatting.
+	Text,
+	/// JSON output for programmatic consumption.
+	Json,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum DoctorOutputFormat {
 	/// Human-readable text output with colors and formatting.
 	Text,
 	/// JSON output for programmatic consumption.

--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use mdt_cli::Commands;
+use mdt_cli::DoctorOutputFormat;
 use mdt_cli::InfoOutputFormat;
 use mdt_cli::MdtCli;
 use mdt_core::AnyEmptyResult;
@@ -326,5 +327,26 @@ fn info_command_is_accepted_by_cli_parser() {
 			assert!(matches!(format, InfoOutputFormat::Json));
 		}
 		_ => panic!("expected Info command"),
+	}
+}
+
+#[test]
+fn doctor_command_is_accepted_by_cli_parser() {
+	use clap::Parser;
+
+	let cli = MdtCli::parse_from(["mdt", "doctor"]);
+	match cli.command {
+		Some(Commands::Doctor { format }) => {
+			assert!(matches!(format, DoctorOutputFormat::Text));
+		}
+		_ => panic!("expected Doctor command"),
+	}
+
+	let cli = MdtCli::parse_from(["mdt", "doctor", "--format", "json"]);
+	match cli.command {
+		Some(Commands::Doctor { format }) => {
+			assert!(matches!(format, DoctorOutputFormat::Json));
+		}
+		_ => panic!("expected Doctor command"),
 	}
 }

--- a/mdt_cli/tests/fixtures/doctor_duplicate_provider/one.t.md
+++ b/mdt_cli/tests/fixtures/doctor_duplicate_provider/one.t.md
@@ -1,0 +1,5 @@
+<!-- {@greeting} -->
+
+hello from one
+
+<!-- {/greeting} -->

--- a/mdt_cli/tests/fixtures/doctor_duplicate_provider/readme.md
+++ b/mdt_cli/tests/fixtures/doctor_duplicate_provider/readme.md
@@ -1,0 +1,5 @@
+<!-- {=greeting} -->
+
+hello
+
+<!-- {/greeting} -->

--- a/mdt_cli/tests/fixtures/doctor_duplicate_provider/two.t.md
+++ b/mdt_cli/tests/fixtures/doctor_duplicate_provider/two.t.md
@@ -1,0 +1,5 @@
+<!-- {@greeting} -->
+
+hello from two
+
+<!-- {/greeting} -->

--- a/mdt_cli/tests/snapshots.rs
+++ b/mdt_cli/tests/snapshots.rs
@@ -1153,3 +1153,65 @@ fn typescript_workspace_update_idempotent() -> AnyEmptyResult {
 
 	Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// doctor: project health diagnostics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn doctor_empty_project() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!("doctor_empty_project", mdt_cmd(tmp.path()).arg("doctor"));
+	});
+
+	Ok(())
+}
+
+#[test]
+fn doctor_empty_project_json() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!(
+			"doctor_empty_project_json",
+			mdt_cmd(tmp.path())
+				.arg("doctor")
+				.arg("--format")
+				.arg("json")
+		);
+	});
+
+	Ok(())
+}
+
+#[test]
+fn doctor_info_project_fails() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("info_project", tmp.path());
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!(
+			"doctor_info_project_fails",
+			mdt_cmd(tmp.path()).arg("doctor")
+		);
+	});
+
+	Ok(())
+}
+
+#[test]
+fn doctor_duplicate_provider_fails() -> AnyEmptyResult {
+	let tmp = tempfile::tempdir()?;
+	copy_fixture("doctor_duplicate_provider", tmp.path());
+
+	with_redacted_paths(tmp.path(), || {
+		assert_cmd_snapshot!(
+			"doctor_duplicate_provider_fails",
+			mdt_cmd(tmp.path()).arg("doctor")
+		);
+	});
+
+	Ok(())
+}

--- a/mdt_cli/tests/snapshots/snapshots__doctor_duplicate_provider_fails.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_duplicate_provider_fails.snap
@@ -1,0 +1,31 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 1207
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmppy1uCY
+    - doctor
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+mdt doctor
+[WARN] Config Discovery       no config file found (using defaults)
+       hint: create `mdt.toml`, `.mdt.toml`, or `.config/mdt.toml` to define data and scan rules
+[SKIP] Data Sources           skipped because no valid config was loaded
+       hint: add a config file to enable explicit data source validation
+[PASS] Template Layout        using default template discovery (`*.t.md`)
+[FAIL] Duplicate Providers    provider `greeting` is declared in `[TEMP_DIR]/one.t.md` and `[TEMP_DIR]/two.t.md`
+       hint: rename one provider to a unique name; provider names must be globally unique
+[SKIP] Missing Providers      skipped because project scan did not complete
+[SKIP] Orphan Consumers       skipped because project scan did not complete
+[SKIP] Unused Providers       skipped because project scan did not complete
+[SKIP] Parser Diagnostics     skipped because project scan did not complete
+
+summary: 1 pass, 1 warn, 1 fail, 5 skip
+
+----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__doctor_empty_project.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_empty_project.snap
@@ -1,0 +1,30 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 1166
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpyrhrWI
+    - doctor
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+mdt doctor
+[WARN] Config Discovery       no config file found (using defaults)
+       hint: create `mdt.toml`, `.mdt.toml`, or `.config/mdt.toml` to define data and scan rules
+[SKIP] Data Sources           skipped because no valid config was loaded
+       hint: add a config file to enable explicit data source validation
+[PASS] Template Layout        using default template discovery (`*.t.md`)
+[PASS] Duplicate Providers    provider names are unique
+[PASS] Missing Providers      all consumer blocks resolve to providers
+[PASS] Orphan Consumers       no orphan consumer blocks found
+[PASS] Unused Providers       all providers have at least one consumer
+[PASS] Parser Diagnostics     no parser diagnostics found
+
+summary: 6 pass, 1 warn, 0 fail, 1 skip
+
+----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__doctor_empty_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_empty_project_json.snap
@@ -1,0 +1,86 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 1177
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmph4nWNV
+    - doctor
+    - "--format"
+    - json
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+{
+  "ok": true,
+  "summary": {
+    "pass": 6,
+    "warn": 1,
+    "fail": 0,
+    "skip": 1
+  },
+  "checks": [
+    {
+      "id": "config_discovery",
+      "title": "Config Discovery",
+      "status": "warn",
+      "message": "no config file found (using defaults)",
+      "hint": "create `mdt.toml`, `.mdt.toml`, or `.config/mdt.toml` to define data and scan rules"
+    },
+    {
+      "id": "data_sources",
+      "title": "Data Sources",
+      "status": "skip",
+      "message": "skipped because no valid config was loaded",
+      "hint": "add a config file to enable explicit data source validation"
+    },
+    {
+      "id": "template_layout",
+      "title": "Template Layout",
+      "status": "pass",
+      "message": "using default template discovery (`*.t.md`)",
+      "hint": null
+    },
+    {
+      "id": "duplicate_providers",
+      "title": "Duplicate Providers",
+      "status": "pass",
+      "message": "provider names are unique",
+      "hint": null
+    },
+    {
+      "id": "missing_providers",
+      "title": "Missing Providers",
+      "status": "pass",
+      "message": "all consumer blocks resolve to providers",
+      "hint": null
+    },
+    {
+      "id": "orphan_consumers",
+      "title": "Orphan Consumers",
+      "status": "pass",
+      "message": "no orphan consumer blocks found",
+      "hint": null
+    },
+    {
+      "id": "unused_providers",
+      "title": "Unused Providers",
+      "status": "pass",
+      "message": "all providers have at least one consumer",
+      "hint": null
+    },
+    {
+      "id": "parser_diagnostics",
+      "title": "Parser Diagnostics",
+      "status": "pass",
+      "message": "no parser diagnostics found",
+      "hint": null
+    }
+  ]
+}
+
+----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__doctor_info_project_fails.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_info_project_fails.snap
@@ -1,0 +1,33 @@
+---
+source: mdt_cli/tests/snapshots.rs
+assertion_line: 1192
+info:
+  program: mdt
+  args:
+    - "--path"
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp0HzGJR
+    - doctor
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+mdt doctor
+[PASS] Config Discovery       resolved config at [TEMP_DIR]/mdt.toml
+[PASS] Data Sources           loaded 2 namespace(s) successfully
+[WARN] Template Layout        configured template directories: templates, shared/templates
+       hint: prefer `.templates/` as the canonical location for template files
+[PASS] Duplicate Providers    provider names are unique
+[FAIL] Missing Providers      1 missing provider name(s): missing_block
+       hint: define the missing provider blocks in template files or rename orphan consumers
+[FAIL] Orphan Consumers       found 1 orphan consumer block(s)
+       hint: add matching provider blocks or remove stale consumer references
+[WARN] Unused Providers       found 1 unused provider block(s)
+       hint: reuse existing providers from consumer blocks or remove dead templates
+[FAIL] Parser Diagnostics     1 error(s), 0 warning(s)
+       hint: fix malformed blocks and invalid transformers reported by `mdt check`
+
+summary: 3 pass, 2 warn, 3 fail, 0 skip
+
+----- stderr -----


### PR DESCRIPTION
## Summary
Implements issue #76 by introducing a new `mdt doctor` command that provides a project health report with actionable diagnostics in both human-friendly and machine-friendly formats.

Closes #76.
Part of #74.

## What changed

### 1) New `doctor` CLI command
- Added `doctor` subcommand to CLI parser.
- Added `--format <text|json>` output mode (`text` default).
- Added help text entry for `mdt doctor`.

### 2) Health checks implemented
`mdt doctor` now evaluates and reports:
- Config discovery (including support for `mdt.toml`, `.mdt.toml`, `.config/mdt.toml`).
- Data source load/parse status.
- Template layout guidance (canonical `.templates/` recommendation).
- Duplicate provider detection.
- Missing providers.
- Orphan consumers.
- Unused providers.
- Parser diagnostics summary.

Each check includes:
- deterministic status (`pass`/`warn`/`fail`/`skip`),
- concise message,
- remediation hint when relevant.

### 3) Exit behavior for automation
- `mdt doctor` exits non-zero when one or more failing checks are present.
- `--format json` includes:
  - `ok` boolean,
  - summary counts (`pass/warn/fail/skip`),
  - detailed check entries for downstream tooling.

## Tests added

### Parser/integration tests
- `doctor_command_is_accepted_by_cli_parser`

### Snapshot/e2e coverage
- `doctor_empty_project`
- `doctor_empty_project_json`
- `doctor_info_project_fails`
- `doctor_duplicate_provider_fails`

### Fixtures
- Added dedicated duplicate-provider fixture project for failing-health scenarios.

## Validation run
Executed locally on this branch:
- `dprint check`
- `cargo clippy --all-features`
- `cargo nextest run`
- `cargo test --doc`
- `cargo run --bin mdt -- check`
- `cargo test -p mdt_cli -q`

All commands passed.

## Notes
- This command is reporting-only (no auto-fix behavior).
- JSON output is intentionally stable for future MCP/CI integrations.
