### PR TITLE
feat(core): phase C optional cache content-hash verification

### DIFF
--- a/mdt_core/src/index_cache.rs
+++ b/mdt_core/src/index_cache.rs
@@ -19,6 +19,7 @@ const CACHE_FILE_NAME: &str = "index-v2.json";
 pub(crate) struct FileFingerprint {
 	pub size: u64,
 	pub modified_unix_ms: u64,
+	pub content_hash: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,7 +66,10 @@ pub(crate) fn relative_file_key(root: &Path, file: &Path) -> String {
 		.replace('\\', "/")
 }
 
-pub(crate) fn build_file_fingerprint(metadata: &Metadata) -> FileFingerprint {
+pub(crate) fn build_file_fingerprint(
+	metadata: &Metadata,
+	content_hash: Option<u64>,
+) -> FileFingerprint {
 	let modified_unix_ms = metadata
 		.modified()
 		.ok()
@@ -76,6 +80,7 @@ pub(crate) fn build_file_fingerprint(metadata: &Metadata) -> FileFingerprint {
 	FileFingerprint {
 		size: metadata.len(),
 		modified_unix_ms,
+		content_hash,
 	}
 }
 

--- a/mdt_core/src/project.rs
+++ b/mdt_core/src/project.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -49,6 +52,8 @@ pub struct ScanOptions {
 	pub markdown_codeblocks: CodeBlockFilter,
 	/// Block names to exclude from scanning.
 	pub excluded_blocks: Vec<String>,
+	/// Whether to include content hashes in file fingerprints for cache validation.
+	pub cache_verify_hash: bool,
 }
 
 impl Default for ScanOptions {
@@ -61,6 +66,7 @@ impl Default for ScanOptions {
 			disable_gitignore: false,
 			markdown_codeblocks: CodeBlockFilter::default(),
 			excluded_blocks: Vec::new(),
+			cache_verify_hash: false,
 		}
 	}
 }
@@ -84,6 +90,7 @@ impl ScanOptions {
 			.map(|c| c.exclude.markdown_codeblocks.clone())
 			.unwrap_or_default();
 		let excluded_blocks = config.map(|c| c.exclude.blocks.clone()).unwrap_or_default();
+		let cache_verify_hash = std::env::var_os("MDT_CACHE_VERIFY_HASH").is_some();
 		let include_set = build_glob_set(include_patterns);
 
 		Self {
@@ -94,6 +101,7 @@ impl ScanOptions {
 			disable_gitignore,
 			markdown_codeblocks,
 			excluded_blocks,
+			cache_verify_hash,
 		}
 	}
 }
@@ -290,13 +298,14 @@ fn build_project_cache_key(options: &ScanOptions) -> String {
 
 	format!(
 		"index-v2|max={}|disable_gitignore={}|markdown={:?\
-		 }|exclude={}|templates={}|excluded_blocks={}",
+		 }|exclude={}|templates={}|excluded_blocks={}|cache_verify_hash={}",
 		options.max_file_size,
 		options.disable_gitignore,
 		options.markdown_codeblocks,
 		exclude_patterns.join("\u{1f}"),
 		template_paths.join("\u{1f}"),
 		excluded_blocks.join("\u{1f}"),
+		options.cache_verify_hash,
 	)
 }
 
@@ -304,6 +313,7 @@ fn collect_file_fingerprints(
 	root: &Path,
 	files: &[PathBuf],
 	max_file_size: u64,
+	verify_hash: bool,
 ) -> MdtResult<BTreeMap<String, FileFingerprint>> {
 	let mut fingerprints = BTreeMap::new();
 
@@ -317,13 +327,26 @@ fn collect_file_fingerprints(
 			});
 		}
 
+		let content_hash = if verify_hash {
+			Some(hash_file_contents(file)?)
+		} else {
+			None
+		};
+
 		fingerprints.insert(
 			index_cache::relative_file_key(root, file),
-			index_cache::build_file_fingerprint(&metadata),
+			index_cache::build_file_fingerprint(&metadata, content_hash),
 		);
 	}
 
 	Ok(fingerprints)
+}
+
+fn hash_file_contents(path: &Path) -> MdtResult<u64> {
+	let bytes = std::fs::read(path)?;
+	let mut hasher = DefaultHasher::new();
+	bytes.hash(&mut hasher);
+	Ok(hasher.finish())
 }
 
 fn parse_diagnostic_to_project(file: &Path, diag: ParseDiagnostic) -> ProjectDiagnostic {
@@ -531,7 +554,12 @@ pub fn scan_project_with_options(root: &Path, options: &ScanOptions) -> MdtResul
 	}
 
 	let project_key = build_project_cache_key(options);
-	let file_fingerprints = collect_file_fingerprints(root, &files, options.max_file_size)?;
+	let file_fingerprints = collect_file_fingerprints(
+		root,
+		&files,
+		options.max_file_size,
+		options.cache_verify_hash,
+	)?;
 	let cache = index_cache::load(root, &project_key);
 
 	if let Some(cached) = &cache {


### PR DESCRIPTION
## Summary
Ports **Phase C optional content-hash verification** onto the Phase B-on-main branch.

## Why this PR exists
Phase C was previously merged in a stacked branch chain that didn’t directly target `main`. This PR keeps Phase C as a separate review/merge unit while depending on Phase B.

## Base branch
- `feat/project-index-cache-phase-b-main` (PR #87)

## Scope
Implements #85:
- optional `content_hash` in cache file fingerprints
- opt-in hash verification mode via `ScanOptions.cache_verify_hash`
- project cache key includes hash mode to prevent cross-mode reuse

## Changes
- `mdt_core/src/index_cache.rs`
  - `FileFingerprint.content_hash: Option<u64>`
  - `build_file_fingerprint` accepts optional hash

- `mdt_core/src/project.rs`
  - `ScanOptions.cache_verify_hash` added (default false)
  - `ScanOptions::from_config` enables hash mode via `MDT_CACHE_VERIFY_HASH`
  - `collect_file_fingerprints` computes hash when enabled
  - cache key now includes `cache_verify_hash`

- `mdt_core/src/__tests.rs`
  - `scan_project_cache_stores_content_hash_when_enabled`
  - `scan_project_hash_mismatch_invalidates_cache`

## Validation
Locally executed:
- `dprint check`
- `cargo check --tests -p mdt_core -p mdt_cli`
- `cargo check --all-targets`

Note: full local `cargo test` linking is blocked in this terminal environment by unaccepted local Xcode license (`xcrun` exit 69). CI will validate full link/test execution.

Related:
- #85
- #78
