### PR TITLE
fix(clippy): resolve remaining all-target warnings

### DIFF
--- a/mdt_cli/tests/update.rs
+++ b/mdt_cli/tests/update.rs
@@ -369,14 +369,14 @@ old
 fn update_multiline_idempotent_after_write() -> AnyEmptyResult {
 	let tmp = tempfile::tempdir()?;
 
-	let template = r#"<!-- {@links} -->
+	let template = r"<!-- {@links} -->
 
 [repo]: https://github.com/example/repo
 [docs]: https://docs.example.com
 [ci]: https://ci.example.com/badge.svg
 
 <!-- {/links} -->
-"#;
+";
 	std::fs::write(tmp.path().join("template.t.md"), template)?;
 	std::fs::write(
 		tmp.path().join("readme.md"),

--- a/mdt_core/src/__tests.rs
+++ b/mdt_core/src/__tests.rs
@@ -7879,7 +7879,7 @@ fn build_render_context_preserves_base_data() {
 			arguments: vec!["name".to_string()],
 		},
 		file: PathBuf::from("template.t.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 	let consumer = ConsumerEntry {
 		block: Block {
@@ -7891,7 +7891,7 @@ fn build_render_context_preserves_base_data() {
 			arguments: vec!["my-lib".to_string()],
 		},
 		file: PathBuf::from("readme.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 
 	let result = build_render_context(&base_data, &provider, &consumer);
@@ -7918,7 +7918,7 @@ fn build_render_context_returns_none_on_count_mismatch() {
 			arguments: vec!["a".to_string(), "b".to_string()],
 		},
 		file: PathBuf::from("template.t.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 	let consumer = ConsumerEntry {
 		block: Block {
@@ -7930,7 +7930,7 @@ fn build_render_context_returns_none_on_count_mismatch() {
 			arguments: vec!["x".to_string()],
 		},
 		file: PathBuf::from("readme.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 
 	let result = build_render_context(&HashMap::new(), &provider, &consumer);
@@ -7952,7 +7952,7 @@ fn build_render_context_no_args_returns_base_data() {
 			arguments: vec![],
 		},
 		file: PathBuf::from("template.t.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 	let consumer = ConsumerEntry {
 		block: Block {
@@ -7964,7 +7964,7 @@ fn build_render_context_no_args_returns_base_data() {
 			arguments: vec![],
 		},
 		file: PathBuf::from("readme.md"),
-		content: "".to_string(),
+		content: String::new(),
 	};
 
 	let result = build_render_context(&base_data, &provider, &consumer);
@@ -8531,17 +8531,16 @@ fn transformer_if_top_level_key() {
 }
 
 #[test]
-fn transformer_if_validates_requires_one_arg() -> MdtResult<()> {
+fn transformer_if_validates_requires_one_arg() {
 	let result = validate_transformers(&[Transformer {
 		r#type: TransformerType::If,
 		args: vec![],
 	}]);
 	assert!(result.is_err());
-	Ok(())
 }
 
 #[test]
-fn transformer_if_validates_rejects_extra_args() -> MdtResult<()> {
+fn transformer_if_validates_rejects_extra_args() {
 	let result = validate_transformers(&[Transformer {
 		r#type: TransformerType::If,
 		args: vec![
@@ -8550,7 +8549,6 @@ fn transformer_if_validates_rejects_extra_args() -> MdtResult<()> {
 		],
 	}]);
 	assert!(result.is_err());
-	Ok(())
 }
 
 #[test]
@@ -8651,50 +8649,50 @@ old content
 	let updates = compute_updates(&ctx)?;
 
 	let readme_path = tmp.path().join("readme.md");
-	let updated = updates
+	let updated_content = updates
 		.updated_files
 		.get(&readme_path)
 		.unwrap_or_else(|| panic!("readme.md should be in updated files"));
 
 	// Every link definition should be on its own line
 	assert!(
-		updated.contains("\n[crate-image]:"),
+		updated_content.contains("\n[crate-image]:"),
 		"crate-image should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[crate-link]:"),
+		updated_content.contains("\n[crate-link]:"),
 		"crate-link should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[docs-image]:"),
+		updated_content.contains("\n[docs-image]:"),
 		"docs-image should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[docs-link]:"),
+		updated_content.contains("\n[docs-link]:"),
 		"docs-link should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[ci-status-image]:"),
+		updated_content.contains("\n[ci-status-image]:"),
 		"ci-status-image should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[ci-status-link]:"),
+		updated_content.contains("\n[ci-status-link]:"),
 		"ci-status-link should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[coverage-image]:"),
+		updated_content.contains("\n[coverage-image]:"),
 		"coverage-image should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[coverage-link]:"),
+		updated_content.contains("\n[coverage-link]:"),
 		"coverage-link should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[unlicense-image]:"),
+		updated_content.contains("\n[unlicense-image]:"),
 		"unlicense-image should be on its own line"
 	);
 	assert!(
-		updated.contains("\n[unlicense-link]:"),
+		updated_content.contains("\n[unlicense-link]:"),
 		"unlicense-link should be on its own line"
 	);
 
@@ -8752,22 +8750,22 @@ fn update_idempotent_multiline_link_definitions() -> MdtResult<()> {
 fn update_preserves_newlines_with_valid_link_definitions() -> MdtResult<()> {
 	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
 	// Template with NO template variables — all URLs are valid
-	let template_content = r#"<!-- {@links} -->
+	let template_content = r"<!-- {@links} -->
 
 [repo]: https://github.com/example/repo
 [docs]: https://docs.example.com
 [ci]: https://ci.example.com/badge.svg
 
 <!-- {/links} -->
-"#;
-	let consumer_content = r#"# Readme
+";
+	let consumer_content = r"# Readme
 
 <!-- {=links} -->
 
 old content
 
 <!-- {/links} -->
-"#;
+";
 	std::fs::write(tmp.path().join("template.t.md"), template_content)
 		.unwrap_or_else(|e| panic!("write template: {e}"));
 	std::fs::write(tmp.path().join("readme.md"), consumer_content)
@@ -8779,18 +8777,18 @@ old content
 	write_updates(&updates)?;
 
 	// Read back the updated content
-	let updated = std::fs::read_to_string(tmp.path().join("readme.md"))
+	let updated_content = std::fs::read_to_string(tmp.path().join("readme.md"))
 		.unwrap_or_else(|e| panic!("read: {e}"));
 	assert!(
-		updated.contains("\n[repo]:"),
+		updated_content.contains("\n[repo]:"),
 		"[repo] should be on its own line after first update"
 	);
 	assert!(
-		updated.contains("\n[docs]:"),
+		updated_content.contains("\n[docs]:"),
 		"[docs] should be on its own line after first update"
 	);
 	assert!(
-		updated.contains("\n[ci]:"),
+		updated_content.contains("\n[ci]:"),
 		"[ci] should be on its own line after first update"
 	);
 
@@ -8900,8 +8898,7 @@ fn config_load_data_script_uses_cache_until_watch_changes() -> MdtResult<()> {
 	std::fs::write(
 		tmp.path().join("mdt.toml"),
 		format!(
-			"[data]\nversion = {{ command = {:?}, format = \"text\", watch = [\"VERSION\"] }}\n",
-			command
+			"[data]\nversion = {{ command = {command:?}, format = \"text\", watch = [\"VERSION\"] }}\n"
 		),
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));

--- a/mdt_lsp/src/__tests.rs
+++ b/mdt_lsp/src/__tests.rs
@@ -2995,19 +2995,17 @@ fn completion_returns_all_provider_names() {
 		},
 	);
 
-	let make_provider = |name: &str| {
-		ProviderEntry {
-			block: Block {
-				name: name.to_string(),
-				r#type: BlockType::Provider,
-				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-				transformers: Vec::new(),
-				arguments: vec![],
-			},
-			file: PathBuf::from("/tmp/test/template.t.md"),
-			content: "\n\ncontent\n\n".to_string(),
-		}
+	let make_provider = |name: &str| ProviderEntry {
+		block: Block {
+			name: name.to_string(),
+			r#type: BlockType::Provider,
+			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+			transformers: Vec::new(),
+			arguments: vec![],
+		},
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: "\n\ncontent\n\n".to_string(),
 	};
 
 	let mut providers = HashMap::new();
@@ -3060,8 +3058,7 @@ fn transformer_completions_have_sort_text() {
 		assert_eq!(
 			item.sort_text,
 			Some(format!("{i:02}")),
-			"transformer at index {i} should have sort_text '{:02}'",
-			i
+			"transformer at index {i} should have sort_text '{i:02}'"
 		);
 	}
 }
@@ -3276,19 +3273,17 @@ fn suggest_similar_names_empty_providers_returns_empty() {
 
 #[test]
 fn suggest_similar_names_max_three_results() {
-	let make_provider = |name: &str| {
-		ProviderEntry {
-			block: Block {
-				name: name.to_string(),
-				r#type: BlockType::Provider,
-				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-				transformers: Vec::new(),
-				arguments: vec![],
-			},
-			file: PathBuf::from("/tmp/test/template.t.md"),
-			content: String::new(),
-		}
+	let make_provider = |name: &str| ProviderEntry {
+		block: Block {
+			name: name.to_string(),
+			r#type: BlockType::Provider,
+			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+			transformers: Vec::new(),
+			arguments: vec![],
+		},
+		file: PathBuf::from("/tmp/test/template.t.md"),
+		content: String::new(),
 	};
 
 	let mut providers = HashMap::new();
@@ -3596,11 +3591,9 @@ Old farewell
 
 	let titles: Vec<String> = actions
 		.iter()
-		.map(|a| {
-			match a {
-				CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
-				CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
-			}
+		.map(|a| match a {
+			CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
+			CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
 		})
 		.collect();
 	assert!(
@@ -5065,8 +5058,7 @@ fn document_symbols_multiple_blocks_correct_ranges() {
 /// consumer that passes an argument value.  The provider template uses
 /// `{{ crate_name }}` which should be replaced by the consumer's argument.
 fn make_args_test_state(consumer_arg: &str, consumer_body: &str) -> (WorkspaceState, Uri) {
-	let provider_template =
-		"<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
+	let provider_template = "<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
 		 crate_name }})]\n\n<!-- {/badges} -->\n";
 	let consumer_doc = format!(
 		"# Readme\n\n<!-- {{=badges:\"{consumer_arg}\"}} -->\n\n{consumer_body}\n\n<!-- \

--- a/mdt_mcp/src/__tests.rs
+++ b/mdt_mcp/src/__tests.rs
@@ -1469,20 +1469,17 @@ fn scan_ctx_on_nonexistent_path_returns_default_context() {
 	// scan_project_with_config gracefully handles nonexistent paths by
 	// returning an empty project context (no providers, no consumers).
 	let result = scan_ctx(Path::new("/tmp/nonexistent_mdt_test_dir_12345"));
-	match result {
-		Ok(ctx) => {
-			assert!(
-				ctx.project.providers.is_empty(),
-				"nonexistent path should have no providers"
-			);
-			assert!(
-				ctx.project.consumers.is_empty(),
-				"nonexistent path should have no consumers"
-			);
-		}
-		Err(_) => {
-			// Some platforms may return an error for nonexistent paths, that's OK too.
-		}
+	if let Ok(ctx) = result {
+		assert!(
+			ctx.project.providers.is_empty(),
+			"nonexistent path should have no providers"
+		);
+		assert!(
+			ctx.project.consumers.is_empty(),
+			"nonexistent path should have no consumers"
+		);
+	} else {
+		// Some platforms may return an error for nonexistent paths, that's OK too.
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR fixes the remaining pedantic clippy warnings from:

- `cargo clippy --workspace --all-features --all-targets`

## What Changed
- `mdt_mcp/src/__tests.rs`
  - Replaced a single-pattern `match` with `if let` (`clippy::single_match_else`).
- `mdt_core/src/__tests.rs`
  - Replaced `"".to_string()` with `String::new()` (`clippy::manual_string_new`).
  - Removed unnecessary `MdtResult<()>` return wrappers in two tests (`clippy::unnecessary_wraps`).
  - Renamed locals to avoid `similar_names` warnings.
  - Simplified raw string literals by removing unnecessary `#` delimiters (`clippy::needless_raw_string_hashes`).
  - Inlined `format!` arguments (`clippy::uninlined_format_args`).
- `mdt_lsp/src/__tests.rs`
  - Inlined format args in assertion message.
- `mdt_cli/tests/update.rs`
  - Removed unnecessary raw string hash delimiters.

## Validation
- `cargo clippy --workspace --all-features --all-targets`
