### PR TITLE
feat(cache): expose cache observability in info/doctor (phase d)

### DIFF
--- a/.changeset/cache_observability_info_doctor.md
+++ b/.changeset/cache_observability_info_doctor.md
@@ -1,0 +1,12 @@
+---
+mdt_core: minor
+mdt_cli: minor
+---
+
+Add cache observability across core and CLI diagnostics.
+
+- Persist cache telemetry counters in the project index cache (scan count, full-hit count, cumulative reused/reparsed file counts, and last scan details).
+- Expose cache inspection APIs from `mdt_core::project` for diagnostics surfaces.
+- Extend `mdt info` with a cache section in text and JSON output (artifact health, schema/key compatibility, hash mode, cumulative metrics, and last scan summary).
+- Extend `mdt doctor` with cache checks for artifact validity, hash mode guidance, and efficiency trend heuristics.
+- Add unit/e2e/snapshot coverage and docs updates for the new observability output.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -166,6 +166,30 @@ Includes:
 - Data namespaces and their configured source files.
 - Template file count, discovered template files, and template directory hints.
 - Diagnostic totals (errors/warnings) and missing provider names.
+- Cache observability details (artifact path/health, schema compatibility, hash verification mode, cumulative reuse/reparse totals, and last scan metrics).
+
+### `mdt doctor`
+
+Run project health checks with remediation hints and an explicit pass/warn/fail summary.
+
+```sh
+mdt doctor
+mdt doctor --path ./my-project
+mdt doctor --format json
+```
+
+Checks include:
+
+- Config discovery and config parse status.
+- Data source loading and parse validity.
+- Template layout conventions (`.templates/` preferred).
+- Provider/consumer integrity (duplicates, missing providers, orphan consumers, unused providers).
+- Parser diagnostics aggregation.
+- Cache artifact validity and schema compatibility.
+- Cache hash verification mode guidance.
+- Cache efficiency trend analysis based on reuse vs reparse telemetry.
+
+Text output prints one line per check with a status tag (`PASS`, `WARN`, `FAIL`, `SKIP`) and optional hints. JSON output includes `ok`, `summary`, and a detailed `checks` array.
 
 ### `mdt lsp`
 
@@ -196,6 +220,7 @@ Use this command when you want an AI assistant to query template providers, cons
 
 ## Environment variables
 
-| Variable   | Effect                                                                  |
-| ---------- | ----------------------------------------------------------------------- |
-| `NO_COLOR` | When set (to any value), disables colored output. Same as `--no-color`. |
+| Variable                | Effect                                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `NO_COLOR`              | When set (to any value), disables colored output. Same as `--no-color`.                                            |
+| `MDT_CACHE_VERIFY_HASH` | When set (to any value), cache fingerprints include content hashes (in addition to size/mtime) for stricter reuse. |

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -31,6 +31,8 @@ cargo install mdt_cli@0.6.0
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
+- `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 

--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -114,8 +114,9 @@ pub enum Commands {
 	/// Print a diagnostic summary of the current project.
 	///
 	/// Shows discovered providers/consumers, orphan and unused counts,
-	/// data namespaces from config, template file overview, and diagnostic
-	/// totals (errors, warnings, and missing providers).
+	/// data namespaces from config, template file overview, diagnostic
+	/// totals (errors, warnings, and missing providers), and cache
+	/// observability metrics.
 	Info {
 		/// Output format for info results. Use `text` for human-readable
 		/// output or `json` for programmatic consumption.
@@ -125,8 +126,9 @@ pub enum Commands {
 	/// Run project health checks with actionable remediation hints.
 	///
 	/// Evaluates config discovery, data loading, provider/consumer linkage,
-	/// template directory conventions, and parser diagnostics. Exits with a
-	/// non-zero code when failing checks are present.
+	/// template directory conventions, parser diagnostics, and cache
+	/// effectiveness trends. Exits with a non-zero code when failing checks
+	/// are present.
 	Doctor {
 		/// Output format for doctor results. Use `text` for human-readable
 		/// output or `json` for programmatic consumption.

--- a/mdt_cli/tests/snapshots.rs
+++ b/mdt_cli/tests/snapshots.rs
@@ -69,6 +69,14 @@ fn with_redacted_paths(tmp_path: &Path, f: impl FnOnce()) {
 	}
 	let mut settings = insta::Settings::clone_current();
 	settings.add_filter(&escaped, "[TEMP_DIR]");
+	settings.add_filter(
+		r#""timestamp_unix_ms": \d+"#,
+		r#""timestamp_unix_ms": [UNIX_MS]"#,
+	);
+	settings.add_filter(
+		r"Last scan unix ms\s+\d+",
+		"Last scan unix ms            [UNIX_MS]",
+	);
 	settings.bind(f);
 }
 

--- a/mdt_cli/tests/snapshots/snapshots__doctor_duplicate_provider_fails.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_duplicate_provider_fails.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 1207
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmppy1uCY
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpUNsyae
     - doctor
   env:
     NO_COLOR: "1"
@@ -25,7 +24,13 @@ mdt doctor
 [SKIP] Orphan Consumers       skipped because project scan did not complete
 [SKIP] Unused Providers       skipped because project scan did not complete
 [SKIP] Parser Diagnostics     skipped because project scan did not complete
+[WARN] Cache Artifact         cache artifact not found at [TEMP_DIR]/.mdt/cache/index-v2.json
+       hint: run `mdt check` or `mdt info` to trigger a scan and write the cache artifact
+[PASS] Cache Hash Mode        content-hash verification disabled (mtime + size fingerprints only)
+       hint: set `MDT_CACHE_VERIFY_HASH=1` to validate cache keys with content hashes while troubleshooting
+[SKIP] Cache Efficiency       cache telemetry unavailable
+       hint: ensure cache artifact is valid, then run `mdt info` or `mdt check` a few times to gather telemetry
 
-summary: 1 pass, 1 warn, 1 fail, 5 skip
+summary: 2 pass, 2 warn, 1 fail, 6 skip
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__doctor_empty_project.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_empty_project.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 1166
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpyrhrWI
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpfYCLXK
     - doctor
   env:
     NO_COLOR: "1"
@@ -24,7 +23,11 @@ mdt doctor
 [PASS] Orphan Consumers       no orphan consumer blocks found
 [PASS] Unused Providers       all providers have at least one consumer
 [PASS] Parser Diagnostics     no parser diagnostics found
+[PASS] Cache Artifact         cache artifact is readable and valid at [TEMP_DIR]/.mdt/cache/index-v2.json
+[PASS] Cache Hash Mode        content-hash verification disabled (mtime + size fingerprints only)
+       hint: set `MDT_CACHE_VERIFY_HASH=1` to validate cache keys with content hashes while troubleshooting
+[SKIP] Cache Efficiency       insufficient history for trend analysis (need at least 3 scans)
 
-summary: 6 pass, 1 warn, 0 fail, 1 skip
+summary: 8 pass, 1 warn, 0 fail, 2 skip
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__doctor_empty_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_empty_project_json.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 1177
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmph4nWNV
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpllT9hC
     - doctor
     - "--format"
     - json
@@ -18,10 +17,10 @@ exit_code: 0
 {
   "ok": true,
   "summary": {
-    "pass": 6,
+    "pass": 8,
     "warn": 1,
     "fail": 0,
-    "skip": 1
+    "skip": 2
   },
   "checks": [
     {
@@ -78,6 +77,27 @@ exit_code: 0
       "title": "Parser Diagnostics",
       "status": "pass",
       "message": "no parser diagnostics found",
+      "hint": null
+    },
+    {
+      "id": "cache_artifact",
+      "title": "Cache Artifact",
+      "status": "pass",
+      "message": "cache artifact is readable and valid at [TEMP_DIR]/.mdt/cache/index-v2.json",
+      "hint": null
+    },
+    {
+      "id": "cache_hash_mode",
+      "title": "Cache Hash Mode",
+      "status": "pass",
+      "message": "content-hash verification disabled (mtime + size fingerprints only)",
+      "hint": "set `MDT_CACHE_VERIFY_HASH=1` to validate cache keys with content hashes while troubleshooting"
+    },
+    {
+      "id": "cache_efficiency",
+      "title": "Cache Efficiency",
+      "status": "skip",
+      "message": "insufficient history for trend analysis (need at least 3 scans)",
       "hint": null
     }
   ]

--- a/mdt_cli/tests/snapshots/snapshots__doctor_info_project_fails.snap
+++ b/mdt_cli/tests/snapshots/snapshots__doctor_info_project_fails.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 1192
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp0HzGJR
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpsyymwl
     - doctor
   env:
     NO_COLOR: "1"
@@ -27,7 +26,11 @@ mdt doctor
        hint: reuse existing providers from consumer blocks or remove dead templates
 [FAIL] Parser Diagnostics     1 error(s), 0 warning(s)
        hint: fix malformed blocks and invalid transformers reported by `mdt check`
+[PASS] Cache Artifact         cache artifact is readable and valid at [TEMP_DIR]/.mdt/cache/index-v2.json
+[PASS] Cache Hash Mode        content-hash verification disabled (mtime + size fingerprints only)
+       hint: set `MDT_CACHE_VERIFY_HASH=1` to validate cache keys with content hashes while troubleshooting
+[SKIP] Cache Efficiency       insufficient history for trend analysis (need at least 3 scans)
 
-summary: 3 pass, 2 warn, 3 fail, 0 skip
+summary: 5 pass, 2 warn, 3 fail, 1 skip
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__info_empty_project.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_empty_project.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 162
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpA4Cz6F
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpCbOHK6
     - info
   env:
     NO_COLOR: "1"
@@ -41,5 +40,18 @@ Errors                       0
 Warnings                     0
 Missing providers            0
 Missing names                none
+
+Cache
+Artifact path                [TEMP_DIR]/.mdt/cache/index-v2.json
+Artifact status              ok
+Schema version               2 (supported)
+Project key match            yes
+Hash verification            disabled
+Scans recorded               1
+Full project hits            0 (0.0%)
+File reuse totals            0 reused / 0 reparsed (n/a)
+Last scan mode               incremental reuse
+Last scan files              0 reused / 0 reparsed / 0 total
+Last scan unix ms            [UNIX_MS]
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__info_empty_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_empty_project_json.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 185
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpXXVXV2
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpNOea9e
     - info
     - "--format"
     - json
@@ -47,6 +46,29 @@ exit_code: 0
     "warnings": 0,
     "missing_provider_count": 0,
     "missing_provider_names": []
+  },
+  "cache": {
+    "path": "[TEMP_DIR]/.mdt/cache/index-v2.json",
+    "exists": true,
+    "readable": true,
+    "valid": true,
+    "schema_version": 2,
+    "schema_supported": true,
+    "project_key_matches": true,
+    "hash_verification_enabled": false,
+    "scan_count": 1,
+    "full_project_hit_count": 0,
+    "full_project_hit_rate": "0.0%",
+    "reused_file_count_total": 0,
+    "reparsed_file_count_total": 0,
+    "file_reuse_rate": "n/a",
+    "last_scan": {
+      "timestamp_unix_ms": [UNIX_MS],
+      "full_project_hit": false,
+      "reused_files": 0,
+      "reparsed_files": 0,
+      "total_files": 0
+    }
   }
 }
 

--- a/mdt_cli/tests/snapshots/snapshots__info_project.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_project.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 174
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmp6s5U9G
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpf0LUS7
     - info
   env:
     NO_COLOR: "1"
@@ -43,5 +42,18 @@ Errors                       1
 Warnings                     0
 Missing providers            1
 Missing names                missing_block
+
+Cache
+Artifact path                [TEMP_DIR]/.mdt/cache/index-v2.json
+Artifact status              ok
+Schema version               2 (supported)
+Project key match            yes
+Hash verification            disabled
+Scans recorded               1
+Full project hits            0 (0.0%)
+File reuse totals            0 reused / 3 reparsed (0.0%)
+Last scan mode               incremental reuse
+Last scan files              0 reused / 3 reparsed / 3 total
+Last scan unix ms            [UNIX_MS]
 
 ----- stderr -----

--- a/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
@@ -1,11 +1,10 @@
 ---
 source: mdt_cli/tests/snapshots.rs
-assertion_line: 203
 info:
   program: mdt
   args:
     - "--path"
-    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpnMBFFI
+    - /var/folders/lm/90xr38kd5y52p5y6jj2ny_dr0000gn/T/.tmpFc7Jkb
     - info
     - "--format"
     - json
@@ -68,6 +67,29 @@ exit_code: 0
     "missing_provider_names": [
       "missing_block"
     ]
+  },
+  "cache": {
+    "path": "[TEMP_DIR]/.mdt/cache/index-v2.json",
+    "exists": true,
+    "readable": true,
+    "valid": true,
+    "schema_version": 2,
+    "schema_supported": true,
+    "project_key_matches": true,
+    "hash_verification_enabled": false,
+    "scan_count": 1,
+    "full_project_hit_count": 0,
+    "full_project_hit_rate": "0.0%",
+    "reused_file_count_total": 0,
+    "reparsed_file_count_total": 3,
+    "file_reuse_rate": "0.0%",
+    "last_scan": {
+      "timestamp_unix_ms": [UNIX_MS],
+      "full_project_hit": false,
+      "reused_files": 0,
+      "reparsed_files": 3,
+      "total_files": 3
+    }
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,8 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
+- `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 

--- a/template.t.md
+++ b/template.t.md
@@ -11,6 +11,8 @@
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
+- `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 


### PR DESCRIPTION
## Summary
Implements Phase D cache observability from #89 by surfacing cache effectiveness in both `mdt info` and `mdt doctor`, backed by persisted telemetry in the cache artifact.

Closes #89.

## What changed

### Core (`mdt_core`)
- Added persisted cache telemetry in `index-v2.json`:
  - `scan_count`
  - `full_project_hit_count`
  - `reused_file_count_total`
  - `reparsed_file_count_total`
  - `last_scan` (`timestamp_unix_ms`, `full_project_hit`, `reused_files`, `reparsed_files`, `total_files`)
- Updated scan flow to record telemetry for:
  - full cache hits
  - mixed incremental reuse
  - cold-cache rebuilds
- Added public cache inspection APIs in `mdt_core::project`:
  - `project_cache_path`
  - `inspect_project_cache`
  - cache inspection/telemetry structs for diagnostics surfaces

### CLI (`mdt_cli`)
- Extended `mdt info` text + JSON with a new `cache` section:
  - artifact path/status
  - schema support
  - project key compatibility
  - hash verification mode
  - cumulative hit/reuse/reparse counters
  - last-scan summary
- Extended `mdt doctor` with cache checks:
  - `Cache Artifact`
  - `Cache Hash Mode` (includes actionable hash mode hint)
  - `Cache Efficiency` (heuristic trend check with skip/warn/pass)

### Docs/templates
- Updated CLI reference with cache observability coverage for `mdt info` and added a dedicated `mdt doctor` section.
- Added `MDT_CACHE_VERIFY_HASH` to documented env vars.
- Updated command lists in `template.t.md`, root `readme.md`, and `mdt_cli/readme.md` (via `mdt update`).

## Tests

### New tests
- `mdt_core` telemetry unit coverage:
  - full cache hit telemetry progression
  - mixed incremental reuse telemetry progression
  - cold-cache rebuild telemetry reset
- `mdt_cli` e2e assertions:
  - `info --format json` includes cache observability fields
  - `doctor --format json` includes cache checks
- Snapshot stabilization:
  - added snapshot redaction for dynamic `timestamp_unix_ms` / `Last scan unix ms`
  - refreshed impacted `info_*` and `doctor_*` snapshots

### Commands run
- `dprint check`
- `cargo check --all-targets`
- `cargo test -p mdt_core`
- `cargo test -p mdt_cli`
- `cargo test --workspace`

## Dogfooding
Ran directly on this repository:
- `cargo run -p mdt_cli -- --path . info`
- `cargo run -p mdt_cli -- --path . doctor`
- `cargo run -p mdt_cli -- --path . update`

This validated the new cache sections/checks in real project output and ensured docs/readme template synchronization.
