### PR TITLE
docs: expand diagnostics docs and fix mdt update/format idempotency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ mdt (manage **m**ark**d**own **t**emplates) is a data-driven template engine for
 
 1. **Content synchronization**: Provider blocks define content in `*.t.md` template files. Consumer blocks in other files reference providers by name and get replaced with the provider content on `mdt update`.
 
-2. **Data interpolation** (via `minijinja`): Provider content can reference data pulled from project files (e.g., `package.json` version, `Cargo.toml` metadata) using `{{ namespace.key }}` syntax. An `mdt.toml` config file maps source files to namespaces. Supports JSON, TOML, YAML, and KDL data sources.
+2. **Data interpolation** (via `minijinja`): Provider content can reference data pulled from project files (e.g., `package.json` version, `Cargo.toml` metadata) using `{{ namespace.key }}` syntax. An `mdt.toml` config file maps source files to namespaces. Supports JSON, TOML, YAML, KDL, and INI data sources.
 
 3. **Source file scanning**: Consumer tags are detected inside code comments in any language (`.rs`, `.ts`, `.py`, `.go`, `.java`, etc.), not just markdown files. This enables keeping Rust doc comments, JSDoc, Python docstrings, etc. in sync with central template definitions.
 
@@ -138,6 +138,10 @@ This content gets replaced
 - `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
+- `mdt info [--path <dir>] [--format text|json]` — Print project diagnostics and cache observability metrics.
+- `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency trends.
+- `mdt lsp` — Start the language server.
+- `mdt mcp` — Start the MCP server for AI/agent integrations.
 
 ### Data Interpolation
 
@@ -152,7 +156,13 @@ cargo = "Cargo.toml"
 
 Then in provider blocks: `Version: {{ pkg.version }}` or `Edition: {{ cargo.package.edition }}`.
 
-Supported data file formats: `.json`, `.toml`, `.yaml`/`.yml`, `.kdl`.
+Supported data file formats: `.json`, `.toml`, `.yaml`/`.yml`, `.kdl`, `.ini`.
+
+### Cache Diagnostics
+
+- `mdt info` includes cache artifact/schema status and reuse/reparse telemetry.
+- `mdt doctor` includes cache checks (`Cache Artifact`, `Cache Hash Mode`, `Cache Efficiency`).
+- Set `MDT_CACHE_VERIFY_HASH=1` to include content hashes in cache fingerprints while troubleshooting cache consistency.
 
 ### Block Padding
 
@@ -251,12 +261,14 @@ Defined in `.cargo/config.toml` — these proxy to `cargo-run-bin`:
 
 **Every change MUST be made via a pull request.** Do not commit directly to `main`. The workflow is:
 
-1. Create a feature branch from `main`
+1. Create a feature branch from `origin/main` (not from a stacked feature branch unless intentionally stacking)
 2. Make all changes on the feature branch
 3. Create a PR with a descriptive title and summary
 4. Monitor CI checks — wait for all checks to pass
-5. Merge the PR back into `main` only after all checks pass
-6. If checks fail, fix the issues on the branch and push again
+5. Ensure the PR is merge-clean before merging (`gh pr view --json mergeStateStatus` should be `CLEAN`)
+6. If the PR is `DIRTY`, rebase/cherry-pick onto fresh `origin/main` and push again before merging
+7. Merge the PR back into `main` only after all checks pass
+8. If checks fail, fix the issues on the branch and push again
 
 ### Logic Bug Testing Protocol
 

--- a/docs/src/advanced/inline-blocks.md
+++ b/docs/src/advanced/inline-blocks.md
@@ -1,11 +1,11 @@
 # Inline Blocks
 
-Inline blocks add provider-free interpolation for small dynamic values that
-still need to stay synchronized.
+Inline blocks add provider-free interpolation for small dynamic values that still need to stay synchronized.
 
 ## Why this exists
 
-<!-- {=mdtInlineBlocksGuide|trim} -->
+<!-- {=mdtInlineBlocksGuide} -->
+
 Inline blocks are useful when you need dynamic content in-place without creating a separate provider. Typical examples include versions, toolchain values, environment metadata, and short computed strings.
 
 Inline blocks render minijinja template content from the block's first argument:
@@ -17,19 +17,21 @@ Inline blocks render minijinja template content from the block's first argument:
 During `mdt update`, mdt evaluates the template argument with your configured `[data]` context, then replaces the content between the opening and closing tags.
 
 Because inline blocks are provider-free, they are ideal for one-off values that still need to stay synchronized.
+
 <!-- {/mdtInlineBlocksGuide} -->
 
 ## Limits and behavior
 
-<!-- {=mdtInlineBlocksLimits|trim} -->
+<!-- {=mdtInlineBlocksLimits} -->
+
 - Inline blocks must include a first argument that is the template string to render.
 - Inline blocks do not resolve provider content; everything comes from the inline template argument and current data context.
 - Inline rendering still supports transformers (`|trim`, `|code`, etc.) after template evaluation.
 - Inline blocks are scanned where mdt scans HTML comment tags (markdown and supported source comments), and follow the same code-block filtering rules configured for source scanning.
+
 <!-- {/mdtInlineBlocksLimits} -->
 
 ## Comparison to providers
 
 - Use `{@name} ... {/name}` when the same content should be reused in many places.
-- Use `{~name:"..."} ... {/name}` when you need localized dynamic output without a
-  dedicated provider block.
+- Use `{~name:"..."} ... {/name}` when you need localized dynamic output without a dedicated provider block.

--- a/docs/src/concepts/how-it-works.md
+++ b/docs/src/concepts/how-it-works.md
@@ -38,9 +38,9 @@ A tag has three parts:
 
 mdt determines how to treat files based on their names:
 
-| Pattern                              | Role                                                           |
-| ------------------------------------ | -------------------------------------------------------------- |
-| `*.t.md`                             | **Template files** — only these can contain provider blocks    |
+| Pattern                              | Role                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------- |
+| `*.t.md`                             | **Template files** — only these can contain provider blocks               |
 | `*.md`, `*.mdx`, `*.markdown`        | **Markdown files** — scanned for consumer and inline blocks               |
 | `*.rs`, `*.ts`, `*.py`, `*.go`, etc. | **Source files** — scanned for consumer and inline blocks inside comments |
 

--- a/docs/src/guide/ci-integration.md
+++ b/docs/src/guide/ci-integration.md
@@ -13,6 +13,24 @@ Add a step to your CI workflow that runs `mdt check`:
 
 If any consumer blocks are out of date, the step fails and the pipeline reports which blocks need updating.
 
+## CI diagnostics triage
+
+When `mdt check` fails in CI, add diagnostics commands so logs include root-cause context:
+
+```yaml
+- name: diagnostics
+  run: |
+    mdt info
+    mdt doctor
+```
+
+This gives you:
+
+- Project/config resolution details (`mdt.toml`, `.mdt.toml`, `.config/mdt.toml`)
+- Provider/consumer linkage summary (orphans, missing providers, duplicates)
+- Cache artifact health and reuse/reparse telemetry
+- Actionable doctor hints for config/data/layout/cache issues
+
 ## GitHub Actions
 
 ### Full workflow example

--- a/docs/src/guide/data-interpolation.md
+++ b/docs/src/guide/data-interpolation.md
@@ -55,24 +55,23 @@ A great library.
 
 ## Supported data formats
 
-| Format / Extension | Parser |
-| ------------------ | ------ |
+| Format / Extension | Parser          |
+| ------------------ | --------------- |
 | `text`, `.txt`     | Raw text string |
-| `json`, `.json`    | JSON   |
-| `toml`, `.toml`    | TOML   |
-| `yaml`, `.yaml`    | YAML   |
-| `yml`, `.yml`      | YAML   |
-| `kdl`, `.kdl`      | KDL    |
-| `ini`, `.ini`      | INI    |
+| `json`, `.json`    | JSON            |
+| `toml`, `.toml`    | TOML            |
+| `yaml`, `.yaml`    | YAML            |
+| `yml`, `.yml`      | YAML            |
+| `kdl`, `.kdl`      | KDL             |
+| `ini`, `.ini`      | INI             |
 
 All formats are converted to a common structure internally. You access values using dot notation regardless of the source format.
 
 ## Script-backed data sources
 
-<!-- {=mdtScriptDataSourcesGuide|trim} -->
-`[data]` entries can run shell commands and use stdout as template data. This
-is useful for values that come from tooling (for example Nix, git metadata,
-or generated version files).
+<!-- {=mdtScriptDataSourcesGuide} -->
+
+`[data]` entries can run shell commands and use stdout as template data. This is useful for values that come from tooling (for example Nix, git metadata, or generated version files).
 
 ```toml
 [data]
@@ -83,14 +82,16 @@ release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
 - `format`: parser for stdout (`text`, `json`, `toml`, `yaml`, `yml`, `kdl`, `ini`).
 - `watch`: files that control cache invalidation.
 
-When `watch` files are unchanged, mdt reuses cached script output from
-`.mdt/cache/data-v1.json` instead of re-running the command.
+When `watch` files are unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json` instead of re-running the command.
+
 <!-- {/mdtScriptDataSourcesGuide} -->
 
-<!-- {=mdtScriptDataSourcesNotes|trim} -->
+<!-- {=mdtScriptDataSourcesNotes} -->
+
 - Script outputs are cached per namespace, command, format, and watch list.
 - If `watch` is empty, mdt re-runs the script every load (no cache hit).
 - A non-zero script exit status fails data loading with an explicit error.
+
 <!-- {/mdtScriptDataSourcesNotes} -->
 
 ### TOML example

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -49,6 +49,7 @@ After running `mdt update`, every consumer named `install` has identical content
 - **Source file support** — Consumer tags work inside code comments too (Rust, TypeScript, Python, Go, and more)
 - **Transformers** — Pipe content through filters like `trim`, `indent`, `prefix`, `codeBlock` to adapt it for each context
 - **CI-friendly** — `mdt check` exits non-zero when docs are stale, with JSON and GitHub Actions output formats
+- **Project diagnostics** — `mdt info` and `mdt doctor` provide project health, cache observability, and actionable remediation hints
 - **Watch mode** — `mdt update --watch` auto-syncs on file changes during development
 - **LSP support** — Language server for editor integration with diagnostics, completions, and hover
 - **MCP support** — `mdt mcp` exposes template data to AI assistants via the Model Context Protocol

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -142,10 +142,10 @@ Consumers:
 
 **Status indicators:**
 
-| Status     | Meaning                                      |
-| ---------- | -------------------------------------------- |
-| `[linked]` | Consumer has a matching provider.            |
-| `[orphan]` | Consumer references a non-existent provider. |
+| Status     | Meaning                                              |
+| ---------- | ---------------------------------------------------- |
+| `[linked]` | Consumer has a matching provider.                    |
+| `[orphan]` | Consumer references a non-existent provider.         |
 | `[inline]` | Inline block renders from its own template argument. |
 
 Transformers are shown after the file path when present.
@@ -157,6 +157,7 @@ Print a human-readable diagnostics summary for the current project.
 ```sh
 mdt info
 mdt info --path ./my-project
+mdt info --format json
 ```
 
 Includes:

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -38,10 +38,9 @@ String paths infer format from file extension. Typed entries use `format` and ar
 
 ### Script-backed data sources
 
-<!-- {=mdtScriptDataSourcesGuide|trim} -->
-`[data]` entries can run shell commands and use stdout as template data. This
-is useful for values that come from tooling (for example Nix, git metadata,
-or generated version files).
+<!-- {=mdtScriptDataSourcesGuide} -->
+
+`[data]` entries can run shell commands and use stdout as template data. This is useful for values that come from tooling (for example Nix, git metadata, or generated version files).
 
 ```toml
 [data]
@@ -52,14 +51,16 @@ release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
 - `format`: parser for stdout (`text`, `json`, `toml`, `yaml`, `yml`, `kdl`, `ini`).
 - `watch`: files that control cache invalidation.
 
-When `watch` files are unchanged, mdt reuses cached script output from
-`.mdt/cache/data-v1.json` instead of re-running the command.
+When `watch` files are unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json` instead of re-running the command.
+
 <!-- {/mdtScriptDataSourcesGuide} -->
 
-<!-- {=mdtScriptDataSourcesNotes|trim} -->
+<!-- {=mdtScriptDataSourcesNotes} -->
+
 - Script outputs are cached per namespace, command, format, and watch list.
 - If `watch` is empty, mdt re-runs the script every load (no cache hit).
 - A non-zero script exit status fails data loading with an explicit error.
+
 <!-- {/mdtScriptDataSourcesNotes} -->
 
 **Supported formats:**

--- a/docs/src/reference/template-syntax.md
+++ b/docs/src/reference/template-syntax.md
@@ -31,7 +31,8 @@ Marks where provider content should be injected.
 
 ### Inline tag
 
-<!-- {=mdtInlineBlocksGuide|trim} -->
+<!-- {=mdtInlineBlocksGuide} -->
+
 Inline blocks are useful when you need dynamic content in-place without creating a separate provider. Typical examples include versions, toolchain values, environment metadata, and short computed strings.
 
 Inline blocks render minijinja template content from the block's first argument:
@@ -43,15 +44,18 @@ Inline blocks render minijinja template content from the block's first argument:
 During `mdt update`, mdt evaluates the template argument with your configured `[data]` context, then replaces the content between the opening and closing tags.
 
 Because inline blocks are provider-free, they are ideal for one-off values that still need to stay synchronized.
+
 <!-- {/mdtInlineBlocksGuide} -->
 
 #### Current limits
 
-<!-- {=mdtInlineBlocksLimits|trim} -->
+<!-- {=mdtInlineBlocksLimits} -->
+
 - Inline blocks must include a first argument that is the template string to render.
 - Inline blocks do not resolve provider content; everything comes from the inline template argument and current data context.
 - Inline rendering still supports transformers (`|trim`, `|code`, etc.) after template evaluation.
 - Inline blocks are scanned where mdt scans HTML comment tags (markdown and supported source comments), and follow the same code-block filtering rules configured for source scanning.
+
 <!-- {/mdtInlineBlocksLimits} -->
 
 ### Close tag

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -111,6 +111,36 @@ Dry run: would update 3 block(s) in 2 file(s):
   src/lib.rs
 ```
 
+## Cache observability and diagnostics
+
+If cache behavior looks suspicious (unexpected reparses, stale cache artifact, inconsistent local vs CI behavior), use:
+
+```sh
+mdt info
+mdt doctor
+```
+
+`mdt info` shows cache telemetry:
+
+- Artifact path and schema support
+- Hash verification mode
+- Cumulative reused vs reparsed file totals
+- Last scan summary (`full cache hit` vs `incremental reuse`)
+
+`mdt doctor` adds cache health checks:
+
+- `Cache Artifact` validates readability/schema/key compatibility
+- `Cache Hash Mode` explains current fingerprint mode and troubleshooting toggle
+- `Cache Efficiency` warns when reparses dominate over time
+
+For strict cache-key validation during investigation:
+
+```sh
+MDT_CACHE_VERIFY_HASH=1 mdt check
+```
+
+This includes content hashes in cache fingerprints (in addition to size/mtime). Disable it again for baseline behavior comparisons.
+
 ## Formatter interference
 
 Code formatters like dprint, Prettier, and rustfmt can reformat content inside template tags, causing mdt to see the blocks as stale even when the provider hasn't changed.

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -36,6 +36,12 @@ cargo install mdt_cli@0.6.0
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 
+### Diagnostics Workflow
+
+- Run `mdt info` first to inspect project shape, diagnostics totals, and cache reuse telemetry.
+- Run `mdt doctor` when you need actionable health checks and remediation hints (config/data/layout/cache).
+- Use `MDT_CACHE_VERIFY_HASH=1` when troubleshooting cache consistency issues and comparing reuse behavior.
+
 <!-- {/mdtCliUsage} -->
 
 <!-- {=mdtTemplateSyntax} -->
@@ -66,7 +72,9 @@ This content gets replaced
 
 ```markdown
 <!-- {~version:"{{ package.version }}"} -->
+
 0.0.0
+
 <!-- {/version} -->
 ```
 

--- a/mdt_cli/src/main.rs
+++ b/mdt_cli/src/main.rs
@@ -197,7 +197,8 @@ fn run_init(args: &MdtCli) -> Result<(), Box<dyn std::error::Error>> {
 	if config_exists {
 		// Skip silently if config already exists.
 	} else {
-		let sample_config = "# mdt configuration\n# See \
+		let sample_config =
+			"# mdt configuration\n# See \
 			 https://ifiokjr.github.io/mdt/reference/configuration.html for full reference.\n\n# \
 			 Map data files to template namespaces.\n# Values from these files are available in \
 			 provider blocks as {{ namespace.key }}.\n# [data]\n# pkg = \"package.json\"\n# cargo \
@@ -261,17 +262,20 @@ fn data_source_format(source: &mdt_core::DataSource) -> (String, bool) {
 	}
 
 	let inferred = match source {
-		mdt_core::DataSource::Path(path) => path
-			.extension()
-			.and_then(|ext| ext.to_str())
-			.unwrap_or("unknown")
-			.to_ascii_lowercase(),
-		mdt_core::DataSource::Typed(typed) => typed
-			.path
-			.extension()
-			.and_then(|ext| ext.to_str())
-			.unwrap_or("unknown")
-			.to_ascii_lowercase(),
+		mdt_core::DataSource::Path(path) => {
+			path.extension()
+				.and_then(|ext| ext.to_str())
+				.unwrap_or("unknown")
+				.to_ascii_lowercase()
+		}
+		mdt_core::DataSource::Typed(typed) => {
+			typed
+				.path
+				.extension()
+				.and_then(|ext| ext.to_str())
+				.unwrap_or("unknown")
+				.to_ascii_lowercase()
+		}
 		mdt_core::DataSource::Script(_) => "text".to_string(),
 		_ => "unknown".to_string(),
 	};
@@ -285,14 +289,16 @@ fn data_source_summary_fields(source: &mdt_core::DataSource) -> (String, String)
 		mdt_core::DataSource::Typed(typed) => {
 			(typed.path.display().to_string(), "file".to_string())
 		}
-		mdt_core::DataSource::Script(script) => (
-			format!("script: {}", script.command),
-			if script.watch.is_empty() {
-				"script".to_string()
-			} else {
-				format!("script (watch: {})", script.watch.len())
-			},
-		),
+		mdt_core::DataSource::Script(script) => {
+			(
+				format!("script: {}", script.command),
+				if script.watch.is_empty() {
+					"script".to_string()
+				} else {
+					format!("script (watch: {})", script.watch.len())
+				},
+			)
+		}
 		_ => ("unknown".to_string(), "unknown".to_string()),
 	}
 }
@@ -987,12 +993,14 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 	let data_sources: Vec<InfoDataSourceSection> = config
 		.data_sources
 		.iter()
-		.map(|source| InfoDataSourceSection {
-			namespace: source.namespace.clone(),
-			location: source.location.clone(),
-			kind: source.kind.clone(),
-			format: source.format.clone(),
-			explicit_format: source.explicit_format,
+		.map(|source| {
+			InfoDataSourceSection {
+				namespace: source.namespace.clone(),
+				location: source.location.clone(),
+				kind: source.kind.clone(),
+				format: source.format.clone(),
+				explicit_format: source.explicit_format,
+			}
 		})
 		.collect();
 
@@ -1322,32 +1330,34 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 				None,
 			);
 		}
-		Some(config) => match config.load_data(&root) {
-			Ok(loaded_data) => {
-				add_doctor_check(
-					&mut checks,
-					"data_sources",
-					"Data Sources",
-					DoctorStatus::Pass,
-					format!("loaded {} namespace(s) successfully", loaded_data.len()),
-					None,
-				);
-			}
-			Err(error) => {
-				add_doctor_check(
-					&mut checks,
-					"data_sources",
-					"Data Sources",
-					DoctorStatus::Fail,
-					format!("failed to load configured data sources: {error}"),
-					Some(
-						"verify data file paths, script commands, formats, and parse validity \
+		Some(config) => {
+			match config.load_data(&root) {
+				Ok(loaded_data) => {
+					add_doctor_check(
+						&mut checks,
+						"data_sources",
+						"Data Sources",
+						DoctorStatus::Pass,
+						format!("loaded {} namespace(s) successfully", loaded_data.len()),
+						None,
+					);
+				}
+				Err(error) => {
+					add_doctor_check(
+						&mut checks,
+						"data_sources",
+						"Data Sources",
+						DoctorStatus::Fail,
+						format!("failed to load configured data sources: {error}"),
+						Some(
+							"verify data file paths, script commands, formats, and parse validity \
 							 for each [data] namespace"
-							.to_string(),
-					),
-				);
+								.to_string(),
+						),
+					);
+				}
 			}
-		},
+		}
 		None => {
 			add_doctor_check(
 				&mut checks,

--- a/mdt_core/readme.md
+++ b/mdt_core/readme.md
@@ -50,8 +50,7 @@ cargo = "Cargo.toml"
 
 Then in provider blocks: `{{ pkg.version }}` or `{{ cargo.package.edition }}`.
 
-Supported sources: files and script commands. Supported formats: text, JSON,
-TOML, YAML, KDL, and INI.
+Supported sources: files and script commands. Supported formats: text, JSON, TOML, YAML, KDL, and INI.
 
 ## Quick Start
 

--- a/mdt_core/src/__tests.rs
+++ b/mdt_core/src/__tests.rs
@@ -8776,8 +8776,8 @@ fn config_load_data_script_text_entry() -> MdtResult<()> {
 	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
 	std::fs::write(
 		tmp.path().join("mdt.toml"),
-		"[data]\nversion = { command = \"printf 1.2.3\", format = \"text\", watch = \
-		 [\"VERSION\"] }\n",
+		"[data]\nversion = { command = \"printf 1.2.3\", format = \"text\", watch = [\"VERSION\"] \
+		 }\n",
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));
 	std::fs::write(tmp.path().join("VERSION"), "1.2.3\n").unwrap_or_else(|e| panic!("write: {e}"));

--- a/mdt_core/src/config.rs
+++ b/mdt_core/src/config.rs
@@ -315,21 +315,25 @@ fn normalize_path_key(path: &Path) -> String {
 
 fn watch_fingerprint(path: &Path) -> WatchFingerprint {
 	match std::fs::metadata(path) {
-		Ok(metadata) => WatchFingerprint {
-			exists: true,
-			size: metadata.len(),
-			modified_unix_ms: metadata
-				.modified()
-				.ok()
-				.and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-				.and_then(|duration| duration.as_millis().try_into().ok())
-				.unwrap_or(0),
-		},
-		Err(_) => WatchFingerprint {
-			exists: false,
-			size: 0,
-			modified_unix_ms: 0,
-		},
+		Ok(metadata) => {
+			WatchFingerprint {
+				exists: true,
+				size: metadata.len(),
+				modified_unix_ms: metadata
+					.modified()
+					.ok()
+					.and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+					.and_then(|duration| duration.as_millis().try_into().ok())
+					.unwrap_or(0),
+			}
+		}
+		Err(_) => {
+			WatchFingerprint {
+				exists: false,
+				size: 0,
+				modified_unix_ms: 0,
+			}
+		}
 	}
 }
 
@@ -472,11 +476,12 @@ impl MdtConfig {
 			let value = match source {
 				DataSource::Path(rel_path) => {
 					let abs_path = root.join(rel_path);
-					let content =
-						std::fs::read_to_string(&abs_path).map_err(|e| MdtError::DataFile {
+					let content = std::fs::read_to_string(&abs_path).map_err(|e| {
+						MdtError::DataFile {
 							path: rel_path.display().to_string(),
 							reason: e.to_string(),
-						})?;
+						}
+					})?;
 					let format = abs_path
 						.extension()
 						.and_then(|e| e.to_str())
@@ -487,11 +492,12 @@ impl MdtConfig {
 				DataSource::Typed(typed) => {
 					let rel_path = typed.path.as_path();
 					let abs_path = root.join(rel_path);
-					let content =
-						std::fs::read_to_string(&abs_path).map_err(|e| MdtError::DataFile {
+					let content = std::fs::read_to_string(&abs_path).map_err(|e| {
+						MdtError::DataFile {
 							path: rel_path.display().to_string(),
 							reason: e.to_string(),
-						})?;
+						}
+					})?;
 					let format = typed.format.trim().to_ascii_lowercase();
 					parse_data_file(&content, format.as_str(), &rel_path.display().to_string())?
 				}
@@ -619,36 +625,48 @@ fn parse_data_file(
 ) -> MdtResult<serde_json::Value> {
 	match format {
 		"text" | "string" | "raw" | "txt" => Ok(serde_json::Value::String(content.to_string())),
-		"json" => serde_json::from_str(content).map_err(|e| MdtError::DataFile {
-			path: path_display.to_string(),
-			reason: e.to_string(),
-		}),
-		"toml" => {
-			let toml_value: toml::Value =
-				toml::from_str(content).map_err(|e| MdtError::DataFile {
+		"json" => {
+			serde_json::from_str(content).map_err(|e| {
+				MdtError::DataFile {
 					path: path_display.to_string(),
 					reason: e.to_string(),
-				})?;
+				}
+			})
+		}
+		"toml" => {
+			let toml_value: toml::Value = toml::from_str(content).map_err(|e| {
+				MdtError::DataFile {
+					path: path_display.to_string(),
+					reason: e.to_string(),
+				}
+			})?;
 			toml_to_json(toml_value, path_display)
 		}
-		"yaml" | "yml" => serde_yaml_ng::from_str(content).map_err(|e| MdtError::DataFile {
-			path: path_display.to_string(),
-			reason: e.to_string(),
-		}),
+		"yaml" | "yml" => {
+			serde_yaml_ng::from_str(content).map_err(|e| {
+				MdtError::DataFile {
+					path: path_display.to_string(),
+					reason: e.to_string(),
+				}
+			})
+		}
 		"kdl" => {
-			let doc: kdl::KdlDocument =
-				content
-					.parse()
-					.map_err(|e: kdl::KdlError| MdtError::DataFile {
-						path: path_display.to_string(),
-						reason: e.to_string(),
-					})?;
+			let doc: kdl::KdlDocument = content.parse().map_err(|e: kdl::KdlError| {
+				MdtError::DataFile {
+					path: path_display.to_string(),
+					reason: e.to_string(),
+				}
+			})?;
 			kdl_document_to_value(&doc, path_display)
 		}
-		"ini" => serde_ini::from_str(content).map_err(|e| MdtError::DataFile {
-			path: path_display.to_string(),
-			reason: e.to_string(),
-		}),
+		"ini" => {
+			serde_ini::from_str(content).map_err(|e| {
+				MdtError::DataFile {
+					path: path_display.to_string(),
+					reason: e.to_string(),
+				}
+			})
+		}
 		other => Err(MdtError::UnsupportedDataFormat(other.to_string())),
 	}
 }
@@ -759,20 +777,26 @@ fn kdl_entry_value_to_json(
 ) -> MdtResult<serde_json::Value> {
 	match value {
 		kdl::KdlValue::String(s) => Ok(serde_json::Value::String(s.clone())),
-		kdl::KdlValue::Integer(i) => Ok(serde_json::Value::Number(
-			serde_json::Number::from_f64(*i as f64).ok_or_else(|| {
-				MdtError::UnconvertibleFloat {
-					path: path_display.to_string(),
-					value: i.to_string(),
-				}
-			})?,
-		)),
-		kdl::KdlValue::Float(f) => Ok(serde_json::Value::Number(
-			serde_json::Number::from_f64(*f).ok_or_else(|| MdtError::UnconvertibleFloat {
-				path: path_display.to_string(),
-				value: f.to_string(),
-			})?,
-		)),
+		kdl::KdlValue::Integer(i) => {
+			Ok(serde_json::Value::Number(
+				serde_json::Number::from_f64(*i as f64).ok_or_else(|| {
+					MdtError::UnconvertibleFloat {
+						path: path_display.to_string(),
+						value: i.to_string(),
+					}
+				})?,
+			))
+		}
+		kdl::KdlValue::Float(f) => {
+			Ok(serde_json::Value::Number(
+				serde_json::Number::from_f64(*f).ok_or_else(|| {
+					MdtError::UnconvertibleFloat {
+						path: path_display.to_string(),
+						value: f.to_string(),
+					}
+				})?,
+			))
+		}
 		kdl::KdlValue::Bool(b) => Ok(serde_json::Value::Bool(*b)),
 		kdl::KdlValue::Null => Ok(serde_json::Value::Null),
 	}

--- a/mdt_core/src/engine.rs
+++ b/mdt_core/src/engine.rs
@@ -301,8 +301,8 @@ pub fn check_project(ctx: &ProjectContext) -> MdtResult<CheckResult> {
 					render_errors.push(RenderError {
 						file: consumer.file.clone(),
 						block_name: consumer.block.name.clone(),
-						message: "inline block requires one template argument, e.g. \
-						          <!-- {~name:\"{{ pkg.version }}\"} -->"
+						message: "inline block requires one template argument, e.g. <!-- \
+						          {~name:\"{{ pkg.version }}\"} -->"
 							.to_string(),
 						line: consumer.block.opening.start.line,
 						column: consumer.block.opening.start.column,
@@ -792,17 +792,21 @@ fn pad_content_with_config(
 }
 
 fn get_string_arg(args: &[Argument], index: usize) -> Option<String> {
-	args.get(index).map(|arg| match arg {
-		Argument::String(s) => s.clone(),
-		Argument::Number(n) => n.to_string(),
-		Argument::Boolean(b) => b.to_string(),
+	args.get(index).map(|arg| {
+		match arg {
+			Argument::String(s) => s.clone(),
+			Argument::Number(n) => n.to_string(),
+			Argument::Boolean(b) => b.to_string(),
+		}
 	})
 }
 
 fn get_bool_arg(args: &[Argument], index: usize) -> Option<bool> {
-	args.get(index).map(|arg| match arg {
-		Argument::Boolean(b) => *b,
-		Argument::String(s) => s == "true",
-		Argument::Number(n) => n.0 != 0.0,
+	args.get(index).map(|arg| {
+		match arg {
+			Argument::Boolean(b) => *b,
+			Argument::String(s) => s == "true",
+			Argument::Number(n) => n.0 != 0.0,
+		}
 	})
 }

--- a/mdt_core/src/lexer.rs
+++ b/mdt_core/src/lexer.rs
@@ -235,39 +235,41 @@ impl<'a> TokenWalker<'a> {
 						}
 					}
 				}
-				Some(LexerContext::HtmlComment) => match raw {
-					RawToken::HtmlCommentClose => {
-						self.stack.pop();
-						self.push_token(Token::HtmlCommentClose, false);
-						self.push_token_group();
+				Some(LexerContext::HtmlComment) => {
+					match raw {
+						RawToken::HtmlCommentClose => {
+							self.stack.pop();
+							self.push_token(Token::HtmlCommentClose, false);
+							self.push_token_group();
+						}
+						RawToken::ConsumerTag => {
+							self.stack.push(LexerContext::Tag);
+							self.push_token(Token::ConsumerTag, false);
+						}
+						RawToken::ProviderTag => {
+							self.stack.push(LexerContext::Tag);
+							self.push_token(Token::ProviderTag, false);
+						}
+						RawToken::InlineTag => {
+							self.stack.push(LexerContext::Tag);
+							self.push_token(Token::InlineTag, false);
+						}
+						RawToken::CloseTag => {
+							self.stack.push(LexerContext::Tag);
+							self.push_token(Token::CloseTag, false);
+						}
+						RawToken::Newline => {
+							self.push_token(Token::Newline, false);
+						}
+						RawToken::Whitespace => {
+							let byte = self.current_slice().as_bytes()[0];
+							self.push_token(Token::Whitespace(byte), false);
+						}
+						_ => {
+							self.exit_comment_block();
+						}
 					}
-					RawToken::ConsumerTag => {
-						self.stack.push(LexerContext::Tag);
-						self.push_token(Token::ConsumerTag, false);
-					}
-					RawToken::ProviderTag => {
-						self.stack.push(LexerContext::Tag);
-						self.push_token(Token::ProviderTag, false);
-					}
-					RawToken::InlineTag => {
-						self.stack.push(LexerContext::Tag);
-						self.push_token(Token::InlineTag, false);
-					}
-					RawToken::CloseTag => {
-						self.stack.push(LexerContext::Tag);
-						self.push_token(Token::CloseTag, false);
-					}
-					RawToken::Newline => {
-						self.push_token(Token::Newline, false);
-					}
-					RawToken::Whitespace => {
-						let byte = self.current_slice().as_bytes()[0];
-						self.push_token(Token::Whitespace(byte), false);
-					}
-					_ => {
-						self.exit_comment_block();
-					}
-				},
+				}
 				Some(LexerContext::Tag) => {
 					match raw {
 						RawToken::BraceClose => {

--- a/mdt_core/src/lib.rs
+++ b/mdt_core/src/lib.rs
@@ -39,8 +39,7 @@
 //!
 //! Then in provider blocks: `{{ pkg.version }}` or `{{ cargo.package.edition }}`.
 //!
-//! Supported sources: files and script commands. Supported formats: text, JSON,
-//! TOML, YAML, KDL, and INI.
+//! Supported sources: files and script commands. Supported formats: text, JSON, TOML, YAML, KDL, and INI.
 //!
 //! ## Quick Start
 //!

--- a/mdt_core/src/patterns.rs
+++ b/mdt_core/src/patterns.rs
@@ -150,12 +150,12 @@ pub fn group(matchers: Vec<PatternMatcher>) -> PatternMatcher {
 
 pub fn optional_many_group(matchers: Vec<PatternMatcher>) -> PatternMatcher {
 	let method = many_group(matchers);
-	Box::new(
-		move |token_group: &TokenGroup, index: usize| match method(token_group, index) {
+	Box::new(move |token_group: &TokenGroup, index: usize| {
+		match method(token_group, index) {
 			Ok(index) => Ok(index),
 			Err(_) => Ok(index),
-		},
-	)
+		}
+	})
 }
 
 pub fn many_group(matchers: Vec<PatternMatcher>) -> PatternMatcher {
@@ -187,12 +187,12 @@ pub fn one(tokens: Vec<Token>) -> PatternMatcher {
 
 pub fn optional_many(tokens: Vec<Token>) -> PatternMatcher {
 	let method = many(tokens);
-	Box::new(
-		move |token_group: &TokenGroup, index: usize| match method(token_group, index) {
+	Box::new(move |token_group: &TokenGroup, index: usize| {
+		match method(token_group, index) {
 			Ok(index) => Ok(index),
 			Err(_) => Ok(index),
-		},
-	)
+		}
+	})
 }
 
 pub fn many(tokens: Vec<Token>) -> PatternMatcher {

--- a/mdt_core/src/project.rs
+++ b/mdt_core/src/project.rs
@@ -486,34 +486,40 @@ fn hash_file_contents(path: &Path) -> MdtResult<u64> {
 
 fn parse_diagnostic_to_project(file: &Path, diag: ParseDiagnostic) -> ProjectDiagnostic {
 	match diag {
-		ParseDiagnostic::UnclosedBlock { name, line, column } => ProjectDiagnostic {
-			file: file.to_path_buf(),
-			kind: DiagnosticKind::UnclosedBlock { name },
-			line,
-			column,
-		},
-		ParseDiagnostic::UnknownTransformer { name, line, column } => ProjectDiagnostic {
-			file: file.to_path_buf(),
-			kind: DiagnosticKind::UnknownTransformer { name },
-			line,
-			column,
-		},
+		ParseDiagnostic::UnclosedBlock { name, line, column } => {
+			ProjectDiagnostic {
+				file: file.to_path_buf(),
+				kind: DiagnosticKind::UnclosedBlock { name },
+				line,
+				column,
+			}
+		}
+		ParseDiagnostic::UnknownTransformer { name, line, column } => {
+			ProjectDiagnostic {
+				file: file.to_path_buf(),
+				kind: DiagnosticKind::UnknownTransformer { name },
+				line,
+				column,
+			}
+		}
 		ParseDiagnostic::InvalidTransformerArgs {
 			name,
 			expected,
 			got,
 			line,
 			column,
-		} => ProjectDiagnostic {
-			file: file.to_path_buf(),
-			kind: DiagnosticKind::InvalidTransformerArgs {
-				name,
-				expected,
-				got,
-			},
-			line,
-			column,
-		},
+		} => {
+			ProjectDiagnostic {
+				file: file.to_path_buf(),
+				kind: DiagnosticKind::InvalidTransformerArgs {
+					name,
+					expected,
+					got,
+				},
+				line,
+				column,
+			}
+		}
 	}
 }
 

--- a/mdt_lsp/src/__tests.rs
+++ b/mdt_lsp/src/__tests.rs
@@ -2995,17 +2995,19 @@ fn completion_returns_all_provider_names() {
 		},
 	);
 
-	let make_provider = |name: &str| ProviderEntry {
-		block: Block {
-			name: name.to_string(),
-			r#type: BlockType::Provider,
-			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-			transformers: Vec::new(),
-			arguments: vec![],
-		},
-		file: PathBuf::from("/tmp/test/template.t.md"),
-		content: "\n\ncontent\n\n".to_string(),
+	let make_provider = |name: &str| {
+		ProviderEntry {
+			block: Block {
+				name: name.to_string(),
+				r#type: BlockType::Provider,
+				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+				transformers: Vec::new(),
+				arguments: vec![],
+			},
+			file: PathBuf::from("/tmp/test/template.t.md"),
+			content: "\n\ncontent\n\n".to_string(),
+		}
 	};
 
 	let mut providers = HashMap::new();
@@ -3274,17 +3276,19 @@ fn suggest_similar_names_empty_providers_returns_empty() {
 
 #[test]
 fn suggest_similar_names_max_three_results() {
-	let make_provider = |name: &str| ProviderEntry {
-		block: Block {
-			name: name.to_string(),
-			r#type: BlockType::Provider,
-			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-			transformers: Vec::new(),
-			arguments: vec![],
-		},
-		file: PathBuf::from("/tmp/test/template.t.md"),
-		content: String::new(),
+	let make_provider = |name: &str| {
+		ProviderEntry {
+			block: Block {
+				name: name.to_string(),
+				r#type: BlockType::Provider,
+				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+				transformers: Vec::new(),
+				arguments: vec![],
+			},
+			file: PathBuf::from("/tmp/test/template.t.md"),
+			content: String::new(),
+		}
 	};
 
 	let mut providers = HashMap::new();
@@ -3592,9 +3596,11 @@ Old farewell
 
 	let titles: Vec<String> = actions
 		.iter()
-		.map(|a| match a {
-			CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
-			CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
+		.map(|a| {
+			match a {
+				CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
+				CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
+			}
 		})
 		.collect();
 	assert!(
@@ -5059,7 +5065,8 @@ fn document_symbols_multiple_blocks_correct_ranges() {
 /// consumer that passes an argument value.  The provider template uses
 /// `{{ crate_name }}` which should be replaced by the consumer's argument.
 fn make_args_test_state(consumer_arg: &str, consumer_body: &str) -> (WorkspaceState, Uri) {
-	let provider_template = "<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
+	let provider_template =
+		"<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
 		 crate_name }})]\n\n<!-- {/badges} -->\n";
 	let consumer_doc = format!(
 		"# Readme\n\n<!-- {{=badges:\"{consumer_arg}\"}} -->\n\n{consumer_body}\n\n<!-- \

--- a/mdt_lsp/src/lib.rs
+++ b/mdt_lsp/src/lib.rs
@@ -738,8 +738,8 @@ fn compute_diagnostics(state: &WorkspaceState, uri: &Uri) -> Vec<Diagnostic> {
 						severity: Some(DiagnosticSeverity::ERROR),
 						source: Some("mdt".to_string()),
 						message: format!(
-							"Inline block `{}` requires a template argument, e.g. \
-							 <!-- {{~{}:\"{{{{ pkg.version }}}}\"}} -->",
+							"Inline block `{}` requires a template argument, e.g. <!-- \
+							 {{~{}:\"{{{{ pkg.version }}}}\"}} -->",
 							block.name, block.name
 						),
 						..Default::default()
@@ -1056,15 +1056,17 @@ fn block_name_completions(state: &WorkspaceState) -> Vec<CompletionItem> {
 	state
 		.providers
 		.iter()
-		.map(|(name, entry)| CompletionItem {
-			label: name.clone(),
-			kind: Some(CompletionItemKind::REFERENCE),
-			detail: Some(format!("Provider from {}", entry.file.display())),
-			documentation: Some(Documentation::MarkupContent(MarkupContent {
-				kind: MarkupKind::Markdown,
-				value: format!("```\n{}\n```", entry.content.trim()),
-			})),
-			..Default::default()
+		.map(|(name, entry)| {
+			CompletionItem {
+				label: name.clone(),
+				kind: Some(CompletionItemKind::REFERENCE),
+				detail: Some(format!("Provider from {}", entry.file.display())),
+				documentation: Some(Documentation::MarkupContent(MarkupContent {
+					kind: MarkupKind::Markdown,
+					value: format!("```\n{}\n```", entry.content.trim()),
+				})),
+				..Default::default()
+			}
 		})
 		.collect()
 }
@@ -1115,12 +1117,14 @@ fn transformer_completions() -> Vec<CompletionItem> {
 	transformers
 		.iter()
 		.enumerate()
-		.map(|(i, (name, desc))| CompletionItem {
-			label: (*name).to_string(),
-			kind: Some(CompletionItemKind::FUNCTION),
-			detail: Some((*desc).to_string()),
-			sort_text: Some(format!("{i:02}")),
-			..Default::default()
+		.map(|(i, (name, desc))| {
+			CompletionItem {
+				label: (*name).to_string(),
+				kind: Some(CompletionItemKind::FUNCTION),
+				detail: Some((*desc).to_string()),
+				sort_text: Some(format!("{i:02}")),
+				..Default::default()
+			}
 		})
 		.collect()
 }

--- a/mdt_mcp/readme.md
+++ b/mdt_mcp/readme.md
@@ -22,6 +22,12 @@
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
 - **`mdt_init`** — Initialize a new mdt project with a sample template file.
 
+### Agent Workflow
+
+- Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+- Keep provider names global and unique in the project to avoid collisions.
+- After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
+
 ### Usage
 
 Start the MCP server via the CLI:

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -11,6 +11,12 @@
 //! - **`mdt_preview`** — Preview the result of applying transformers to a block.
 //! - **`mdt_init`** — Initialize a new mdt project with a sample template file.
 //!
+//! ### Agent Workflow
+//!
+//! - Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+//! - Keep provider names global and unique in the project to avoid collisions.
+//! - After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
+//!
 //! ### Usage
 //!
 //! Start the MCP server via the CLI:
@@ -147,7 +153,8 @@ impl ServerHandler for MdtMcpServer {
 				 project using comment-based template tags. Use these tools to check, update, \
 				 list, preview, and find reusable blocks. Before creating a new provider, run \
 				 mdt_find_reuse or mdt_list to discover similar block names and existing \
-				 markdown/source consumers."
+				 markdown/source consumers. Prefer reuse over new provider names when possible, \
+				 then run mdt_check (and mdt_update if needed) to keep consumers synchronized."
 					.into(),
 			),
 			capabilities: ServerCapabilities::builder().enable_tools().build(),

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,9 @@ This content gets replaced
 
 ```markdown
 <!-- {~version:"{{ package.version }}"} -->
+
 0.0.0
+
 <!-- {/version} -->
 ```
 
@@ -77,6 +79,12 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 - `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
+
+### Diagnostics Workflow
+
+- Run `mdt info` first to inspect project shape, diagnostics totals, and cache reuse telemetry.
+- Run `mdt doctor` when you need actionable health checks and remediation hints (config/data/layout/cache).
+- Use `MDT_CACHE_VERIFY_HASH=1` when troubleshooting cache consistency issues and comparing reuse behavior.
 
 <!-- {/mdtCliUsage} -->
 

--- a/template.t.md
+++ b/template.t.md
@@ -16,6 +16,12 @@
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 
+### Diagnostics Workflow
+
+- Run `mdt info` first to inspect project shape, diagnostics totals, and cache reuse telemetry.
+- Run `mdt doctor` when you need actionable health checks and remediation hints (config/data/layout/cache).
+- Use `MDT_CACHE_VERIFY_HASH=1` when troubleshooting cache consistency issues and comparing reuse behavior.
+
 <!-- {/mdtCliUsage} -->
 
 <!-- {@mdtTemplateSyntax} -->
@@ -46,7 +52,9 @@ This content gets replaced
 
 ```markdown
 <!-- {~version:"{{ "{{" }} package.version {{ "}}" }}"} -->
+
 0.0.0
+
 <!-- {/version} -->
 ```
 
@@ -87,9 +95,7 @@ Because inline blocks are provider-free, they are ideal for one-off values that 
 
 <!-- {@mdtScriptDataSourcesGuide} -->
 
-`[data]` entries can run shell commands and use stdout as template data. This
-is useful for values that come from tooling (for example Nix, git metadata,
-or generated version files).
+`[data]` entries can run shell commands and use stdout as template data. This is useful for values that come from tooling (for example Nix, git metadata, or generated version files).
 
 ```toml
 [data]
@@ -100,8 +106,7 @@ release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
 - `format`: parser for stdout (`text`, `json`, `toml`, `yaml`, `yml`, `kdl`, `ini`).
 - `watch`: files that control cache invalidation.
 
-When `watch` files are unchanged, mdt reuses cached script output from
-`.mdt/cache/data-v1.json` instead of re-running the command.
+When `watch` files are unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json` instead of re-running the command.
 
 <!-- {/mdtScriptDataSourcesGuide} -->
 
@@ -153,6 +158,12 @@ The server communicates over stdin/stdout using the Language Server Protocol.
 - **`mdt_get_block`** — Get the content of a specific block by name.
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
 - **`mdt_init`** — Initialize a new mdt project with a sample template file.
+
+### Agent Workflow
+
+- Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+- Keep provider names global and unique in the project to avoid collisions.
+- After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
 
 ### Usage
 
@@ -270,8 +281,7 @@ cargo = "Cargo.toml"
 
 Then in provider blocks: `{{ "{{" }} pkg.version {{ "}}" }}` or `{{ "{{" }} cargo.package.edition {{ "}}" }}`.
 
-Supported sources: files and script commands. Supported formats: text, JSON,
-TOML, YAML, KDL, and INI.
+Supported sources: files and script commands. Supported formats: text, JSON, TOML, YAML, KDL, and INI.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

This PR completes the docs/book/README/agent updates for the new diagnostics and cache observability workflow, and fixes the root cause of the previous `mdt update -> dprint fmt -> mdt check` churn.

### What changed

- Added diagnostics guidance across docs and READMEs:
  - `mdt info` workflow and interpretation
  - `mdt doctor` workflow and remediation hints
  - cache troubleshooting via `MDT_CACHE_VERIFY_HASH=1`
- Updated agent-facing guidance:
  - `CLAUDE.md` command/docs updates
  - MCP server instruction text to enforce reuse-first workflows (`mdt_find_reuse` / `mdt_list`) and post-edit sync (`mdt_check` / `mdt_update`)
- Updated template-driven documentation (`template.t.md`) and regenerated consumers.

### Root-cause fix for the previous issue

`mdt check` was failing after formatting because some generated markdown blocks were not formatter-stable:

- provider content style in `template.t.md` did not match dprint-normalized output in consumers
- `|trim` on specific docs consumer tags removed boundary newlines that dprint then reintroduced

Fixes applied:

- normalized affected provider block bodies in `template.t.md` to match post-format markdown style
- removed `|trim` on the affected docs consumer tags so output remains stable through formatting

Result: `mdt update -> dprint fmt -> mdt check` is now idempotent again.

## Verification

Local verification run end-to-end:

- `dprint check`
- `cargo clippy --all-features`
- `cargo run --bin mdt -- check`
- `cargo nextest run` (816 passed)
- `cargo test --doc`
- `cargo build --locked`
- `cargo build --all-features --locked`
- `mdbook build docs`

Dogfooding on this repo:

- `cargo run --bin mdt -- info --path .`
- `cargo run --bin mdt -- doctor --path .`

Both diagnostics commands execute successfully and report expected project/cache telemetry.
