### PR TITLE
fix(lint): format clippy test updates with dprint

### DIFF
--- a/mdt_core/src/__tests.rs
+++ b/mdt_core/src/__tests.rs
@@ -8898,7 +8898,8 @@ fn config_load_data_script_uses_cache_until_watch_changes() -> MdtResult<()> {
 	std::fs::write(
 		tmp.path().join("mdt.toml"),
 		format!(
-			"[data]\nversion = {{ command = {command:?}, format = \"text\", watch = [\"VERSION\"] }}\n"
+			"[data]\nversion = {{ command = {command:?}, format = \"text\", watch = [\"VERSION\"] \
+			 }}\n"
 		),
 	)
 	.unwrap_or_else(|e| panic!("write: {e}"));

--- a/mdt_lsp/src/__tests.rs
+++ b/mdt_lsp/src/__tests.rs
@@ -2995,17 +2995,19 @@ fn completion_returns_all_provider_names() {
 		},
 	);
 
-	let make_provider = |name: &str| ProviderEntry {
-		block: Block {
-			name: name.to_string(),
-			r#type: BlockType::Provider,
-			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-			transformers: Vec::new(),
-			arguments: vec![],
-		},
-		file: PathBuf::from("/tmp/test/template.t.md"),
-		content: "\n\ncontent\n\n".to_string(),
+	let make_provider = |name: &str| {
+		ProviderEntry {
+			block: Block {
+				name: name.to_string(),
+				r#type: BlockType::Provider,
+				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+				transformers: Vec::new(),
+				arguments: vec![],
+			},
+			file: PathBuf::from("/tmp/test/template.t.md"),
+			content: "\n\ncontent\n\n".to_string(),
+		}
 	};
 
 	let mut providers = HashMap::new();
@@ -3273,17 +3275,19 @@ fn suggest_similar_names_empty_providers_returns_empty() {
 
 #[test]
 fn suggest_similar_names_max_three_results() {
-	let make_provider = |name: &str| ProviderEntry {
-		block: Block {
-			name: name.to_string(),
-			r#type: BlockType::Provider,
-			opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
-			closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
-			transformers: Vec::new(),
-			arguments: vec![],
-		},
-		file: PathBuf::from("/tmp/test/template.t.md"),
-		content: String::new(),
+	let make_provider = |name: &str| {
+		ProviderEntry {
+			block: Block {
+				name: name.to_string(),
+				r#type: BlockType::Provider,
+				opening: mdt_core::Position::new(1, 1, 0, 1, 20, 19),
+				closing: mdt_core::Position::new(3, 1, 30, 3, 20, 49),
+				transformers: Vec::new(),
+				arguments: vec![],
+			},
+			file: PathBuf::from("/tmp/test/template.t.md"),
+			content: String::new(),
+		}
 	};
 
 	let mut providers = HashMap::new();
@@ -3591,9 +3595,11 @@ Old farewell
 
 	let titles: Vec<String> = actions
 		.iter()
-		.map(|a| match a {
-			CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
-			CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
+		.map(|a| {
+			match a {
+				CodeActionOrCommand::CodeAction(ca) => ca.title.clone(),
+				CodeActionOrCommand::Command(cmd) => cmd.title.clone(),
+			}
 		})
 		.collect();
 	assert!(
@@ -5058,7 +5064,8 @@ fn document_symbols_multiple_blocks_correct_ranges() {
 /// consumer that passes an argument value.  The provider template uses
 /// `{{ crate_name }}` which should be replaced by the consumer's argument.
 fn make_args_test_state(consumer_arg: &str, consumer_body: &str) -> (WorkspaceState, Uri) {
-	let provider_template = "<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
+	let provider_template =
+		"<!-- {@badges:\"crate_name\"} -->\n\n[![crates.io](https://img.shields.io/crates/v/{{ \
 		 crate_name }})]\n\n<!-- {/badges} -->\n";
 	let consumer_doc = format!(
 		"# Readme\n\n<!-- {{=badges:\"{consumer_arg}\"}} -->\n\n{consumer_body}\n\n<!-- \


### PR DESCRIPTION
## Summary
Follow-up lint fix for the all-target clippy cleanup PR.

## Why
PR #100 resolved clippy warnings but failed `ci/lint` due dprint formatting differences in two test files.

## What Changed
- Applied `dprint fmt` updates for:
  - `mdt_core/src/__tests.rs`
  - `mdt_lsp/src/__tests.rs`

## Validation
- `dprint check mdt_core/src/__tests.rs mdt_lsp/src/__tests.rs`
- `cargo clippy --workspace --all-features --all-targets`
