### PR TITLE
chore(test): migrate assert_cmd cargo_bin usage

### DIFF
--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -1,4 +1,5 @@
-use assert_cmd::Command;
+mod common;
+
 use mdt_cli::Commands;
 use mdt_cli::InfoOutputFormat;
 use mdt_cli::MdtCli;
@@ -21,7 +22,7 @@ fn check_passes_when_up_to_date() -> AnyEmptyResult {
 		"# Readme\n\n<!-- {=greeting} -->\n\nHello world!\n\n<!-- {/greeting} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	let _ = cmd
 		.env("NO_COLOR", "1")
 		.arg("check")
@@ -50,7 +51,7 @@ fn check_fails_when_stale() -> AnyEmptyResult {
 		"# Readme\n\n<!-- {=greeting} -->\n\nOld content.\n\n<!-- {/greeting} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -68,7 +69,7 @@ fn check_with_no_blocks() -> AnyEmptyResult {
 
 	std::fs::write(tmp.path().join("readme.md"), "# Just a readme\n")?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -93,7 +94,7 @@ fn check_verbose_shows_provider_count() -> AnyEmptyResult {
 		"<!-- {=block} -->\n\ncontent\n\n<!-- {/block} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--verbose")
@@ -117,7 +118,7 @@ fn check_warns_missing_provider() -> AnyEmptyResult {
 		"<!-- {=orphan} -->\n\nstuff\n\n<!-- {/orphan} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -144,7 +145,7 @@ fn check_stale_shows_block_name_and_file() -> AnyEmptyResult {
 		"<!-- {=myBlock} -->\n\nold\n\n<!-- {/myBlock} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -171,7 +172,7 @@ fn check_multiple_stale_blocks() -> AnyEmptyResult {
 		"<!-- {=a} -->\n\nold a\n\n<!-- {/a} -->\n\n<!-- {=b} -->\n\nold b\n\n<!-- {/b} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -207,7 +208,7 @@ fn check_warns_undefined_template_variables() -> AnyEmptyResult {
 		"<!-- {=install} -->\n\nnpm install \n\n<!-- {/install} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -242,7 +243,7 @@ fn check_no_warnings_for_valid_template_variables() -> AnyEmptyResult {
 		"<!-- {=install} -->\n\nnpm install my-lib@1.0.0\n\n<!-- {/install} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -295,7 +296,7 @@ fn check_watch_flag_accepted_by_binary() -> AnyEmptyResult {
 	// We cannot test the full watch loop (it runs forever), but we can verify
 	// the binary accepts --watch without crashing. Output timing can be flaky
 	// under piped test execution, so we avoid asserting on stdout contents.
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	let _ = cmd
 		.env("NO_COLOR", "1")
 		.arg("check")

--- a/mdt_cli/tests/common.rs
+++ b/mdt_cli/tests/common.rs
@@ -1,0 +1,8 @@
+use assert_cmd::Command;
+use insta_cmd::get_cargo_bin;
+
+pub fn mdt_cmd() -> Command {
+	let mut cmd = Command::new(get_cargo_bin("mdt"));
+	cmd.env("NO_COLOR", "1");
+	cmd
+}

--- a/mdt_cli/tests/config_resolution.rs
+++ b/mdt_cli/tests/config_resolution.rs
@@ -1,4 +1,5 @@
-use assert_cmd::Command;
+mod common;
+
 use mdt_core::AnyEmptyResult;
 
 #[test]
@@ -8,7 +9,7 @@ fn info_resolves_dot_mdt_toml() -> AnyEmptyResult {
 
 	let expected_path = tmp.path().join(".mdt.toml").display().to_string();
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("info")
 		.arg("--path")
 		.arg(tmp.path())
@@ -28,7 +29,7 @@ fn info_resolves_dot_config_mdt_toml() -> AnyEmptyResult {
 
 	let expected_path = tmp.path().join(".config/mdt.toml").display().to_string();
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("info")
 		.arg("--path")
 		.arg(tmp.path())
@@ -50,7 +51,7 @@ fn info_prefers_mdt_toml_over_other_candidates() -> AnyEmptyResult {
 
 	let expected_path = tmp.path().join("mdt.toml").display().to_string();
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("info")
 		.arg("--path")
 		.arg(tmp.path())

--- a/mdt_cli/tests/init.rs
+++ b/mdt_cli/tests/init.rs
@@ -1,10 +1,11 @@
-use assert_cmd::Command;
+mod common;
+
 use mdt_core::AnyEmptyResult;
 
 #[test]
 fn can_init() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	let assert = cmd
 		.arg("init")
 		.arg("--path")
@@ -41,7 +42,7 @@ fn init_does_not_overwrite() -> AnyEmptyResult {
 	let config_path = tmp.path().join("mdt.toml");
 	std::fs::write(&config_path, "existing config")?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	let assert = cmd
 		.arg("init")
 		.arg("--path")
@@ -63,7 +64,7 @@ fn init_does_not_overwrite() -> AnyEmptyResult {
 fn init_creates_valid_template() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("init")
 		.arg("--path")
 		.arg(tmp.path())
@@ -83,7 +84,7 @@ fn init_creates_valid_template() -> AnyEmptyResult {
 fn init_shows_next_steps() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("init")
 		.arg("--path")
 		.arg(tmp.path())
@@ -99,7 +100,7 @@ fn init_shows_next_steps() -> AnyEmptyResult {
 fn init_creates_both_template_and_config() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("init")
 		.arg("--path")
 		.arg(tmp.path())
@@ -138,7 +139,7 @@ fn init_creates_config_when_template_exists() -> AnyEmptyResult {
 	let template_path = tmp.path().join("template.t.md");
 	std::fs::write(&template_path, "existing template")?;
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.arg("init")
 		.arg("--path")
 		.arg(tmp.path())

--- a/mdt_cli/tests/typescript_workspace.rs
+++ b/mdt_cli/tests/typescript_workspace.rs
@@ -1,6 +1,7 @@
+mod common;
+
 use std::path::Path;
 
-use assert_cmd::Command;
 use mdt_core::AnyEmptyResult;
 
 fn copy_fixture(dest: &Path) {
@@ -33,7 +34,7 @@ fn update_typescript_workspace() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 	copy_fixture(tmp.path());
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -78,7 +79,7 @@ fn check_typescript_workspace_after_update() -> AnyEmptyResult {
 	copy_fixture(tmp.path());
 
 	// First update
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -87,7 +88,7 @@ fn check_typescript_workspace_after_update() -> AnyEmptyResult {
 		.success();
 
 	// Then check — should pass
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -105,7 +106,7 @@ fn check_typescript_workspace_stale() -> AnyEmptyResult {
 	copy_fixture(tmp.path());
 
 	// Check without updating — should fail because content is stale
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.env("NO_COLOR", "1")
 		.arg("check")
 		.arg("--path")
@@ -123,7 +124,7 @@ fn dry_run_typescript_workspace() -> AnyEmptyResult {
 
 	let readme_before = std::fs::read_to_string(tmp.path().join("readme.md"))?;
 
-	Command::cargo_bin("mdt")?
+	common::mdt_cmd()
 		.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--dry-run")

--- a/mdt_cli/tests/update.rs
+++ b/mdt_cli/tests/update.rs
@@ -1,4 +1,5 @@
-use assert_cmd::Command;
+mod common;
+
 use mdt_core::AnyEmptyResult;
 
 #[test]
@@ -17,7 +18,7 @@ fn update_replaces_stale_content() -> AnyEmptyResult {
 		"# Readme\n\n<!-- {=greeting} -->\n\nOld content.\n\n<!-- {/greeting} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -47,7 +48,7 @@ fn update_noop_when_in_sync() -> AnyEmptyResult {
 		"# Readme\n\n<!-- {=greeting} -->\n\nHello world!\n\n<!-- {/greeting} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -72,7 +73,7 @@ fn update_dry_run_does_not_write() -> AnyEmptyResult {
 		"# Readme\n\n<!-- {=greeting} -->\n\nOld content.\n\n<!-- {/greeting} -->\n";
 	std::fs::write(tmp.path().join("readme.md"), consumer_content)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--dry-run")
@@ -103,7 +104,7 @@ fn update_with_transformers() -> AnyEmptyResult {
 		"<!-- {=docs|trim} -->\n\nold\n\n<!-- {/docs} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -130,7 +131,7 @@ fn update_verbose_shows_files() -> AnyEmptyResult {
 		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--verbose")
@@ -152,7 +153,7 @@ fn update_warns_missing_provider() -> AnyEmptyResult {
 		"<!-- {=orphan} -->\n\nstuff\n\n<!-- {/orphan} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -179,7 +180,7 @@ fn update_multiple_blocks_in_one_file() -> AnyEmptyResult {
 		"<!-- {=a} -->\n\nold\n\n<!-- {/a} -->\n\n<!-- {=b} -->\n\nold\n\n<!-- {/b} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -209,7 +210,7 @@ fn update_dry_run_shows_file_list() -> AnyEmptyResult {
 		"<!-- {=block} -->\n\nold\n\n<!-- {/block} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--dry-run")
@@ -244,7 +245,7 @@ fn update_with_config_and_data() -> AnyEmptyResult {
 		"<!-- {=install} -->\n\nold\n\n<!-- {/install} -->\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -286,7 +287,7 @@ old
 "#,
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -348,7 +349,7 @@ fn update_multiline_idempotent_after_write() -> AnyEmptyResult {
 	)?;
 
 	// First update
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -363,7 +364,7 @@ fn update_multiline_idempotent_after_write() -> AnyEmptyResult {
 	assert!(after_first.contains("\n[ci]:"));
 
 	// Second update — should be idempotent
-	let mut cmd2 = Command::cargo_bin("mdt")?;
+	let mut cmd2 = common::mdt_cmd();
 	cmd2.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")
@@ -395,7 +396,7 @@ fn update_preserves_surrounding_content() -> AnyEmptyResult {
 		 -->\n\nParagraph after.\n",
 	)?;
 
-	let mut cmd = Command::cargo_bin("mdt")?;
+	let mut cmd = common::mdt_cmd();
 	cmd.env("NO_COLOR", "1")
 		.arg("update")
 		.arg("--path")


### PR DESCRIPTION
## Summary
Implements #77 by removing deprecated `assert_cmd::Command::cargo_bin` usage from CLI integration/e2e tests and replacing it with a shared, non-deprecated command builder.

Closes #77.
Part of #74.

## Motivation
`Command::cargo_bin("mdt")` currently emits deprecation warnings about compatibility with custom cargo build directories. This warning noise obscures real failures and is a future break risk.

## What changed

### 1) Added shared command helper
- New file: `mdt_cli/tests/common.rs`
- Introduced `common::mdt_cmd()` which:
  - builds command via `Command::new(get_cargo_bin("mdt"))`
  - sets `NO_COLOR=1` consistently for stable assertion output

### 2) Migrated all deprecated call sites
Replaced all CLI test invocations of `Command::cargo_bin("mdt")` with `common::mdt_cmd()` in:
- `mdt_cli/tests/check.rs`
- `mdt_cli/tests/config_resolution.rs`
- `mdt_cli/tests/init.rs`
- `mdt_cli/tests/typescript_workspace.rs`
- `mdt_cli/tests/update.rs`

### 3) Behavior preserved
- Assertions, command args, and expected output paths are unchanged.
- This is a test harness modernization only; no production code changes.

## Validation
Executed locally on this branch:
- `dprint check`
- `cargo test -p mdt_cli -q`
- `cargo clippy --all-features`
- `cargo nextest run`
- `cargo test --doc`
- `cargo run --bin mdt -- check`

All commands passed.

## Result
- Deprecated `cargo_bin` warnings are removed from CLI test runs.
- Test setup is now centralized and easier to maintain.
