### PR TITLE
fix(ci): resolve benchmark run failure and lint formatting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,11 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
+      - name: mark workspace as safe for git
+        shell: bash
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
       - name: install benchmark dependencies
         run: |
           apt-get update
@@ -159,7 +164,11 @@ jobs:
             echo "- Baseline ref: \`${{ steps.refs.outputs.baseline_ref }}\`"
             echo "- Candidate ref: \`${{ steps.refs.outputs.candidate_ref }}\`"
             echo
-            cat benchmark-results/compare.md
+            if [[ -f benchmark-results/compare.md ]]; then
+              cat benchmark-results/compare.md
+            else
+              echo "Benchmark comparison report was not generated."
+            fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: upload benchmark artifacts
@@ -171,7 +180,7 @@ jobs:
           retention-days: 90
 
       - name: comment benchmark report on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && hashFiles('benchmark-results/compare.md') != ''
         uses: actions/github-script@v7
         with:
           script: |

--- a/docs/src/advanced/benchmarking-and-regressions.md
+++ b/docs/src/advanced/benchmarking-and-regressions.md
@@ -40,9 +40,7 @@ This avoids failing on tiny/noisy deltas.
 
 ## Regression policy
 
-If benchmark regressions are detected on a pull request, the PR must include a
-`## Benchmark Justification` section in the PR description explaining why the
-tradeoff is acceptable.
+If benchmark regressions are detected on a pull request, the PR must include a `## Benchmark Justification` section in the PR description explaining why the tradeoff is acceptable.
 
 Without this section, the benchmark workflow fails.
 

--- a/docs/src/guide/ci-integration.md
+++ b/docs/src/guide/ci-integration.md
@@ -193,8 +193,7 @@ jobs:
 
 ## Benchmark CI (this repository)
 
-This repository also runs `.github/workflows/benchmark.yml` on `pull_request`
-and `push` to `main`.
+This repository also runs `.github/workflows/benchmark.yml` on `pull_request` and `push` to `main`.
 
 The benchmark job:
 
@@ -203,6 +202,4 @@ The benchmark job:
 3. Compares medians per scenario with relative and absolute thresholds.
 4. Uploads raw benchmark artifacts and posts a PR comment report.
 
-When regressions exceed threshold, pull requests must include a
-`## Benchmark Justification` section in the PR description to document the
-tradeoff.
+When regressions exceed threshold, pull requests must include a `## Benchmark Justification` section in the PR description to document the tradeoff.

--- a/scripts/benchmark/compare_results.sh
+++ b/scripts/benchmark/compare_results.sh
@@ -36,43 +36,43 @@ fail_on_regression=false
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--baseline)
-			baseline="${2:-}"
-			shift 2
-			;;
-		--candidate)
-			candidate="${2:-}"
-			shift 2
-			;;
-		--output)
-			output="${2:-}"
-			shift 2
-			;;
-		--markdown)
-			markdown="${2:-}"
-			shift 2
-			;;
-		--relative-threshold-pct)
-			relative_threshold_pct="${2:-}"
-			shift 2
-			;;
-		--absolute-threshold-ms)
-			absolute_threshold_ms="${2:-}"
-			shift 2
-			;;
-		--fail-on-regression)
-			fail_on_regression=true
-			shift
-			;;
-		-h|--help)
-			usage
-			exit 0
-			;;
-		*)
-			echo "unknown option: $1" >&2
-			usage >&2
-			exit 1
-			;;
+	--baseline)
+		baseline="${2:-}"
+		shift 2
+		;;
+	--candidate)
+		candidate="${2:-}"
+		shift 2
+		;;
+	--output)
+		output="${2:-}"
+		shift 2
+		;;
+	--markdown)
+		markdown="${2:-}"
+		shift 2
+		;;
+	--relative-threshold-pct)
+		relative_threshold_pct="${2:-}"
+		shift 2
+		;;
+	--absolute-threshold-ms)
+		absolute_threshold_ms="${2:-}"
+		shift 2
+		;;
+	--fail-on-regression)
+		fail_on_regression=true
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown option: $1" >&2
+		usage >&2
+		exit 1
+		;;
 	esac
 done
 
@@ -157,7 +157,7 @@ jq -n \
 		else "ok"
 		end
 	)
-' > "$output"
+' >"$output"
 
 if [[ -n "$markdown" ]]; then
 	mkdir -p "$(dirname "$markdown")"
@@ -182,7 +182,7 @@ if [[ -n "$markdown" ]]; then
 		echo "Regressions: $(jq '.regression_count' "$output")"
 		echo "Improvements: $(jq '.improvement_count' "$output")"
 		echo "Missing scenarios: $(jq '.missing_count' "$output")"
-	} > "$markdown"
+	} >"$markdown"
 fi
 
 status=$(jq -r '.status' "$output")
@@ -193,7 +193,7 @@ echo "comparison status: $status"
 echo "regression_count: $regression_count"
 echo "missing_count: $missing_count"
 
-if (( missing_count > 0 )); then
+if ((missing_count > 0)); then
 	echo "missing scenarios detected between baseline and candidate" >&2
 	exit 2
 fi

--- a/scripts/benchmark/generate_workload.sh
+++ b/scripts/benchmark/generate_workload.sh
@@ -19,23 +19,23 @@ file_count=180
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--output)
-			output_dir="${2:-}"
-			shift 2
-			;;
-		--files)
-			file_count="${2:-}"
-			shift 2
-			;;
-		-h|--help)
-			usage
-			exit 0
-			;;
-		*)
-			echo "unknown option: $1" >&2
-			usage >&2
-			exit 1
-			;;
+	--output)
+		output_dir="${2:-}"
+		shift 2
+		;;
+	--files)
+		file_count="${2:-}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown option: $1" >&2
+		usage >&2
+		exit 1
+		;;
 	esac
 done
 
@@ -50,7 +50,7 @@ if ! [[ "$file_count" =~ ^[0-9]+$ ]]; then
 	exit 1
 fi
 
-if (( file_count < 1 )); then
+if ((file_count < 1)); then
 	echo "--files must be >= 1" >&2
 	exit 1
 fi
@@ -58,7 +58,7 @@ fi
 rm -rf "$output_dir"
 mkdir -p "$output_dir/.templates" "$output_dir/modules"
 
-cat > "$output_dir/package.json" <<'JSON'
+cat >"$output_dir/package.json" <<'JSON'
 {
 	"name": "mdt-benchmark-fixture",
 	"version": "1.0.0",
@@ -66,7 +66,7 @@ cat > "$output_dir/package.json" <<'JSON'
 }
 JSON
 
-cat > "$output_dir/mdt.toml" <<'TOML'
+cat >"$output_dir/mdt.toml" <<'TOML'
 [templates]
 paths = [".templates"]
 
@@ -78,7 +78,7 @@ before = 0
 after = 0
 TOML
 
-cat > "$output_dir/.templates/template.t.md" <<'TEMPLATE'
+cat >"$output_dir/.templates/template.t.md" <<'TEMPLATE'
 <!-- {@overview} -->
 
 {{ package.name }} v{{ package.version }}
@@ -116,7 +116,7 @@ for ((i = 1; i <= file_count; i++)); do
 	group_dir="$output_dir/modules/group-$group_id"
 	mkdir -p "$group_dir"
 
-	cat > "$group_dir/module-$module_id.md" <<EOF_MODULE
+	cat >"$group_dir/module-$module_id.md" <<EOF_MODULE
 # Module $module_id
 
 <!-- {=overview|trim} -->

--- a/scripts/benchmark/run_suite.sh
+++ b/scripts/benchmark/run_suite.sh
@@ -56,7 +56,7 @@ join_by() {
 
 calc_stats_json() {
 	local values=("$@")
-	if (( ${#values[@]} == 0 )); then
+	if ((${#values[@]} == 0)); then
 		echo '{"min_ms":0,"max_ms":0,"mean_ms":0,"median_ms":0,"p95_ms":0,"samples_ms":[]}'
 		return
 	fi
@@ -226,43 +226,43 @@ workdir=""
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
-		--binary)
-			binary="${2:-}"
-			shift 2
-			;;
-		--output)
-			output="${2:-}"
-			shift 2
-			;;
-		--label)
-			label="${2:-}"
-			shift 2
-			;;
-		--iterations)
-			iterations="${2:-}"
-			shift 2
-			;;
-		--warmup)
-			warmup="${2:-}"
-			shift 2
-			;;
-		--files)
-			file_count="${2:-}"
-			shift 2
-			;;
-		--workdir)
-			workdir="${2:-}"
-			shift 2
-			;;
-		-h|--help)
-			usage
-			exit 0
-			;;
-		*)
-			echo "unknown option: $1" >&2
-			usage >&2
-			exit 1
-			;;
+	--binary)
+		binary="${2:-}"
+		shift 2
+		;;
+	--output)
+		output="${2:-}"
+		shift 2
+		;;
+	--label)
+		label="${2:-}"
+		shift 2
+		;;
+	--iterations)
+		iterations="${2:-}"
+		shift 2
+		;;
+	--warmup)
+		warmup="${2:-}"
+		shift 2
+		;;
+	--files)
+		file_count="${2:-}"
+		shift 2
+		;;
+	--workdir)
+		workdir="${2:-}"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown option: $1" >&2
+		usage >&2
+		exit 1
+		;;
 	esac
 done
 
@@ -285,23 +285,23 @@ for numeric_arg in iterations warmup file_count; do
 	value="${!numeric_arg}"
 	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
 		case "$numeric_arg" in
-			file_count)
-				echo "--files must be a non-negative integer" >&2
-				;;
-			*)
-				echo "--$numeric_arg must be a non-negative integer" >&2
-				;;
+		file_count)
+			echo "--files must be a non-negative integer" >&2
+			;;
+		*)
+			echo "--$numeric_arg must be a non-negative integer" >&2
+			;;
 		esac
 		exit 1
 	fi
 done
 
-if (( iterations < 1 )); then
+if ((iterations < 1)); then
 	echo "--iterations must be >= 1" >&2
 	exit 1
 fi
 
-if (( file_count < 1 )); then
+if ((file_count < 1)); then
 	echo "--files must be >= 1" >&2
 	exit 1
 fi
@@ -343,7 +343,7 @@ escaped_binary=$(json_escape "$binary")
 generated_at_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 scenario_joined=$(join_by , "${scenario_json_entries[@]}")
 
-cat > "$output" <<EOF_JSON
+cat >"$output" <<EOF_JSON
 {
 	"schema_version": 1,
 	"generated_at_utc": "${generated_at_utc}",


### PR DESCRIPTION
## Summary
- fix benchmark workflow failure in container jobs by marking `$GITHUB_WORKSPACE` as a safe git directory before git commands
- make benchmark summary/comment steps resilient when compare output is missing after earlier failures
- apply dprint formatting to benchmark scripts/docs updates so lint passes

## Failure context addressed
- benchmark run `22522432005` failed with: `fatal: detected dubious ownership in repository at '/__w/mdt/mdt'`
- lint run `22522431995` failed due dprint formatting in benchmark files

## Validation
- `dprint check .github/workflows/benchmark.yml scripts/benchmark/*.sh docs/src/advanced/benchmarking-and-regressions.md docs/src/guide/ci-integration.md`
- `bash -n scripts/benchmark/generate_workload.sh scripts/benchmark/run_suite.sh scripts/benchmark/compare_results.sh`
- `cargo build --release --locked --manifest-path mdt_cli/Cargo.toml`
- `scripts/benchmark/run_suite.sh --binary ./target/release/mdt --output /tmp/mdt-benchmark-candidate-fix.json --label candidate --iterations 2 --warmup 1 --files 20`
- `scripts/benchmark/compare_results.sh --baseline /tmp/mdt-benchmark-candidate-fix.json --candidate /tmp/mdt-benchmark-candidate-fix.json --output /tmp/mdt-benchmark-compare-fix.json --markdown /tmp/mdt-benchmark-compare-fix.md --relative-threshold-pct 8 --absolute-threshold-ms 5`
