### PR TITLE
feat: add script-backed data sources with watch cache

### DIFF
--- a/mdt_cli/tests/snapshots/snapshots__info_project.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_project.snap
@@ -26,8 +26,8 @@ Unused providers             1
 
 Data
 Namespaces                   2
-source                       meta -> meta.toml
-source                       pkg -> package.json
+source                       meta [file] -> meta.toml
+source                       pkg [file] -> package.json
 
 Templates
 Template files               2

--- a/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
+++ b/mdt_cli/tests/snapshots/snapshots__info_project_json.snap
@@ -30,13 +30,15 @@ exit_code: 0
     "namespaces": [
       {
         "namespace": "meta",
-        "path": "meta.toml",
+        "location": "meta.toml",
+        "kind": "file",
         "format": "toml",
         "explicit_format": false
       },
       {
         "namespace": "pkg",
-        "path": "package.json",
+        "location": "package.json",
+        "kind": "file",
         "format": "json",
         "explicit_format": false
       }

--- a/mdt_core/readme.md
+++ b/mdt_core/readme.md
@@ -50,7 +50,8 @@ cargo = "Cargo.toml"
 
 Then in provider blocks: `{{ pkg.version }}` or `{{ cargo.package.edition }}`.
 
-Supported formats: JSON, TOML, YAML, KDL, and INI.
+Supported sources: files and script commands. Supported formats: text, JSON,
+TOML, YAML, KDL, and INI.
 
 ## Quick Start
 

--- a/mdt_core/src/error.rs
+++ b/mdt_core/src/error.rs
@@ -48,10 +48,14 @@ pub enum MdtError {
 	#[diagnostic(code(mdt::data_file))]
 	DataFile { path: String, reason: String },
 
+	#[error("failed to execute data script for `{namespace}`: {reason}")]
+	#[diagnostic(code(mdt::data_script))]
+	DataScript { namespace: String, reason: String },
+
 	#[error("unsupported data file format: `{0}`")]
 	#[diagnostic(
 		code(mdt::unsupported_format),
-		help("supported formats: .json, .toml, .yaml, .yml, .kdl, .ini")
+		help("supported formats: text, json, toml, yaml, yml, kdl, ini")
 	)]
 	UnsupportedDataFormat(String),
 

--- a/mdt_core/src/lib.rs
+++ b/mdt_core/src/lib.rs
@@ -39,7 +39,8 @@
 //!
 //! Then in provider blocks: `{{ pkg.version }}` or `{{ cargo.package.edition }}`.
 //!
-//! Supported formats: JSON, TOML, YAML, KDL, and INI.
+//! Supported sources: files and script commands. Supported formats: text, JSON,
+//! TOML, YAML, KDL, and INI.
 //!
 //! ## Quick Start
 //!

--- a/template.t.md
+++ b/template.t.md
@@ -85,6 +85,34 @@ Because inline blocks are provider-free, they are ideal for one-off values that 
 
 <!-- {/mdtInlineBlocksLimits} -->
 
+<!-- {@mdtScriptDataSourcesGuide} -->
+
+`[data]` entries can run shell commands and use stdout as template data. This
+is useful for values that come from tooling (for example Nix, git metadata,
+or generated version files).
+
+```toml
+[data]
+release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
+```
+
+- `command`: shell command executed from the project root.
+- `format`: parser for stdout (`text`, `json`, `toml`, `yaml`, `yml`, `kdl`, `ini`).
+- `watch`: files that control cache invalidation.
+
+When `watch` files are unchanged, mdt reuses cached script output from
+`.mdt/cache/data-v1.json` instead of re-running the command.
+
+<!-- {/mdtScriptDataSourcesGuide} -->
+
+<!-- {@mdtScriptDataSourcesNotes} -->
+
+- Script outputs are cached per namespace, command, format, and watch list.
+- If `watch` is empty, mdt re-runs the script every load (no cache hit).
+- A non-zero script exit status fails data loading with an explicit error.
+
+<!-- {/mdtScriptDataSourcesNotes} -->
+
 <!-- {@mdtLspOverview} -->
 
 `mdt_lsp` is a [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) implementation for the [mdt](https://github.com/ifiokjr/mdt) template engine. It provides real-time editor integration for managing markdown template blocks.
@@ -242,7 +270,8 @@ cargo = "Cargo.toml"
 
 Then in provider blocks: `{{ "{{" }} pkg.version {{ "}}" }}` or `{{ "{{" }} cargo.package.edition {{ "}}" }}`.
 
-Supported formats: JSON, TOML, YAML, KDL, and INI.
+Supported sources: files and script commands. Supported formats: text, JSON,
+TOML, YAML, KDL, and INI.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
This PR adds script-backed `[data]` sources so template data can come from commands, with watch-based caching to avoid rerunning expensive scripts when inputs are unchanged.

## Problem
Some values are best produced dynamically (for example via Nix, git, or tooling commands), but current `[data]` sources only support files. Running expensive scripts on every load would also hurt performance.

## What changed
### Core API (`mdt_core`)
- Extended `DataSource` with `Script` variant:
  - `command`: shell command run from project root
  - `format`: optional parser (`text`, `json`, `toml`, `yaml`, `yml`, `kdl`, `ini`)
  - `watch`: files that control cache invalidation
- Added script execution + parsing path in `MdtConfig::load_data`.
- Added script cache file at `.mdt/cache/data-v1.json`:
  - keyed per namespace
  - validates command/format/watch list and watched-file fingerprints
  - reuses cached stdout-derived value when watch files are unchanged
  - reruns script when watch files change
- Added `MdtError::DataScript` for clear script execution failures.
- Added `text`/`raw`/`string` parsing mode for script output (and file formats).

### CLI (`mdt_cli`)
- Updated `mdt info` data-source reporting to include source kind and location:
  - `file` sources
  - `script` sources (including watch count)
- Updated doctor guidance text to include script command validation.
- Updated snapshot tests for the revised info output schema/text.

### Tests
- Added core tests covering:
  - script source config parsing
  - script output loading
  - watch-based cache reuse and invalidation behavior
- Full workspace tests pass.

### Documentation
- Added script data source docs to mdbook:
  - reference configuration (`[data]` section)
  - data interpolation guide
- Reused shared docs content through `template.t.md` MDT providers/consumers so book docs stay DRY.

## User impact
Users can now source template data from commands and avoid repeated expensive executions by declaring watch files.

## Example
```toml
[data]
version = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
```

## Validation
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo run -p mdt_cli -- check --path .`
