### PR TITLE
feat(core): phase C optional cache content-hash verification

### DIFF
--- a/mdt_core/src/index_cache.rs
+++ b/mdt_core/src/index_cache.rs
@@ -19,6 +19,7 @@ const CACHE_FILE_NAME: &str = "index-v2.json";
 pub(crate) struct FileFingerprint {
 	pub size: u64,
 	pub modified_unix_ms: u64,
+	pub content_hash: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,7 +66,10 @@ pub(crate) fn relative_file_key(root: &Path, file: &Path) -> String {
 		.replace('\\', "/")
 }
 
-pub(crate) fn build_file_fingerprint(metadata: &Metadata) -> FileFingerprint {
+pub(crate) fn build_file_fingerprint(
+	metadata: &Metadata,
+	content_hash: Option<u64>,
+) -> FileFingerprint {
 	let modified_unix_ms = metadata
 		.modified()
 		.ok()
@@ -76,6 +80,7 @@ pub(crate) fn build_file_fingerprint(metadata: &Metadata) -> FileFingerprint {
 	FileFingerprint {
 		size: metadata.len(),
 		modified_unix_ms,
+		content_hash,
 	}
 }
 

--- a/mdt_core/src/project.rs
+++ b/mdt_core/src/project.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -49,6 +52,8 @@ pub struct ScanOptions {
 	pub markdown_codeblocks: CodeBlockFilter,
 	/// Block names to exclude from scanning.
 	pub excluded_blocks: Vec<String>,
+	/// Whether to include content hashes in file fingerprints for cache validation.
+	pub cache_verify_hash: bool,
 }
 
 impl Default for ScanOptions {
@@ -61,6 +66,7 @@ impl Default for ScanOptions {
 			disable_gitignore: false,
 			markdown_codeblocks: CodeBlockFilter::default(),
 			excluded_blocks: Vec::new(),
+			cache_verify_hash: false,
 		}
 	}
 }
@@ -84,6 +90,7 @@ impl ScanOptions {
 			.map(|c| c.exclude.markdown_codeblocks.clone())
 			.unwrap_or_default();
 		let excluded_blocks = config.map(|c| c.exclude.blocks.clone()).unwrap_or_default();
+		let cache_verify_hash = std::env::var_os("MDT_CACHE_VERIFY_HASH").is_some();
 		let include_set = build_glob_set(include_patterns);
 
 		Self {
@@ -94,6 +101,7 @@ impl ScanOptions {
 			disable_gitignore,
 			markdown_codeblocks,
 			excluded_blocks,
+			cache_verify_hash,
 		}
 	}
 }
@@ -290,13 +298,14 @@ fn build_project_cache_key(options: &ScanOptions) -> String {
 
 	format!(
 		"index-v2|max={}|disable_gitignore={}|markdown={:?\
-		 }|exclude={}|templates={}|excluded_blocks={}",
+		 }|exclude={}|templates={}|excluded_blocks={}|cache_verify_hash={}",
 		options.max_file_size,
 		options.disable_gitignore,
 		options.markdown_codeblocks,
 		exclude_patterns.join("\u{1f}"),
 		template_paths.join("\u{1f}"),
 		excluded_blocks.join("\u{1f}"),
+		options.cache_verify_hash,
 	)
 }
 
@@ -304,6 +313,7 @@ fn collect_file_fingerprints(
 	root: &Path,
 	files: &[PathBuf],
 	max_file_size: u64,
+	verify_hash: bool,
 ) -> MdtResult<BTreeMap<String, FileFingerprint>> {
 	let mut fingerprints = BTreeMap::new();
 
@@ -317,13 +327,26 @@ fn collect_file_fingerprints(
 			});
 		}
 
+		let content_hash = if verify_hash {
+			Some(hash_file_contents(file)?)
+		} else {
+			None
+		};
+
 		fingerprints.insert(
 			index_cache::relative_file_key(root, file),
-			index_cache::build_file_fingerprint(&metadata),
+			index_cache::build_file_fingerprint(&metadata, content_hash),
 		);
 	}
 
 	Ok(fingerprints)
+}
+
+fn hash_file_contents(path: &Path) -> MdtResult<u64> {
+	let bytes = std::fs::read(path)?;
+	let mut hasher = DefaultHasher::new();
+	bytes.hash(&mut hasher);
+	Ok(hasher.finish())
 }
 
 fn parse_diagnostic_to_project(file: &Path, diag: ParseDiagnostic) -> ProjectDiagnostic {
@@ -531,7 +554,12 @@ pub fn scan_project_with_options(root: &Path, options: &ScanOptions) -> MdtResul
 	}
 
 	let project_key = build_project_cache_key(options);
-	let file_fingerprints = collect_file_fingerprints(root, &files, options.max_file_size)?;
+	let file_fingerprints = collect_file_fingerprints(
+		root,
+		&files,
+		options.max_file_size,
+		options.cache_verify_hash,
+	)?;
 	let cache = index_cache::load(root, &project_key);
 
 	if let Some(cached) = &cache {


### PR DESCRIPTION
## Summary
Implements **Phase C cache hardening** from #85 with optional content-hash verification in cache fingerprints.

## Base branch
This PR is intentionally stacked on:
- `feat/project-index-cache-phase-b` (PR #84)

## Problem
Phase B fingerprints use `(size, mtime)` only. In edge cases, metadata can appear unchanged even when contents differ.

## What changed
### 1) Optional content hash in file fingerprints
- `mdt_core/src/index_cache.rs`
- `FileFingerprint` now includes:
  - `content_hash: Option<u64>`
- `build_file_fingerprint` updated to accept optional hash input.

### 2) New scan option for hash verification mode
- `mdt_core/src/project.rs`
- `ScanOptions` now has:
  - `cache_verify_hash: bool` (default `false`)
- `ScanOptions::from_config` enables this mode when env var `MDT_CACHE_VERIFY_HASH` is set.

### 3) Fingerprint computation and cache key hardening
- Added file-content hashing helper for opt-in mode.
- `collect_file_fingerprints` now computes content hashes when enabled.
- Project cache key now includes `cache_verify_hash` to prevent cross-mode cache reuse.

### 4) Tests
- `mdt_core/src/__tests.rs`
- Added:
  - `scan_project_cache_stores_content_hash_when_enabled`
  - `scan_project_hash_mismatch_invalidates_cache`

These validate both serialization of hash fingerprints and cache invalidation behavior when hash data diverges.

## Validation
Run locally:
- `dprint check`
- `cargo check --tests -p mdt_core -p mdt_cli`
- `cargo check --all-targets`

Note:
- Full local `cargo test` linking remains blocked in this terminal environment by unaccepted local Xcode license (`xcrun` exit 69). CI on GitHub Actions will validate full link/test execution.

Related:
- #85
- #78
