### PR TITLE
fix(lint): format inline example updates

### DIFF
--- a/docs/src/advanced/inline-blocks.md
+++ b/docs/src/advanced/inline-blocks.md
@@ -46,8 +46,8 @@ Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releas
 ### Inline value in a table cell
 
 ```markdown
-| Package | Version |
-| ------- | ------- |
+| Package | Version                                                               |
+| ------- | --------------------------------------------------------------------- |
 | mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
 ```
 

--- a/docs/src/guide/data-interpolation.md
+++ b/docs/src/guide/data-interpolation.md
@@ -109,8 +109,8 @@ Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releas
 ### Inline value in a table cell
 
 ```markdown
-| Package | Version |
-| ------- | ------- |
+| Package | Version                                                               |
+| ------- | --------------------------------------------------------------------- |
 | mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
 ```
 

--- a/docs/src/reference/template-syntax.md
+++ b/docs/src/reference/template-syntax.md
@@ -73,8 +73,8 @@ Install version <!-- {~releaseVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/releas
 ### Inline value in a table cell
 
 ```markdown
-| Package | Version |
-| ------- | ------- |
+| Package | Version                                                               |
+| ------- | --------------------------------------------------------------------- |
 | mdt     | <!-- {~mdtVersion:"{{ pkg.version }}"} -->0.0.0<!-- {/mdtVersion} --> |
 ```
 

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -75,8 +75,8 @@ Current version: <!-- {~version:"{{ package.version }}"} -->0.0.0<!-- {/version}
 ```
 
 ```markdown
-| Artifact | Version |
-| -------- | ------- |
+| Artifact | Version                                                                   |
+| -------- | ------------------------------------------------------------------------- |
 | mdt_cli  | <!-- {~cliVersion:"{{ package.version }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 

--- a/mdt_cli/tests/update.rs
+++ b/mdt_cli/tests/update.rs
@@ -273,8 +273,8 @@ fn update_inline_table_cell_with_data() -> AnyEmptyResult {
 	)?;
 	std::fs::write(
 		tmp.path().join("readme.md"),
-		"| Package | Version |\n| ------- | ------- |\n| mdt     | <!-- \
-		 {~version:\"{{ pkg.version }}\"} -->0.0.0<!-- {/version} --> |\n",
+		"| Package | Version |\n| ------- | ------- |\n| mdt     | <!-- {~version:\"{{ \
+		 pkg.version }}\"} -->0.0.0<!-- {/version} --> |\n",
 	)?;
 
 	let mut cmd = common::mdt_cmd();

--- a/mdt_core/src/__tests.rs
+++ b/mdt_core/src/__tests.rs
@@ -562,8 +562,8 @@ fn compute_updates_replaces_inline_content_in_markdown_table() -> MdtResult<()> 
 		.unwrap_or_else(|e| panic!("write: {e}"));
 	std::fs::write(
 		tmp.path().join("readme.md"),
-		"| Package | Version |\n| ------- | ------- |\n| mdt     | <!-- \
-		 {~version:\"{{ pkg.version }}\"} -->0.0.0<!-- {/version} --> |\n",
+		"| Package | Version |\n| ------- | ------- |\n| mdt     | <!-- {~version:\"{{ \
+		 pkg.version }}\"} -->0.0.0<!-- {/version} --> |\n",
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));
 
@@ -590,14 +590,13 @@ fn compute_updates_inline_with_script_data_source() -> MdtResult<()> {
 	std::fs::write(tmp.path().join("VERSION"), "2.4.6\n").unwrap_or_else(|e| panic!("write: {e}"));
 	std::fs::write(
 		tmp.path().join("mdt.toml"),
-		"[data]\nrelease = { command = \"cat VERSION\", format = \"text\", watch = \
-		 [\"VERSION\"] }\n",
+		"[data]\nrelease = { command = \"cat VERSION\", format = \"text\", watch = [\"VERSION\"] \
+		 }\n",
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));
 	std::fs::write(
 		tmp.path().join("readme.md"),
-		"Release <!-- {~releaseValue:\"{{ release | trim }}\"} -->0.0.0<!-- {/releaseValue} \
-		 -->\n",
+		"Release <!-- {~releaseValue:\"{{ release | trim }}\"} -->0.0.0<!-- {/releaseValue} -->\n",
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));
 

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,8 @@ Current version: <!-- {~version:"{{ package.version }}"} -->0.0.0<!-- {/version}
 ```
 
 ```markdown
-| Artifact | Version |
-| -------- | ------- |
+| Artifact | Version                                                                   |
+| -------- | ------------------------------------------------------------------------- |
 | mdt_cli  | <!-- {~cliVersion:"{{ package.version }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 


### PR DESCRIPTION
## Summary
- apply dprint formatting to files touched by inline-example updates
- align markdown table examples and wrapped strings with repo formatter rules

## Failure context addressed
- CI run `22528971704` still failed in `lint` after benchmark fix
- lint log reported `Found 7 not formatted files`

## Validation
- `dprint fmt readme.md mdt_cli/readme.md docs/src/guide/data-interpolation.md docs/src/advanced/inline-blocks.md docs/src/reference/template-syntax.md mdt_core/src/__tests.rs mdt_cli/tests/update.rs`
- `dprint check readme.md mdt_cli/readme.md docs/src/guide/data-interpolation.md docs/src/advanced/inline-blocks.md docs/src/reference/template-syntax.md mdt_core/src/__tests.rs mdt_cli/tests/update.rs`
