### PR TITLE
fix(clippy): resolve implicit hasher and bool-heavy structs

### DIFF
--- a/mdt_cli/src/main.rs
+++ b/mdt_cli/src/main.rs
@@ -885,15 +885,27 @@ struct InfoCacheLastScanSection {
 }
 
 #[derive(serde::Serialize)]
-struct InfoCacheSection {
-	path: String,
+struct InfoCacheArtifactStateSection {
 	exists: bool,
 	readable: bool,
 	valid: bool,
-	schema_version: Option<u32>,
+}
+
+#[derive(serde::Serialize)]
+struct InfoCacheCompatibilityStateSection {
 	schema_supported: bool,
 	project_key_matches: bool,
 	hash_verification_enabled: bool,
+}
+
+#[derive(serde::Serialize)]
+struct InfoCacheSection {
+	path: String,
+	#[serde(flatten)]
+	artifact: InfoCacheArtifactStateSection,
+	schema_version: Option<u32>,
+	#[serde(flatten)]
+	compatibility: InfoCacheCompatibilityStateSection,
 	scan_count: u64,
 	full_project_hit_count: u64,
 	full_project_hit_rate: String,
@@ -1034,13 +1046,17 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 		},
 		cache: InfoCacheSection {
 			path: cache_inspection.path.display().to_string(),
-			exists: cache_inspection.exists,
-			readable: cache_inspection.readable,
-			valid: cache_inspection.valid,
+			artifact: InfoCacheArtifactStateSection {
+				exists: cache_inspection.artifact.exists,
+				readable: cache_inspection.artifact.readable,
+				valid: cache_inspection.artifact.valid,
+			},
 			schema_version: cache_inspection.schema_version,
-			schema_supported: cache_inspection.schema_supported,
-			project_key_matches: cache_inspection.project_key_matches,
-			hash_verification_enabled: cache_inspection.hash_verification_enabled,
+			compatibility: InfoCacheCompatibilityStateSection {
+				schema_supported: cache_inspection.compatibility.schema_supported,
+				project_key_matches: cache_inspection.compatibility.project_key_matches,
+				hash_verification_enabled: cache_inspection.compatibility.hash_verification_enabled,
+			},
 			scan_count,
 			full_project_hit_count,
 			full_project_hit_rate,
@@ -1115,11 +1131,11 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 
 			print_section("Cache");
 			print_field("Artifact path", &report.cache.path);
-			let cache_status = if !report.cache.exists {
+			let cache_status = if !report.cache.artifact.exists {
 				"missing".to_string()
-			} else if !report.cache.readable {
+			} else if !report.cache.artifact.readable {
 				"unreadable".to_string()
-			} else if !report.cache.valid {
+			} else if !report.cache.artifact.valid {
 				"invalid".to_string()
 			} else {
 				"ok".to_string()
@@ -1128,7 +1144,7 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 			let schema_display = report.cache.schema_version.map_or_else(
 				|| "unknown".to_string(),
 				|schema| {
-					if report.cache.schema_supported {
+					if report.cache.compatibility.schema_supported {
 						format!("{schema} (supported)")
 					} else {
 						format!("{schema} (unsupported)")
@@ -1138,7 +1154,7 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 			print_field("Schema version", schema_display);
 			print_field(
 				"Project key match",
-				if report.cache.project_key_matches {
+				if report.cache.compatibility.project_key_matches {
 					"yes"
 				} else {
 					"no"
@@ -1146,7 +1162,7 @@ fn run_info(args: &MdtCli, format: InfoOutputFormat) -> Result<(), Box<dyn std::
 			);
 			print_field(
 				"Hash verification",
-				if report.cache.hash_verification_enabled {
+				if report.cache.compatibility.hash_verification_enabled {
 					"enabled"
 				} else {
 					"disabled"
@@ -1620,7 +1636,7 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 	}
 
 	let cache = inspect_project_cache(&root, &scan_options);
-	if !cache.exists {
+	if !cache.artifact.exists {
 		add_doctor_check(
 			&mut checks,
 			"cache_artifact",
@@ -1632,7 +1648,7 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 					.to_string(),
 			),
 		);
-	} else if !cache.readable {
+	} else if !cache.artifact.readable {
 		add_doctor_check(
 			&mut checks,
 			"cache_artifact",
@@ -1644,7 +1660,7 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 			),
 			Some("verify filesystem permissions for `.mdt/cache/`".to_string()),
 		);
-	} else if !cache.valid {
+	} else if !cache.artifact.valid {
 		let schema = cache
 			.schema_version
 			.map_or_else(|| "unknown".to_string(), |version| version.to_string());
@@ -1660,7 +1676,7 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 					.to_string(),
 			),
 		);
-	} else if !cache.project_key_matches {
+	} else if !cache.compatibility.project_key_matches {
 		add_doctor_check(
 			&mut checks,
 			"cache_artifact",
@@ -1687,7 +1703,7 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 		);
 	}
 
-	let hash_mode_message = if cache.hash_verification_enabled {
+	let hash_mode_message = if cache.compatibility.hash_verification_enabled {
 		"content-hash verification enabled (`MDT_CACHE_VERIFY_HASH` set)".to_string()
 	} else {
 		"content-hash verification disabled (mtime + size fingerprints only)".to_string()
@@ -1698,7 +1714,9 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 		"Cache Hash Mode",
 		DoctorStatus::Pass,
 		hash_mode_message,
-		Some(cache_hash_mode_hint(cache.hash_verification_enabled)),
+		Some(cache_hash_mode_hint(
+			cache.compatibility.hash_verification_enabled,
+		)),
 	);
 
 	if let Some(telemetry) = &cache.telemetry {
@@ -1729,7 +1747,9 @@ fn run_doctor(args: &MdtCli, format: DoctorOutputFormat) -> Result<(), Box<dyn s
 						"high reparse trend: {} reparsed vs {} reused ({reparse_rate} reparsed)",
 						telemetry.reparsed_file_count_total, telemetry.reused_file_count_total
 					),
-					Some(cache_hash_mode_hint(cache.hash_verification_enabled)),
+					Some(cache_hash_mode_hint(
+						cache.compatibility.hash_verification_enabled,
+					)),
 				);
 			} else {
 				let reuse_rate =

--- a/mdt_core/src/__tests.rs
+++ b/mdt_core/src/__tests.rs
@@ -9415,7 +9415,7 @@ fn scan_project_cache_telemetry_tracks_full_cache_hit() -> MdtResult<()> {
 	let _ = scan_project_with_options(tmp.path(), &options)?;
 
 	let cache = inspect_project_cache(tmp.path(), &options);
-	assert!(cache.valid, "expected valid cache inspection");
+	assert!(cache.valid(), "expected valid cache inspection");
 	let telemetry = cache
 		.telemetry
 		.as_ref()

--- a/mdt_core/src/engine.rs
+++ b/mdt_core/src/engine.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::hash::BuildHasher;
 use std::path::PathBuf;
 
 use crate::Argument;
@@ -203,11 +204,11 @@ fn has_template_syntax(content: &str) -> bool {
 /// variables.
 /// Build a data context that merges base project data with block-specific
 /// positional arguments. Returns `None` if the argument count doesn't match.
-pub fn build_render_context(
-	base_data: &HashMap<String, serde_json::Value>,
+pub fn build_render_context<S: BuildHasher + Clone>(
+	base_data: &HashMap<String, serde_json::Value, S>,
 	provider: &ProviderEntry,
 	consumer: &ConsumerEntry,
-) -> Option<HashMap<String, serde_json::Value>> {
+) -> Option<HashMap<String, serde_json::Value, S>> {
 	let param_count = provider.block.arguments.len();
 	let arg_count = consumer.block.arguments.len();
 

--- a/mdt_core/src/project.rs
+++ b/mdt_core/src/project.rs
@@ -251,27 +251,73 @@ pub struct ProjectCacheTelemetry {
 	pub last_scan: Option<ProjectCacheLastScan>,
 }
 
-/// Read-only inspection of the on-disk project index cache artifact.
+/// Readability and validity of the cache artifact itself.
 #[derive(Debug, Clone, Serialize)]
-pub struct ProjectCacheInspection {
-	/// Absolute path to the cache artifact.
-	pub path: PathBuf,
+pub struct ProjectCacheArtifactState {
 	/// Whether a cache artifact file exists at the expected path.
 	pub exists: bool,
 	/// Whether the artifact could be read from disk.
 	pub readable: bool,
 	/// Whether the artifact parsed and matched the supported schema.
 	pub valid: bool,
-	/// Schema version read from the artifact, if present.
-	pub schema_version: Option<u32>,
+}
+
+/// Compatibility details for the current scan mode vs cached metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectCacheCompatibilityState {
 	/// Whether the artifact schema matches the current implementation.
 	pub schema_supported: bool,
 	/// Whether the artifact key matches current scan options.
 	pub project_key_matches: bool,
 	/// Whether content-hash cache verification is enabled for this scan mode.
 	pub hash_verification_enabled: bool,
+}
+
+/// Read-only inspection of the on-disk project index cache artifact.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectCacheInspection {
+	/// Absolute path to the cache artifact.
+	pub path: PathBuf,
+	/// Readability and validity details for the artifact.
+	pub artifact: ProjectCacheArtifactState,
+	/// Schema version read from the artifact, if present.
+	pub schema_version: Option<u32>,
+	/// Compatibility details for current scan options.
+	pub compatibility: ProjectCacheCompatibilityState,
 	/// Persisted telemetry metrics if the artifact parsed successfully.
 	pub telemetry: Option<ProjectCacheTelemetry>,
+}
+
+impl ProjectCacheInspection {
+	/// True when a cache artifact exists.
+	pub fn exists(&self) -> bool {
+		self.artifact.exists
+	}
+
+	/// True when the cache artifact can be read from disk.
+	pub fn readable(&self) -> bool {
+		self.artifact.readable
+	}
+
+	/// True when the cache artifact parsed and matched supported schema.
+	pub fn valid(&self) -> bool {
+		self.artifact.valid
+	}
+
+	/// True when cache schema version is supported.
+	pub fn schema_supported(&self) -> bool {
+		self.compatibility.schema_supported
+	}
+
+	/// True when cache key matches current scan options.
+	pub fn project_key_matches(&self) -> bool {
+		self.compatibility.project_key_matches
+	}
+
+	/// True when content-hash verification mode is enabled.
+	pub fn hash_verification_enabled(&self) -> bool {
+		self.compatibility.hash_verification_enabled
+	}
 }
 
 impl From<index_cache::LastScanTelemetry> for ProjectCacheLastScan {
@@ -399,24 +445,28 @@ pub fn inspect_project_cache(root: &Path, options: &ScanOptions) -> ProjectCache
 	let path = project_cache_path(root);
 	let mut inspection = ProjectCacheInspection {
 		path: path.clone(),
-		exists: path.is_file(),
-		readable: false,
-		valid: false,
+		artifact: ProjectCacheArtifactState {
+			exists: path.is_file(),
+			readable: false,
+			valid: false,
+		},
 		schema_version: None,
-		schema_supported: false,
-		project_key_matches: false,
-		hash_verification_enabled: options.cache_verify_hash,
+		compatibility: ProjectCacheCompatibilityState {
+			schema_supported: false,
+			project_key_matches: false,
+			hash_verification_enabled: options.cache_verify_hash,
+		},
 		telemetry: None,
 	};
 
-	if !inspection.exists {
+	if !inspection.artifact.exists {
 		return inspection;
 	}
 
 	let Ok(bytes) = std::fs::read(&path) else {
 		return inspection;
 	};
-	inspection.readable = true;
+	inspection.artifact.readable = true;
 
 	let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
 		return inspection;
@@ -427,10 +477,11 @@ pub fn inspect_project_cache(root: &Path, options: &ScanOptions) -> ProjectCache
 		.and_then(serde_json::Value::as_u64)
 		.and_then(|version| u32::try_from(version).ok());
 	inspection.schema_version = schema_version;
-	inspection.schema_supported = schema_version == Some(index_cache::CACHE_SCHEMA_VERSION);
+	inspection.compatibility.schema_supported =
+		schema_version == Some(index_cache::CACHE_SCHEMA_VERSION);
 
 	let expected_project_key = build_project_cache_key(options);
-	inspection.project_key_matches = value
+	inspection.compatibility.project_key_matches = value
 		.get("project_key")
 		.and_then(serde_json::Value::as_str)
 		.is_some_and(|key| key == expected_project_key);
@@ -439,7 +490,7 @@ pub fn inspect_project_cache(root: &Path, options: &ScanOptions) -> ProjectCache
 		return inspection;
 	};
 
-	inspection.valid = inspection.schema_supported;
+	inspection.artifact.valid = inspection.compatibility.schema_supported;
 	inspection.telemetry = Some(cache.telemetry.into());
 	inspection
 }


### PR DESCRIPTION
## Summary
This PR resolves the clippy warnings reported in normal workspace checks (`cargo clippy --workspace --all-features`) for `mdt_core` and `mdt_cli`.

## What Changed
- Generalized `build_render_context` over `BuildHasher` so it no longer assumes the default `HashMap` hasher.
- Refactored cache inspection state in `mdt_core` into grouped structs:
  - `ProjectCacheArtifactState`
  - `ProjectCacheCompatibilityState`
- Updated `ProjectCacheInspection` construction and access paths to use grouped state.
- Updated `mdt info` / `mdt doctor` cache reporting structures in `mdt_cli` to avoid excessive bools while preserving output fields via `#[serde(flatten)]`.
- Updated cache inspection test usage to use the accessor (`cache.valid()`).

## Why
Clippy pedantic flagged:
- `clippy::implicit_hasher`
- `clippy::struct_excessive_bools`

This refactor keeps behavior unchanged while aligning APIs and reporting structs with those lint requirements.

## Validation
- `cargo clippy --workspace --all-features`
