### PR TITLE
ci: add benchmark workflow with regression policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe what changed and why.
+
+## Testing
+
+- [ ] `cargo test`
+- [ ] manual validation (if applicable)
+
+## Benchmark Justification
+
+Required only when benchmark CI reports regressions above threshold.
+
+Explain:
+
+- which benchmark scenario regressed
+- why the tradeoff is necessary
+- how/when performance will be recovered (if applicable)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,264 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  benchmark:
+    name: benchmark (baseline vs candidate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    container:
+      image: rust:1.86.0-bookworm
+    env:
+      BENCH_ITERATIONS: "7"
+      BENCH_WARMUP: "2"
+      BENCH_FILE_COUNT: "200"
+      BENCH_RELATIVE_THRESHOLD_PCT: "8"
+      BENCH_ABSOLUTE_THRESHOLD_MS: "5"
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: install benchmark dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends jq
+
+      - name: cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: determine benchmark refs
+        id: refs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          candidate_ref="$(git rev-parse HEAD)"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags --prune --depth=1 origin main
+            baseline_ref="$(git merge-base "${candidate_ref}" origin/main)"
+          else
+            if git rev-parse "${candidate_ref}^" >/dev/null 2>&1; then
+              baseline_ref="$(git rev-parse "${candidate_ref}^")"
+            else
+              baseline_ref="${candidate_ref}"
+            fi
+          fi
+
+          echo "candidate_ref=${candidate_ref}" >> "${GITHUB_OUTPUT}"
+          echo "baseline_ref=${baseline_ref}" >> "${GITHUB_OUTPUT}"
+
+          echo "candidate_ref=${candidate_ref}"
+          echo "baseline_ref=${baseline_ref}"
+
+      - name: create worktrees
+        id: worktrees
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          benchmark_root="$(mktemp -d /tmp/mdt-benchmark-XXXXXX)"
+          baseline_dir="${benchmark_root}/baseline"
+          candidate_dir="${benchmark_root}/candidate"
+
+          git worktree add --detach "${baseline_dir}" "${{ steps.refs.outputs.baseline_ref }}"
+          git worktree add --detach "${candidate_dir}" "${{ steps.refs.outputs.candidate_ref }}"
+
+          echo "benchmark_root=${benchmark_root}" >> "${GITHUB_OUTPUT}"
+          echo "baseline_dir=${baseline_dir}" >> "${GITHUB_OUTPUT}"
+          echo "candidate_dir=${candidate_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: build baseline and candidate binaries
+        id: build
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          baseline_target="${{ steps.worktrees.outputs.benchmark_root }}/target-baseline"
+          candidate_target="${{ steps.worktrees.outputs.benchmark_root }}/target-candidate"
+
+          CARGO_TARGET_DIR="${baseline_target}" cargo build --release --locked --manifest-path "${{ steps.worktrees.outputs.baseline_dir }}/mdt_cli/Cargo.toml"
+          CARGO_TARGET_DIR="${candidate_target}" cargo build --release --locked --manifest-path "${{ steps.worktrees.outputs.candidate_dir }}/mdt_cli/Cargo.toml"
+
+          baseline_bin="${baseline_target}/release/mdt"
+          candidate_bin="${candidate_target}/release/mdt"
+
+          echo "baseline_bin=${baseline_bin}" >> "${GITHUB_OUTPUT}"
+          echo "candidate_bin=${candidate_bin}" >> "${GITHUB_OUTPUT}"
+
+      - name: run benchmark suite
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p benchmark-results
+
+          scripts/benchmark/run_suite.sh \
+            --binary "${{ steps.build.outputs.baseline_bin }}" \
+            --output benchmark-results/baseline.json \
+            --label "baseline:${{ steps.refs.outputs.baseline_ref }}" \
+            --iterations "${BENCH_ITERATIONS}" \
+            --warmup "${BENCH_WARMUP}" \
+            --files "${BENCH_FILE_COUNT}" \
+            --workdir "${{ steps.worktrees.outputs.benchmark_root }}/suite-baseline"
+
+          scripts/benchmark/run_suite.sh \
+            --binary "${{ steps.build.outputs.candidate_bin }}" \
+            --output benchmark-results/candidate.json \
+            --label "candidate:${{ steps.refs.outputs.candidate_ref }}" \
+            --iterations "${BENCH_ITERATIONS}" \
+            --warmup "${BENCH_WARMUP}" \
+            --files "${BENCH_FILE_COUNT}" \
+            --workdir "${{ steps.worktrees.outputs.benchmark_root }}/suite-candidate"
+
+      - name: compare baseline and candidate
+        id: compare
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          scripts/benchmark/compare_results.sh \
+            --baseline benchmark-results/baseline.json \
+            --candidate benchmark-results/candidate.json \
+            --output benchmark-results/compare.json \
+            --markdown benchmark-results/compare.md \
+            --relative-threshold-pct "${BENCH_RELATIVE_THRESHOLD_PCT}" \
+            --absolute-threshold-ms "${BENCH_ABSOLUTE_THRESHOLD_MS}"
+
+          echo "status=$(jq -r '.status' benchmark-results/compare.json)" >> "${GITHUB_OUTPUT}"
+          echo "regression_count=$(jq -r '.regression_count' benchmark-results/compare.json)" >> "${GITHUB_OUTPUT}"
+          echo "improvement_count=$(jq -r '.improvement_count' benchmark-results/compare.json)" >> "${GITHUB_OUTPUT}"
+          echo "missing_count=$(jq -r '.missing_count' benchmark-results/compare.json)" >> "${GITHUB_OUTPUT}"
+
+      - name: publish benchmark summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "# Benchmark Results"
+            echo
+            echo "- Baseline ref: \`${{ steps.refs.outputs.baseline_ref }}\`"
+            echo "- Candidate ref: \`${{ steps.refs.outputs.candidate_ref }}\`"
+            echo
+            cat benchmark-results/compare.md
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results
+          retention-days: 90
+
+      - name: comment benchmark report on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const marker = '<!-- mdt-benchmark-report -->';
+            const report = fs.readFileSync('benchmark-results/compare.md', 'utf8');
+            const body = `${marker}\n## Benchmark Report\n\n${report}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: enforce benchmark policy
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          regression_count="${{ steps.compare.outputs.regression_count }}"
+
+          if (( regression_count == 0 )); then
+            echo "No regressions above threshold."
+            exit 0
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            echo "::error::Detected ${regression_count} benchmark regressions above threshold on push event."
+            exit 1
+          fi
+
+          pr_body="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
+
+          justification_text="$(
+            printf '%s\n' "${pr_body}" | awk '
+              BEGIN { capture = 0 }
+              /^##[[:space:]]+Benchmark Justification[[:space:]]*$/ { capture = 1; next }
+              /^##[[:space:]]+/ && capture == 1 { capture = 0 }
+              capture == 1 { print }
+            '
+          )"
+
+          justification_text="$(printf '%s\n' "${justification_text}" | sed '/^[[:space:]]*$/d')"
+
+          if [[ -z "${justification_text}" ]]; then
+            echo "::error::Detected ${regression_count} benchmark regressions above threshold. Add a '## Benchmark Justification' section to the PR description explaining the tradeoff."
+            exit 1
+          fi
+
+          echo "Benchmark regressions detected but justification section is present in PR description."
+
+      - name: clean up worktrees
+        if: always()
+        shell: bash
+        run: |
+          set +e
+
+          benchmark_root="${{ steps.worktrees.outputs.benchmark_root }}"
+          baseline_dir="${{ steps.worktrees.outputs.baseline_dir }}"
+          candidate_dir="${{ steps.worktrees.outputs.candidate_dir }}"
+
+          if [[ -n "${baseline_dir}" ]]; then
+            git worktree remove --force "${baseline_dir}" || true
+          fi
+          if [[ -n "${candidate_dir}" ]]; then
+            git worktree remove --force "${candidate_dir}" || true
+          fi
+          if [[ -n "${benchmark_root}" ]]; then
+            rm -rf "${benchmark_root}" || true
+          fi

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Monorepo & Multi-Project Setups](./advanced/monorepos.md)
 - [Block Arguments](./advanced/block-arguments.md)
 - [Inline Blocks](./advanced/inline-blocks.md)
+- [Benchmarking and Regressions](./advanced/benchmarking-and-regressions.md)
 
 # Reference
 

--- a/docs/src/advanced/benchmarking-and-regressions.md
+++ b/docs/src/advanced/benchmarking-and-regressions.md
@@ -1,0 +1,57 @@
+# Benchmarking and Regressions
+
+This project tracks CLI performance continuously in CI.
+
+## What CI benchmarks
+
+The benchmark workflow compares two revisions in the **same CI job** and **same Docker container**:
+
+- `baseline`: merge-base with `main` (for pull requests) or previous commit (for pushes to `main`)
+- `candidate`: the commit under test
+
+Each revision is built in `--release` mode, then benchmarked against the same deterministic workload.
+
+Scenarios currently include:
+
+- `check_cold_clean`
+- `check_warm_clean`
+- `check_cold_stale`
+- `check_diff_stale`
+- `update_stale`
+- `update_noop_clean`
+- `list_clean`
+- `info_clean`
+
+## Consistency strategy
+
+Absolute runtimes naturally drift as GitHub runners evolve. To keep comparisons stable, we enforce:
+
+- Same machine for both baseline and candidate (single job)
+- Same container image (`rust:1.86.0-bookworm`)
+- Same generated workload and iteration counts
+- Median-based comparisons with combined thresholds
+
+A regression is only flagged when **both** are true:
+
+- Relative slowdown exceeds `BENCH_RELATIVE_THRESHOLD_PCT`
+- Absolute slowdown exceeds `BENCH_ABSOLUTE_THRESHOLD_MS`
+
+This avoids failing on tiny/noisy deltas.
+
+## Regression policy
+
+If benchmark regressions are detected on a pull request, the PR must include a
+`## Benchmark Justification` section in the PR description explaining why the
+tradeoff is acceptable.
+
+Without this section, the benchmark workflow fails.
+
+## Historical records
+
+Each benchmark run uploads artifacts with:
+
+- Baseline results (`baseline.json`)
+- Candidate results (`candidate.json`)
+- Comparison report (`compare.json`, `compare.md`)
+
+CI also posts an updated benchmark report comment on pull requests.

--- a/docs/src/guide/ci-integration.md
+++ b/docs/src/guide/ci-integration.md
@@ -190,3 +190,19 @@ jobs:
     steps:
       - uses: actions/deploy-pages@v4
 ```
+
+## Benchmark CI (this repository)
+
+This repository also runs `.github/workflows/benchmark.yml` on `pull_request`
+and `push` to `main`.
+
+The benchmark job:
+
+1. Builds `mdt` for a baseline ref and the candidate ref.
+2. Runs both binaries against the same deterministic workload.
+3. Compares medians per scenario with relative and absolute thresholds.
+4. Uploads raw benchmark artifacts and posts a PR comment report.
+
+When regressions exceed threshold, pull requests must include a
+`## Benchmark Justification` section in the PR description to document the
+tradeoff.

--- a/scripts/benchmark/compare_results.sh
+++ b/scripts/benchmark/compare_results.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Compare two benchmark result JSON files.
+
+Usage:
+  scripts/benchmark/compare_results.sh \
+    --baseline <path> \
+    --candidate <path> \
+    --output <path> \
+    [--markdown <path>] \
+    [--relative-threshold-pct <value>] \
+    [--absolute-threshold-ms <value>] \
+    [--fail-on-regression]
+
+Options:
+  --baseline <path>                 Baseline benchmark JSON (required).
+  --candidate <path>                Candidate benchmark JSON (required).
+  --output <path>                   Comparison JSON output (required).
+  --markdown <path>                 Optional markdown report path.
+  --relative-threshold-pct <value>  Percentage threshold to classify regression (default: 8).
+  --absolute-threshold-ms <value>   Absolute ms threshold to classify regression (default: 5).
+  --fail-on-regression              Exit non-zero when regressions are detected.
+USAGE
+}
+
+baseline=""
+candidate=""
+output=""
+markdown=""
+relative_threshold_pct="8"
+absolute_threshold_ms="5"
+fail_on_regression=false
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--baseline)
+			baseline="${2:-}"
+			shift 2
+			;;
+		--candidate)
+			candidate="${2:-}"
+			shift 2
+			;;
+		--output)
+			output="${2:-}"
+			shift 2
+			;;
+		--markdown)
+			markdown="${2:-}"
+			shift 2
+			;;
+		--relative-threshold-pct)
+			relative_threshold_pct="${2:-}"
+			shift 2
+			;;
+		--absolute-threshold-ms)
+			absolute_threshold_ms="${2:-}"
+			shift 2
+			;;
+		--fail-on-regression)
+			fail_on_regression=true
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "unknown option: $1" >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+done
+
+if [[ -z "$baseline" || -z "$candidate" || -z "$output" ]]; then
+	echo "--baseline, --candidate, and --output are required" >&2
+	exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "jq is required for compare_results.sh" >&2
+	exit 1
+fi
+
+mkdir -p "$(dirname "$output")"
+
+jq -n \
+	--slurpfile baseline "$baseline" \
+	--slurpfile candidate "$candidate" \
+	--argjson relative_threshold_pct "$relative_threshold_pct" \
+	--argjson absolute_threshold_ms "$absolute_threshold_ms" '
+	def to_map($arr):
+		reduce $arr[] as $item ({}; .[$item.name] = $item);
+
+	($baseline[0]) as $baseline_doc
+	| ($candidate[0]) as $candidate_doc
+	| ($baseline_doc.scenarios // []) as $baseline_scenarios
+	| ($candidate_doc.scenarios // []) as $candidate_scenarios
+	| (to_map($baseline_scenarios)) as $baseline_map
+	| (to_map($candidate_scenarios)) as $candidate_map
+	| (((($baseline_map | keys) + ($candidate_map | keys)) | unique | sort)) as $scenario_names
+	| {
+		schema_version: 1,
+		generated_at_utc: (now | strftime("%Y-%m-%dT%H:%M:%SZ")),
+		baseline: {
+			label: ($baseline_doc.label // "baseline"),
+			generated_at_utc: $baseline_doc.generated_at_utc,
+			binary: $baseline_doc.binary
+		},
+		candidate: {
+			label: ($candidate_doc.label // "candidate"),
+			generated_at_utc: $candidate_doc.generated_at_utc,
+			binary: $candidate_doc.binary
+		},
+		relative_threshold_pct: $relative_threshold_pct,
+		absolute_threshold_ms: $absolute_threshold_ms,
+		scenarios: [
+			$scenario_names[] as $name
+			| ($baseline_map[$name]) as $base
+			| ($candidate_map[$name]) as $cand
+			| if ($base == null or $cand == null) then
+				{
+					name: $name,
+					status: "missing"
+				}
+			else
+				($base.stats.median_ms) as $base_ms
+				| ($cand.stats.median_ms) as $cand_ms
+				| ($cand_ms - $base_ms) as $delta_ms
+				| (if $base_ms == 0 then 0 else ($delta_ms / $base_ms * 100) end) as $delta_pct
+				| {
+					name: $name,
+					baseline_ms: $base_ms,
+					candidate_ms: $cand_ms,
+					delta_ms: $delta_ms,
+					delta_pct: $delta_pct,
+					status: (
+						if ($delta_ms > $absolute_threshold_ms and $delta_pct > $relative_threshold_pct) then "regression"
+						elif ($delta_ms < (-$absolute_threshold_ms) and $delta_pct < (-$relative_threshold_pct)) then "improvement"
+						else "neutral"
+						end
+					)
+				}
+			end
+		]
+	}
+	| .missing_count = ([.scenarios[] | select(.status == "missing")] | length)
+	| .regression_count = ([.scenarios[] | select(.status == "regression")] | length)
+	| .improvement_count = ([.scenarios[] | select(.status == "improvement")] | length)
+	| .status = (
+		if .missing_count > 0 then "invalid"
+		elif .regression_count > 0 then "regression"
+		else "ok"
+		end
+	)
+' > "$output"
+
+if [[ -n "$markdown" ]]; then
+	mkdir -p "$(dirname "$markdown")"
+	{
+		echo "## mdt Benchmark Comparison"
+		echo
+		echo "- Baseline: \`$(jq -r '.baseline.label' "$output")\`"
+		echo "- Candidate: \`$(jq -r '.candidate.label' "$output")\`"
+		echo "- Thresholds: > ${relative_threshold_pct}% and > ${absolute_threshold_ms}ms"
+		echo
+		echo "| Scenario | Baseline (ms) | Candidate (ms) | Delta (ms) | Delta (%) | Status |"
+		echo "| --- | ---: | ---: | ---: | ---: | --- |"
+		jq -r '
+			def fmt:
+				if . == null then "-"
+				else (((. * 1000) | round) / 1000 | tostring)
+				end;
+			.scenarios[]
+			| "| `\(.name)` | \((.baseline_ms | fmt)) | \((.candidate_ms | fmt)) | \((.delta_ms | fmt)) | \((.delta_pct | fmt)) | \(.status) |"
+		' "$output"
+		echo
+		echo "Regressions: $(jq '.regression_count' "$output")"
+		echo "Improvements: $(jq '.improvement_count' "$output")"
+		echo "Missing scenarios: $(jq '.missing_count' "$output")"
+	} > "$markdown"
+fi
+
+status=$(jq -r '.status' "$output")
+regression_count=$(jq -r '.regression_count' "$output")
+missing_count=$(jq -r '.missing_count' "$output")
+
+echo "comparison status: $status"
+echo "regression_count: $regression_count"
+echo "missing_count: $missing_count"
+
+if (( missing_count > 0 )); then
+	echo "missing scenarios detected between baseline and candidate" >&2
+	exit 2
+fi
+
+if [[ "$fail_on_regression" == true && "$regression_count" -gt 0 ]]; then
+	echo "benchmark regressions exceeded thresholds" >&2
+	exit 3
+fi

--- a/scripts/benchmark/generate_workload.sh
+++ b/scripts/benchmark/generate_workload.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Generate a deterministic benchmark workload for mdt.
+
+Usage:
+  scripts/benchmark/generate_workload.sh --output <dir> [--files <count>]
+
+Options:
+  --output <dir>   Target directory for generated workload (required).
+  --files <count>  Number of markdown files to generate (default: 180).
+USAGE
+}
+
+output_dir=""
+file_count=180
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--output)
+			output_dir="${2:-}"
+			shift 2
+			;;
+		--files)
+			file_count="${2:-}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "unknown option: $1" >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+done
+
+if [[ -z "$output_dir" ]]; then
+	echo "--output is required" >&2
+	usage >&2
+	exit 1
+fi
+
+if ! [[ "$file_count" =~ ^[0-9]+$ ]]; then
+	echo "--files must be a positive integer" >&2
+	exit 1
+fi
+
+if (( file_count < 1 )); then
+	echo "--files must be >= 1" >&2
+	exit 1
+fi
+
+rm -rf "$output_dir"
+mkdir -p "$output_dir/.templates" "$output_dir/modules"
+
+cat > "$output_dir/package.json" <<'JSON'
+{
+	"name": "mdt-benchmark-fixture",
+	"version": "1.0.0",
+	"description": "Deterministic fixture used for CI benchmark comparisons"
+}
+JSON
+
+cat > "$output_dir/mdt.toml" <<'TOML'
+[templates]
+paths = [".templates"]
+
+[data]
+package = "package.json"
+
+[padding]
+before = 0
+after = 0
+TOML
+
+cat > "$output_dir/.templates/template.t.md" <<'TEMPLATE'
+<!-- {@overview} -->
+
+{{ package.name }} v{{ package.version }}
+
+{{ package.description }}
+
+<!-- {/overview} -->
+
+<!-- {@usage} -->
+
+Run `mdt check` to verify all consumer blocks are synchronized.
+Run `mdt update` to rewrite stale content.
+
+<!-- {/usage} -->
+
+<!-- {@api} -->
+
+pub fn benchmark_fixture_example() -> &'static str {
+    "ok"
+}
+
+<!-- {/api} -->
+
+<!-- {@notes} -->
+
+This fixture is intentionally deterministic.
+Do not manually edit generated files in CI.
+
+<!-- {/notes} -->
+TEMPLATE
+
+for ((i = 1; i <= file_count; i++)); do
+	module_id=$(printf "%04d" "$i")
+	group_id=$(printf "%02d" "$(((i - 1) / 20 + 1))")
+	group_dir="$output_dir/modules/group-$group_id"
+	mkdir -p "$group_dir"
+
+	cat > "$group_dir/module-$module_id.md" <<EOF_MODULE
+# Module $module_id
+
+<!-- {=overview|trim} -->
+stale overview $module_id
+<!-- {/overview} -->
+
+<!-- {=usage|trim} -->
+stale usage $module_id
+<!-- {/usage} -->
+
+<!-- {=api|trim} -->
+stale api $module_id
+<!-- {/api} -->
+
+<!-- {=notes|trim} -->
+stale notes $module_id
+<!-- {/notes} -->
+EOF_MODULE
+done
+
+echo "generated workload at $output_dir with $file_count markdown files"

--- a/scripts/benchmark/readme.md
+++ b/scripts/benchmark/readme.md
@@ -1,0 +1,36 @@
+# Benchmark Harness
+
+This folder contains the CLI benchmark harness used by CI.
+
+## Scripts
+
+- `generate_workload.sh`: creates a deterministic synthetic project with stale consumer blocks.
+- `run_suite.sh`: runs benchmark scenarios for a single `mdt` binary and writes JSON output.
+- `compare_results.sh`: compares baseline/candidate benchmark JSON and writes comparison JSON + markdown.
+
+## Local usage
+
+Build a release binary first:
+
+```bash
+cargo build --release --locked --manifest-path mdt_cli/Cargo.toml
+```
+
+Run the suite:
+
+```bash
+scripts/benchmark/run_suite.sh \
+  --binary ./target/release/mdt \
+  --output /tmp/mdt-benchmark-candidate.json \
+  --label candidate
+```
+
+Compare two runs:
+
+```bash
+scripts/benchmark/compare_results.sh \
+  --baseline /tmp/mdt-benchmark-baseline.json \
+  --candidate /tmp/mdt-benchmark-candidate.json \
+  --output /tmp/mdt-benchmark-compare.json \
+  --markdown /tmp/mdt-benchmark-compare.md
+```

--- a/scripts/benchmark/run_suite.sh
+++ b/scripts/benchmark/run_suite.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'USAGE'
+Run the mdt benchmark suite and export JSON results.
+
+Usage:
+  scripts/benchmark/run_suite.sh \
+    --binary <path> \
+    --output <path> \
+    [--label <name>] \
+    [--iterations <count>] \
+    [--warmup <count>] \
+    [--files <count>] \
+    [--workdir <path>]
+
+Options:
+  --binary <path>      Path to the mdt binary to benchmark (required).
+  --output <path>      JSON output path (required).
+  --label <name>       Logical label for this result set (default: unnamed).
+  --iterations <count> Timed iterations per scenario (default: 9).
+  --warmup <count>     Warmup iterations per scenario (default: 2).
+  --files <count>      Number of generated fixture files (default: 180).
+  --workdir <path>     Working directory for temporary benchmark fixtures.
+USAGE
+}
+
+json_escape() {
+	local value="$1"
+	value=${value//\\/\\\\}
+	value=${value//\"/\\\"}
+	value=${value//$'\n'/\\n}
+	value=${value//$'\r'/\\r}
+	value=${value//$'\t'/\\t}
+	printf '%s' "$value"
+}
+
+now_ns() {
+	perl -MTime::HiRes=time -e 'printf("%.0f\n", time() * 1000000000)'
+}
+
+join_by() {
+	local delimiter="$1"
+	shift
+	local first=true
+	for token in "$@"; do
+		if [[ "$first" == true ]]; then
+			printf '%s' "$token"
+			first=false
+		else
+			printf '%s%s' "$delimiter" "$token"
+		fi
+	done
+}
+
+calc_stats_json() {
+	local values=("$@")
+	if (( ${#values[@]} == 0 )); then
+		echo '{"min_ms":0,"max_ms":0,"mean_ms":0,"median_ms":0,"p95_ms":0,"samples_ms":[]}'
+		return
+	fi
+
+	local sorted
+	sorted=$(printf '%s\n' "${values[@]}" | sort -n)
+	local count
+	count=$(printf '%s\n' "$sorted" | awk 'NF {count += 1} END {print count}')
+
+	local min_ms
+	min_ms=$(printf '%s\n' "$sorted" | awk 'NF {print; exit}')
+	local max_ms
+	max_ms=$(printf '%s\n' "$sorted" | awk 'NF {value=$1} END {print value}')
+	local mean_ms
+	mean_ms=$(printf '%s\n' "$sorted" | awk 'NF {sum += $1; count += 1} END {if (count == 0) {print 0} else {printf "%.3f", sum / count}}')
+
+	local median_ms
+	median_ms=$(printf '%s\n' "$sorted" | awk '
+		NF { values[count] = $1; count += 1 }
+		END {
+			if (count == 0) {
+				print 0;
+				exit;
+			}
+			mid = int(count / 2);
+			if (count % 2 == 1) {
+				printf "%.3f", values[mid];
+			} else {
+				printf "%.3f", (values[mid - 1] + values[mid]) / 2;
+			}
+		}
+	')
+
+	local p95_ms
+	p95_ms=$(printf '%s\n' "$sorted" | awk '
+		NF { values[count] = $1; count += 1 }
+		END {
+			if (count == 0) {
+				print 0;
+				exit;
+			}
+			p95_index = int((count * 95 + 99) / 100) - 1;
+			if (p95_index < 0) {
+				p95_index = 0;
+			}
+			if (p95_index >= count) {
+				p95_index = count - 1;
+			}
+			printf "%.3f", values[p95_index];
+		}
+	')
+
+	local sample_json
+	sample_json="$(printf '%s\n' "$sorted" | awk 'NF {if (count > 0) {printf ","}; printf "%.3f", $1; count += 1} END {if (count == 0) {printf ""}}')"
+	if [[ -z "$sample_json" ]]; then
+		sample_json='[]'
+	else
+		sample_json="[$sample_json]"
+	fi
+
+	cat <<EOF_STATS
+{"min_ms":$min_ms,"max_ms":$max_ms,"mean_ms":$mean_ms,"median_ms":$median_ms,"p95_ms":$p95_ms,"samples_ms":$sample_json}
+EOF_STATS
+}
+
+run_command_timed() {
+	local expected_exit="$1"
+	local project_dir="$2"
+	shift 2
+	local start_ns
+	start_ns=$(now_ns)
+	set +e
+	"$binary" --no-color --path "$project_dir" "$@" >/dev/null 2>&1
+	local exit_code=$?
+	set -e
+	local end_ns
+	end_ns=$(now_ns)
+
+	if [[ "$exit_code" -ne "$expected_exit" ]]; then
+		echo "command failed with unexpected exit code: expected=$expected_exit actual=$exit_code command=$*" >&2
+		exit 1
+	fi
+
+	awk -v start="$start_ns" -v end="$end_ns" 'BEGIN { printf "%.3f", (end - start) / 1000000 }'
+}
+
+scenario_json_entries=()
+
+record_scenario() {
+	local name="$1"
+	local command_text="$2"
+	local expected_exit="$3"
+	shift 3
+	local samples=("$@")
+
+	local stats_json
+	stats_json=$(calc_stats_json "${samples[@]}")
+	local escaped_name
+	escaped_name=$(json_escape "$name")
+	local escaped_command
+	escaped_command=$(json_escape "$command_text")
+
+	scenario_json_entries+=("{\"name\":\"$escaped_name\",\"command\":\"$escaped_command\",\"expected_exit\":$expected_exit,\"iterations\":${#samples[@]},\"stats\":$stats_json}")
+}
+
+run_non_mutating_scenario() {
+	local name="$1"
+	local source_fixture="$2"
+	local cache_mode="$3"
+	local expected_exit="$4"
+	shift 4
+	local command=("$@")
+	local case_dir="$suite_dir/case-$name"
+	local samples=()
+
+	rm -rf "$case_dir"
+	cp -R "$source_fixture" "$case_dir"
+
+	for ((i = 1; i <= warmup; i++)); do
+		if [[ "$cache_mode" == "cold" ]]; then
+			rm -rf "$case_dir/.mdt"
+		fi
+		run_command_timed "$expected_exit" "$case_dir" "${command[@]}" >/dev/null
+	done
+
+	for ((i = 1; i <= iterations; i++)); do
+		if [[ "$cache_mode" == "cold" ]]; then
+			rm -rf "$case_dir/.mdt"
+		fi
+		samples+=("$(run_command_timed "$expected_exit" "$case_dir" "${command[@]}")")
+	done
+
+	record_scenario "$name" "${command[*]}" "$expected_exit" "${samples[@]}"
+}
+
+run_mutating_scenario() {
+	local name="$1"
+	local source_fixture="$2"
+	local expected_exit="$3"
+	shift 3
+	local command=("$@")
+	local case_dir="$suite_dir/case-$name"
+	local samples=()
+
+	for ((i = 1; i <= warmup; i++)); do
+		rm -rf "$case_dir"
+		cp -R "$source_fixture" "$case_dir"
+		run_command_timed "$expected_exit" "$case_dir" "${command[@]}" >/dev/null
+	done
+
+	for ((i = 1; i <= iterations; i++)); do
+		rm -rf "$case_dir"
+		cp -R "$source_fixture" "$case_dir"
+		samples+=("$(run_command_timed "$expected_exit" "$case_dir" "${command[@]}")")
+	done
+
+	record_scenario "$name" "${command[*]}" "$expected_exit" "${samples[@]}"
+}
+
+binary=""
+output=""
+label="unnamed"
+iterations=9
+warmup=2
+file_count=180
+workdir=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--binary)
+			binary="${2:-}"
+			shift 2
+			;;
+		--output)
+			output="${2:-}"
+			shift 2
+			;;
+		--label)
+			label="${2:-}"
+			shift 2
+			;;
+		--iterations)
+			iterations="${2:-}"
+			shift 2
+			;;
+		--warmup)
+			warmup="${2:-}"
+			shift 2
+			;;
+		--files)
+			file_count="${2:-}"
+			shift 2
+			;;
+		--workdir)
+			workdir="${2:-}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "unknown option: $1" >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+done
+
+if [[ -z "$binary" ]]; then
+	echo "--binary is required" >&2
+	exit 1
+fi
+
+if [[ -z "$output" ]]; then
+	echo "--output is required" >&2
+	exit 1
+fi
+
+if [[ ! -x "$binary" ]]; then
+	echo "binary is not executable: $binary" >&2
+	exit 1
+fi
+
+for numeric_arg in iterations warmup file_count; do
+	value="${!numeric_arg}"
+	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+		case "$numeric_arg" in
+			file_count)
+				echo "--files must be a non-negative integer" >&2
+				;;
+			*)
+				echo "--$numeric_arg must be a non-negative integer" >&2
+				;;
+		esac
+		exit 1
+	fi
+done
+
+if (( iterations < 1 )); then
+	echo "--iterations must be >= 1" >&2
+	exit 1
+fi
+
+if (( file_count < 1 )); then
+	echo "--files must be >= 1" >&2
+	exit 1
+fi
+
+if [[ -z "$workdir" ]]; then
+	workdir=$(mktemp -d -t mdt-benchmark-suite-XXXXXX)
+	cleanup_workdir=true
+else
+	mkdir -p "$workdir"
+	cleanup_workdir=false
+fi
+
+suite_dir="$workdir/suite"
+rm -rf "$suite_dir"
+mkdir -p "$suite_dir"
+
+stale_fixture="$suite_dir/workload-stale"
+clean_fixture="$suite_dir/workload-clean"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+"$script_dir/generate_workload.sh" --output "$stale_fixture" --files "$file_count" >/dev/null
+
+cp -R "$stale_fixture" "$clean_fixture"
+"$binary" --no-color --path "$clean_fixture" update >/dev/null
+
+run_non_mutating_scenario "check_cold_clean" "$clean_fixture" "cold" 0 check
+run_non_mutating_scenario "check_warm_clean" "$clean_fixture" "warm" 0 check
+run_non_mutating_scenario "check_cold_stale" "$stale_fixture" "cold" 1 check
+run_non_mutating_scenario "check_diff_stale" "$stale_fixture" "cold" 1 check --diff
+run_mutating_scenario "update_stale" "$stale_fixture" 0 update
+run_mutating_scenario "update_noop_clean" "$clean_fixture" 0 update
+run_non_mutating_scenario "list_clean" "$clean_fixture" "warm" 0 list
+run_non_mutating_scenario "info_clean" "$clean_fixture" "warm" 0 info
+
+mkdir -p "$(dirname "$output")"
+
+escaped_label=$(json_escape "$label")
+escaped_binary=$(json_escape "$binary")
+generated_at_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+scenario_joined=$(join_by , "${scenario_json_entries[@]}")
+
+cat > "$output" <<EOF_JSON
+{
+	"schema_version": 1,
+	"generated_at_utc": "${generated_at_utc}",
+	"label": "${escaped_label}",
+	"binary": "${escaped_binary}",
+	"iterations": ${iterations},
+	"warmup": ${warmup},
+	"file_count": ${file_count},
+	"scenarios": [${scenario_joined}]
+}
+EOF_JSON
+
+echo "benchmark suite complete: $output"
+
+if [[ "$cleanup_workdir" == true ]]; then
+	rm -rf "$workdir"
+fi


### PR DESCRIPTION
## Summary
- add a dedicated benchmark workflow that compares baseline vs candidate in the same containerized job
- add deterministic benchmark harness scripts for workload generation, suite execution, and result comparison
- enforce a benchmark regression policy requiring PR justification when thresholds are exceeded
- document benchmark consistency strategy and local benchmark usage

## Testing
- cargo build --release --locked --manifest-path mdt_cli/Cargo.toml
- bash -n scripts/benchmark/generate_workload.sh scripts/benchmark/run_suite.sh scripts/benchmark/compare_results.sh
- scripts/benchmark/run_suite.sh --binary ./target/release/mdt --output /tmp/mdt-benchmark-candidate.json --label candidate --iterations 3 --warmup 1 --files 40
- scripts/benchmark/run_suite.sh --binary ./target/release/mdt --output /tmp/mdt-benchmark-baseline.json --label baseline --iterations 3 --warmup 1 --files 40
- scripts/benchmark/compare_results.sh --baseline /tmp/mdt-benchmark-baseline.json --candidate /tmp/mdt-benchmark-candidate.json --output /tmp/mdt-benchmark-compare.json --markdown /tmp/mdt-benchmark-compare.md --relative-threshold-pct 8 --absolute-threshold-ms 5