### PR TITLE
docs: expand inline template examples and add coverage

### DIFF
--- a/docs/src/advanced/inline-blocks.md
+++ b/docs/src/advanced/inline-blocks.md
@@ -27,9 +27,50 @@ Because inline blocks are provider-free, they are ideal for one-off values that 
 - Inline blocks must include a first argument that is the template string to render.
 - Inline blocks do not resolve provider content; everything comes from the inline template argument and current data context.
 - Inline rendering still supports transformers (`|trim`, `|code`, etc.) after template evaluation.
-- Inline blocks are scanned where mdt scans HTML comment tags (markdown and supported source comments), and follow the same code-block filtering rules configured for source scanning.
+- In markdown, inline blocks work in normal content (paragraphs, lists, headings, tables) where HTML comments are parsed.
+- Tags shown inside fenced markdown code blocks are treated as examples and are not interpreted as live blocks.
+- In source files, inline tags follow source scanning rules and respect `[exclude] markdown_codeblocks` filtering.
 
 <!-- {/mdtInlineBlocksLimits} -->
+
+## Practical examples
+
+<!-- {=mdtInlineBlocksExamples} -->
+
+### Inline value in prose
+
+```markdown
+Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releaseVersion} --> today.
+```
+
+### Inline value in a table cell
+
+```markdown
+| Package | Version |
+| ------- | ------- |
+| mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
+```
+
+### Inline value with a transformer
+
+```markdown
+CLI version: <!-- {~cliVersionCode:"{{ pkg.version }}"|code} -->`0.0.0`<!-- {/cliVersionCode} -->
+```
+
+### Inline value from a script-backed data source
+
+```toml
+[data]
+release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
+```
+
+```markdown
+Release: <!-- {~releaseValue:"{{ release }}"} -->0.0.0<!-- {/releaseValue} -->
+```
+
+When `VERSION` is unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json`.
+
+<!-- {/mdtInlineBlocksExamples} -->
 
 ## Comparison to providers
 

--- a/docs/src/concepts/how-it-works.md
+++ b/docs/src/concepts/how-it-works.md
@@ -56,7 +56,7 @@ The scanner automatically ignores:
 - Directories with their own `mdt.toml` (treated as separate projects)
 - Files matching gitignore-style patterns in the `[exclude]` config section
 - Blocks whose names appear in `[exclude] blocks`
-- Tags inside fenced code blocks when `[exclude] markdown_codeblocks` is configured
+- Tags inside fenced code blocks in source-file comments when `[exclude] markdown_codeblocks` is configured
 
 ## Matching rules
 

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -58,7 +58,7 @@ These patterns are checked relative to the project root. In addition to your exp
 
 #### `markdown_codeblocks` — Skip tags in code blocks
 
-Controls whether mdt tags inside fenced code blocks are processed. This is useful when your markdown files contain code examples that show mdt tag syntax but should not be treated as real tags.
+Controls whether mdt tags inside fenced code blocks in **source-file comments** are processed. This is useful when doc comments contain fenced examples that show mdt tag syntax but should not be treated as real tags.
 
 ```toml
 [exclude]
@@ -72,7 +72,7 @@ markdown_codeblocks = "ignore"
 markdown_codeblocks = ["ignore", "example"]
 ```
 
-The default is `false`, meaning tags in code blocks are processed normally.
+The default is `false`, meaning tags in fenced source-comment code blocks are processed normally.
 
 #### `blocks` — Exclude specific block names
 
@@ -188,6 +188,7 @@ cargo = "crates/my-lib/Cargo.toml"
 [exclude]
 patterns = ["vendor/", "dist/", "*.generated.md"]
 blocks = ["draft-section"]
+# Applies to fenced code blocks inside source-file comments.
 markdown_codeblocks = true
 
 [include]

--- a/docs/src/guide/data-interpolation.md
+++ b/docs/src/guide/data-interpolation.md
@@ -94,6 +94,47 @@ When `watch` files are unchanged, mdt reuses cached script output from `.mdt/cac
 
 <!-- {/mdtScriptDataSourcesNotes} -->
 
+## Inline interpolation patterns
+
+Inline blocks are useful when you need one local value from your data scope without creating a reusable provider.
+
+<!-- {=mdtInlineBlocksExamples} -->
+
+### Inline value in prose
+
+```markdown
+Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releaseVersion} --> today.
+```
+
+### Inline value in a table cell
+
+```markdown
+| Package | Version |
+| ------- | ------- |
+| mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
+```
+
+### Inline value with a transformer
+
+```markdown
+CLI version: <!-- {~cliVersionCode:"{{ pkg.version }}"|code} -->`0.0.0`<!-- {/cliVersionCode} -->
+```
+
+### Inline value from a script-backed data source
+
+```toml
+[data]
+release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
+```
+
+```markdown
+Release: <!-- {~releaseValue:"{{ release }}"} -->0.0.0<!-- {/releaseValue} -->
+```
+
+When `VERSION` is unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json`.
+
+<!-- {/mdtInlineBlocksExamples} -->
+
 ### TOML example
 
 ```toml

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -131,6 +131,8 @@ markdown_codeblocks = "ignore"
 markdown_codeblocks = ["ignore", "example", "no-sync"]
 ```
 
+Markdown fenced code blocks are not treated as live tags by markdown parsing, so this option is specifically for source-file comment scanning.
+
 **`blocks`:** Array of block names to exclude. Any block (provider or consumer) whose name is in this list is completely ignored during scanning and updating.
 
 ```toml

--- a/docs/src/reference/template-syntax.md
+++ b/docs/src/reference/template-syntax.md
@@ -54,9 +54,50 @@ Because inline blocks are provider-free, they are ideal for one-off values that 
 - Inline blocks must include a first argument that is the template string to render.
 - Inline blocks do not resolve provider content; everything comes from the inline template argument and current data context.
 - Inline rendering still supports transformers (`|trim`, `|code`, etc.) after template evaluation.
-- Inline blocks are scanned where mdt scans HTML comment tags (markdown and supported source comments), and follow the same code-block filtering rules configured for source scanning.
+- In markdown, inline blocks work in normal content (paragraphs, lists, headings, tables) where HTML comments are parsed.
+- Tags shown inside fenced markdown code blocks are treated as examples and are not interpreted as live blocks.
+- In source files, inline tags follow source scanning rules and respect `[exclude] markdown_codeblocks` filtering.
 
 <!-- {/mdtInlineBlocksLimits} -->
+
+#### Practical examples
+
+<!-- {=mdtInlineBlocksExamples} -->
+
+### Inline value in prose
+
+```markdown
+Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releaseVersion} --> today.
+```
+
+### Inline value in a table cell
+
+```markdown
+| Package | Version |
+| ------- | ------- |
+| mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
+```
+
+### Inline value with a transformer
+
+```markdown
+CLI version: <!-- {~cliVersionCode:"{{ pkg.version }}"|code} -->`0.0.0`<!-- {/cliVersionCode} -->
+```
+
+### Inline value from a script-backed data source
+
+```toml
+[data]
+release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
+```
+
+```markdown
+Release: <!-- {~releaseValue:"{{ release }}"} -->0.0.0<!-- {/releaseValue} -->
+```
+
+When `VERSION` is unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json`.
+
+<!-- {/mdtInlineBlocksExamples} -->
 
 ### Close tag
 

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -71,11 +71,13 @@ This content gets replaced
 **Inline tag** (provider-free interpolation using configured data):
 
 ```markdown
-<!-- {~version:"{{ package.version }}"} -->
+Current version: <!-- {~version:"{{ package.version }}"} -->0.0.0<!-- {/version} -->
+```
 
-0.0.0
-
-<!-- {/version} -->
+```markdown
+| Artifact | Version |
+| -------- | ------- |
+| mdt_cli  | <!-- {~cliVersion:"{{ package.version }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 
 **Filters and pipes:** Template values support pipe-delimited transformers:

--- a/readme.md
+++ b/readme.md
@@ -51,11 +51,13 @@ This content gets replaced
 **Inline tag** (provider-free interpolation using configured data):
 
 ```markdown
-<!-- {~version:"{{ package.version }}"} -->
+Current version: <!-- {~version:"{{ package.version }}"} -->0.0.0<!-- {/version} -->
+```
 
-0.0.0
-
-<!-- {/version} -->
+```markdown
+| Artifact | Version |
+| -------- | ------- |
+| mdt_cli  | <!-- {~cliVersion:"{{ package.version }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 
 **Filters and pipes:** Template values support pipe-delimited transformers:

--- a/template.t.md
+++ b/template.t.md
@@ -51,11 +51,13 @@ This content gets replaced
 **Inline tag** (provider-free interpolation using configured data):
 
 ```markdown
-<!-- {~version:"{{ "{{" }} package.version {{ "}}" }}"} -->
+Current version: <!-- {~version:"{{ "{{" }} package.version {{ "}}" }}"} -->0.0.0<!-- {/version} -->
+```
 
-0.0.0
-
-<!-- {/version} -->
+```markdown
+| Artifact | Version |
+| -------- | ------- |
+| mdt_cli  | <!-- {~cliVersion:"{{ "{{" }} package.version {{ "}}" }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 
 **Filters and pipes:** Template values support pipe-delimited transformers:
@@ -89,9 +91,48 @@ Because inline blocks are provider-free, they are ideal for one-off values that 
 - Inline blocks must include a first argument that is the template string to render.
 - Inline blocks do not resolve provider content; everything comes from the inline template argument and current data context.
 - Inline rendering still supports transformers (`|trim`, `|code`, etc.) after template evaluation.
-- Inline blocks are scanned where mdt scans HTML comment tags (markdown and supported source comments), and follow the same code-block filtering rules configured for source scanning.
+- In markdown, inline blocks work in normal content (paragraphs, lists, headings, tables) where HTML comments are parsed.
+- Tags shown inside fenced markdown code blocks are treated as examples and are not interpreted as live blocks.
+- In source files, inline tags follow source scanning rules and respect `[exclude] markdown_codeblocks` filtering.
 
 <!-- {/mdtInlineBlocksLimits} -->
+
+<!-- {@mdtInlineBlocksExamples} -->
+
+### Inline value in prose
+
+```markdown
+Install version <!-- {~releaseVersion:"{{ "{{" }} pkg.version {{ "}}" }}"} -->0.0.0<!-- {/releaseVersion} --> today.
+```
+
+### Inline value in a table cell
+
+```markdown
+| Package | Version |
+| ------- | ------- |
+| mdt     | <!-- {~mdtVersion:"{{ "{{" }} pkg.version {{ "}}" }}"} -->0.0.0<!-- {/mdtVersion} --> |
+```
+
+### Inline value with a transformer
+
+```markdown
+CLI version: <!-- {~cliVersionCode:"{{ "{{" }} pkg.version {{ "}}" }}"|code} -->`0.0.0`<!-- {/cliVersionCode} -->
+```
+
+### Inline value from a script-backed data source
+
+```toml
+[data]
+release = { command = "cat VERSION", format = "text", watch = ["VERSION"] }
+```
+
+```markdown
+Release: <!-- {~releaseValue:"{{ "{{" }} release {{ "}}" }}"} -->0.0.0<!-- {/releaseValue} -->
+```
+
+When `VERSION` is unchanged, mdt reuses cached script output from `.mdt/cache/data-v1.json`.
+
+<!-- {/mdtInlineBlocksExamples} -->
 
 <!-- {@mdtScriptDataSourcesGuide} -->
 


### PR DESCRIPTION
## Summary
This PR strengthens inline MDT documentation and test coverage so provider-free interpolation is better documented, easier to reuse, and safer to evolve.

## Problem
Inline blocks and script-backed data sources were already implemented, but practical examples were sparse across top-level docs and the mdBook. Guidance around where inline tags are parsed (especially markdown fences vs source-comment code blocks) was also easy to misinterpret.

The codebase also lacked regression tests for a few important inline scenarios:
- inline blocks inside markdown table cells
- markdown fenced code blocks containing inline tags (examples only, not executable tags)
- inline rendering that depends on script-backed `[data]` sources
- CLI update behavior for inline tags in tables

## Root Cause
Documentation and tests had good foundational coverage, but they did not yet include enough realistic inline patterns and edge-case assertions for how parsing/rendering behaves in practice.

## Changes
### Reusable MDT docs providers
- Expanded shared provider content in `template.t.md` with richer inline examples:
  - prose inline interpolation
  - table-cell inline interpolation
  - inline + transformer chain
  - inline + script-backed data source
- Reused those providers from:
  - root README
  - `mdt_cli` README
  - mdBook pages under `docs/src`

### mdBook and reference updates
- Added practical inline examples to:
  - `docs/src/advanced/inline-blocks.md`
  - `docs/src/reference/template-syntax.md`
  - `docs/src/guide/data-interpolation.md`
- Clarified `markdown_codeblocks` scope in docs:
  - applies to source-file comment scanning
  - markdown fenced code blocks are not treated as live tags by markdown parsing
- Updated matching conceptual wording in `docs/src/concepts/how-it-works.md`.

### Test coverage
- Added core regression tests in `mdt_core/src/__tests.rs` for:
  - parsing inline blocks in markdown tables
  - ignoring inline tags in markdown fenced code blocks
  - updating inline content in markdown table cells
  - updating inline content from script-backed data (`[data] command + watch`)
- Added CLI integration test in `mdt_cli/tests/update.rs` for inline table-cell update behavior.

## Validation
- `cargo test` (workspace) passed
- `cargo run --bin mdt -- check` passed
