### PR TITLE
feat(core): phase B incremental file-level cache reuse

### DIFF
--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -57,7 +57,7 @@ fn check_writes_project_cache_artifact() -> AnyEmptyResult {
 		.assert()
 		.success();
 
-	let cache_path = tmp.path().join(".mdt").join("cache").join("index-v1.json");
+	let cache_path = tmp.path().join(".mdt").join("cache").join("index-v2.json");
 	assert!(
 		cache_path.is_file(),
 		"expected cache file at {}",

--- a/mdt_core/src/index_cache.rs
+++ b/mdt_core/src/index_cache.rs
@@ -7,10 +7,13 @@ use std::time::UNIX_EPOCH;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::project::ConsumerEntry;
 use crate::project::Project;
+use crate::project::ProjectDiagnostic;
+use crate::project::ProviderEntry;
 
-pub(crate) const CACHE_SCHEMA_VERSION: u32 = 1;
-const CACHE_FILE_NAME: &str = "index-v1.json";
+pub(crate) const CACHE_SCHEMA_VERSION: u32 = 2;
+const CACHE_FILE_NAME: &str = "index-v2.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct FileFingerprint {
@@ -19,10 +22,18 @@ pub(crate) struct FileFingerprint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedFileData {
+	pub providers: Vec<ProviderEntry>,
+	pub consumers: Vec<ConsumerEntry>,
+	pub diagnostics: Vec<ProjectDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ProjectIndexCache {
 	pub schema_version: u32,
 	pub project_key: String,
 	pub files: BTreeMap<String, FileFingerprint>,
+	pub file_data: BTreeMap<String, CachedFileData>,
 	pub project: Project,
 }
 
@@ -30,12 +41,14 @@ impl ProjectIndexCache {
 	pub(crate) fn new(
 		project_key: String,
 		files: BTreeMap<String, FileFingerprint>,
+		file_data: BTreeMap<String, CachedFileData>,
 		project: Project,
 	) -> Self {
 		Self {
 			schema_version: CACHE_SCHEMA_VERSION,
 			project_key,
 			files,
+			file_data,
 			project,
 		}
 	}


### PR DESCRIPTION
## Summary
Implements **Phase B incremental cache reuse** from #83 (and design issue #78).

This moves cache usage from all-or-nothing project reuse to **file-level selective reuse**:
- unchanged files reuse cached parse outputs,
- changed files are reparsed,
- deleted files are removed from cache on rewrite.

## Base branch
This PR is intentionally stacked on:
- `feat/project-index-cache-phase-a` (PR #82)

So the diff here focuses only on Phase B behavior.

## Problem
Phase A only returned cached results when every file fingerprint matched. A single file edit forced a full project reparse.

## What changed
### 1) Cache schema upgraded to v2
- `mdt_core/src/index_cache.rs`
- `CACHE_SCHEMA_VERSION` bumped from `1` to `2`
- cache file moved to `.mdt/cache/index-v2.json`
- added per-file payload map:
  - `file_data: BTreeMap<String, CachedFileData>`
  - `CachedFileData` contains per-file providers, consumers, diagnostics

### 2) Incremental scan flow in `scan_project_with_options`
- `mdt_core/src/project.rs`
- Added per-file parse utility:
  - `parse_file_for_scan`
- Added deterministic project rebuild from merged file data:
  - `build_project_from_file_data`
- Added parse diagnostic mapping helper:
  - `parse_diagnostic_to_project`

Runtime behavior now:
1. collect candidate files + fingerprints
2. load cache (if schema + project key match)
3. if all fingerprints match, return cached project (Phase A fast path)
4. otherwise, for each file:
   - if fingerprint unchanged and cached file entry exists, reuse entry
   - else parse file fresh
5. rebuild global providers/consumers/diagnostics from merged entries
6. save updated cache (deleted files are naturally compacted because they are not emitted in the new `file_data`/`files` maps)

### 3) Test updates
- `mdt_core/src/__tests.rs`
- Added:
  - `scan_project_reuses_unchanged_files_when_other_files_change`
  - `scan_project_removes_deleted_files_from_cache`
- Existing cache tests retained.

### 4) CLI e2e cache artifact path update
- `mdt_cli/tests/check.rs`
- Updated expected cache file from `index-v1.json` to `index-v2.json`

## Correctness notes
- Duplicate provider detection remains global and deterministic when rebuilding merged project state.
- Cache is still treated as an optimization: schema/key mismatch falls back to fresh parse.

## Validation
Run locally:
- `dprint check`
- `cargo check --tests -p mdt_core -p mdt_cli`
- `cargo check --all-targets`

Note:
- Full local `cargo test` linking is blocked in this terminal environment due unaccepted local Xcode license (`xcrun` exits 69). CI on GitHub Actions will validate full test/link execution.

Related:
- #83
- #78
