### PR TITLE
fix(lint): stabilize mdt update vs dprint for inline tables

### DIFF
--- a/template.t.md
+++ b/template.t.md
@@ -55,8 +55,8 @@ Current version: <!-- {~version:"{{ "{{" }} package.version {{ "}}" }}"} -->0.0.
 ```
 
 ```markdown
-| Artifact | Version |
-| -------- | ------- |
+| Artifact | Version                                                                   |
+| -------- | ------------------------------------------------------------------------- |
 | mdt_cli  | <!-- {~cliVersion:"{{ "{{" }} package.version {{ "}}" }}"} -->0.0.0<!-- {/cliVersion} --> |
 ```
 
@@ -108,8 +108,8 @@ Install version <!-- {~releaseVersion:"{{ "{{" }} pkg.version {{ "}}" }}"} -->0.
 ### Inline value in a table cell
 
 ```markdown
-| Package | Version |
-| ------- | ------- |
+| Package | Version                                                               |
+| ------- | --------------------------------------------------------------------- |
 | mdt     | <!-- {~mdtVersion:"{{ "{{" }} pkg.version {{ "}}" }}"} -->0.0.0<!-- {/mdtVersion} --> |
 ```
 


### PR DESCRIPTION
## Summary
- update provider definitions in `template.t.md` so generated inline-table examples match dprint’s markdown table width normalization
- remove the `mdt update` vs `dprint fmt` loop that was causing `mdt check` failures in CI lint

## Failure context addressed
- CI run `22529084954` failed in `lint` -> `check mdt blocks`
- stale consumers were repeatedly reported for:
  - `mdtTemplateSyntax` in `readme.md` and `mdt_cli/readme.md`
  - `mdtInlineBlocksExamples` in docs inline examples pages

## Validation
- `cargo run --bin mdt -- update`
- `cargo run --bin mdt -- check`
- `dprint check`
