### PR TITLE
feat(core): phase B incremental file-level cache reuse

### DIFF
--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -57,7 +57,7 @@ fn check_writes_project_cache_artifact() -> AnyEmptyResult {
 		.assert()
 		.success();
 
-	let cache_path = tmp.path().join(".mdt").join("cache").join("index-v1.json");
+	let cache_path = tmp.path().join(".mdt").join("cache").join("index-v2.json");
 	assert!(
 		cache_path.is_file(),
 		"expected cache file at {}",

--- a/mdt_core/src/index_cache.rs
+++ b/mdt_core/src/index_cache.rs
@@ -7,10 +7,13 @@ use std::time::UNIX_EPOCH;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::project::ConsumerEntry;
 use crate::project::Project;
+use crate::project::ProjectDiagnostic;
+use crate::project::ProviderEntry;
 
-pub(crate) const CACHE_SCHEMA_VERSION: u32 = 1;
-const CACHE_FILE_NAME: &str = "index-v1.json";
+pub(crate) const CACHE_SCHEMA_VERSION: u32 = 2;
+const CACHE_FILE_NAME: &str = "index-v2.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct FileFingerprint {
@@ -19,10 +22,18 @@ pub(crate) struct FileFingerprint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedFileData {
+	pub providers: Vec<ProviderEntry>,
+	pub consumers: Vec<ConsumerEntry>,
+	pub diagnostics: Vec<ProjectDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ProjectIndexCache {
 	pub schema_version: u32,
 	pub project_key: String,
 	pub files: BTreeMap<String, FileFingerprint>,
+	pub file_data: BTreeMap<String, CachedFileData>,
 	pub project: Project,
 }
 
@@ -30,12 +41,14 @@ impl ProjectIndexCache {
 	pub(crate) fn new(
 		project_key: String,
 		files: BTreeMap<String, FileFingerprint>,
+		file_data: BTreeMap<String, CachedFileData>,
 		project: Project,
 	) -> Self {
 		Self {
 			schema_version: CACHE_SCHEMA_VERSION,
 			project_key,
 			files,
+			file_data,
 			project,
 		}
 	}


### PR DESCRIPTION
## Summary
Ports **Phase B incremental file-level cache reuse** to `main`.

## Why this PR exists
Phase B was previously merged in stacked form, but onto a non-`main` base branch. Since this repository uses squash merges, those stacked merges did not automatically land in `main`.

This PR applies the Phase B diff directly on top of current `main`.

## Scope
Implements #83 (and advances #78) by moving cache behavior from all-or-nothing reuse to selective file reuse:
- unchanged files reuse cached parse entries
- changed files are reparsed
- deleted files are removed when cache is rewritten

## Changes
- `mdt_core/src/index_cache.rs`
  - cache schema updated to v2
  - cache file path changed to `index-v2.json`
  - adds `CachedFileData` and `file_data` map in cache payload

- `mdt_core/src/project.rs`
  - adds per-file parse helper and diagnostic mapping helper
  - merges reused + reparsed file entries
  - rebuilds global project state from merged file entries
  - preserves duplicate-provider validation semantics

- `mdt_core/src/__tests.rs`
  - adds tests for mixed changed/unchanged reuse and deleted-file compaction

- `mdt_cli/tests/check.rs`
  - updates cache artifact expectation to `index-v2.json`

## Validation
Locally executed:
- `dprint check`
- `cargo check --tests -p mdt_core -p mdt_cli`
- `cargo check --all-targets`

Note: full local `cargo test` linking is blocked in this terminal environment by unaccepted local Xcode license (`xcrun` exit 69). CI will validate full link/test execution.

Related:
- #83
- #78
