### PR TITLE
fix: align MCP bootstrap flow with canonical .templates init

### DIFF
--- a/.changeset/issue-105-bootstrap.md
+++ b/.changeset/issue-105-bootstrap.md
@@ -1,0 +1,10 @@
+---
+mdt_cli: docs
+mdt_mcp: patch
+---
+
+Align bootstrap documentation around the canonical `.templates/` layout and unify MCP initialization with the CLI.
+
+`mdt_init` now creates the same starter files as `mdt init`: a sample `.templates/template.t.md` file plus `mdt.toml` when no config exists yet. The MCP init flow also respects existing canonical and legacy template locations instead of always writing a new root-level `template.t.md`.
+
+Documentation and generated READMEs now consistently describe `.templates/template.t.md` as the canonical starter path.

--- a/docs/src/advanced/monorepos.md
+++ b/docs/src/advanced/monorepos.md
@@ -8,20 +8,23 @@ When mdt scans a directory tree, it stops descending into any subdirectory that 
 
 ```
 my-monorepo/
-  mdt.toml              # root project
-  template.t.md         # root providers
-  readme.md             # root consumers
+  mdt.toml                    # root project
+  .templates/
+    template.t.md             # root providers
+  readme.md                   # root consumers
   packages/
     lib-a/
-      mdt.toml          # lib-a is a separate project
-      template.t.md     # lib-a providers
-      readme.md         # lib-a consumers
+      mdt.toml                # lib-a is a separate project
+      .templates/
+        template.t.md         # lib-a providers
+      readme.md               # lib-a consumers
     lib-b/
-      mdt.toml          # lib-b is a separate project
-      template.t.md     # lib-b providers
-      readme.md         # lib-b consumers
+      mdt.toml                # lib-b is a separate project
+      .templates/
+        template.t.md         # lib-b providers
+      readme.md               # lib-b consumers
     lib-c/
-      readme.md         # NO mdt.toml — belongs to root project
+      readme.md               # NO mdt.toml — belongs to root project
 ```
 
 Running `mdt update` from the monorepo root updates consumers in `readme.md` and `packages/lib-c/readme.md`, but **not** in `packages/lib-a/` or `packages/lib-b/`. Those are separate projects.
@@ -55,7 +58,7 @@ cargo = "Cargo.toml"
 Each sub-project has its own `*.t.md` files with its own provider blocks:
 
 ```
-<!-- packages/lib-a/template.t.md -->
+<!-- packages/lib-a/.templates/template.t.md -->
 
 <!-- {@install} -->
 
@@ -65,7 +68,7 @@ cargo add lib-a
 ```
 
 ```
-<!-- packages/lib-b/template.t.md -->
+<!-- packages/lib-b/.templates/template.t.md -->
 
 <!-- {@install} -->
 
@@ -98,7 +101,7 @@ done
 
 ## Shared templates across packages
 
-Sub-project boundaries are strict. A provider in the root `template.t.md` is **not visible** to consumers inside `packages/lib-a/`. Each scope is fully isolated.
+Sub-project boundaries are strict. A provider in the root `.templates/template.t.md` is **not visible** to consumers inside `packages/lib-a/`. Each scope is fully isolated.
 
 If you need shared content across packages, you have a few options:
 

--- a/docs/src/concepts/providers-and-consumers.md
+++ b/docs/src/concepts/providers-and-consumers.md
@@ -58,7 +58,7 @@ The `/` sigil closes the block. The name must match the opening tag.
 ## How content flows
 
 ```
-template.t.md                    readme.md                     src/lib.rs
+.templates/template.t.md         readme.md                     src/lib.rs
 ┌─────────────────┐             ┌──────────────────┐          ┌──────────────────┐
 │ <!-- {@docs} -->│             │ <!-- {=docs} --> │          │ // <!-- {=docs|  │
 │                 │──────┬─────→│                  │          │ //  trim|indent: │
@@ -75,7 +75,7 @@ The same provider content feeds multiple consumers. Each consumer can apply its 
 
 ## A complete example
 
-**`template.t.md`** — the single source of truth:
+**`.templates/template.t.md`** — the single source of truth:
 
 ```
 <!-- {@projectDescription} -->

--- a/docs/src/guide/configuration.md
+++ b/docs/src/guide/configuration.md
@@ -155,15 +155,18 @@ If mdt encounters a directory containing its own `mdt.toml`, it treats that dire
 
 ```
 my-monorepo/
-  mdt.toml              # root project config
-  template.t.md
+  mdt.toml                    # root project config
+  .templates/
+    template.t.md
   packages/
     lib-a/
-      mdt.toml          # lib-a is a separate mdt project
-      template.t.md
+      mdt.toml                # lib-a is a separate mdt project
+      .templates/
+        template.t.md
     lib-b/
-      mdt.toml          # lib-b is a separate mdt project
-      template.t.md
+      mdt.toml                # lib-b is a separate mdt project
+      .templates/
+        template.t.md
 ```
 
 Running `mdt update` from the root updates only the root project's consumers. Each sub-project is managed independently.

--- a/docs/src/guide/source-files.md
+++ b/docs/src/guide/source-files.md
@@ -137,7 +137,7 @@ Source files can only contain **consumer** blocks. Even if you write `{@name}` i
 
 Consider a TypeScript library where you want the README, JSDoc, and mdbook docs to stay in sync.
 
-**`template.t.md`** defines the content:
+**`.templates/template.t.md`** defines the content:
 
 ```
 <!-- {@apiDocs} -->

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -20,7 +20,7 @@ Manual synchronization doesn't scale. Copy-pasting is error-prone. The more plac
 mdt uses HTML comments as invisible template tags. You define content once in a **provider** block inside a template file. Then you place **consumer** tags wherever that content should appear. Running `mdt update` replaces the content between consumer tags with the provider's content.
 
 ```markdown
-<!-- In template.t.md (the provider) -->
+<!-- In .templates/template.t.md (the provider) -->
 <!-- {@install} -->
 
 npm install my-lib

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -126,8 +126,8 @@ Output:
 
 ```
 Providers:
-  @installGuide template.t.md (2 consumer(s))
-  @apiDocs template.t.md (3 consumer(s))
+  @installGuide .templates/template.t.md (2 consumer(s))
+  @apiDocs .templates/template.t.md (3 consumer(s))
 
 Consumers:
   =installGuide readme.md [linked]

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -75,8 +75,8 @@ mdt list
 
 ```
 Providers:
-  @installGuide template.t.md (2 consumer(s))
-  @apiDocs template.t.md (3 consumer(s))
+  @installGuide .templates/template.t.md (2 consumer(s))
+  @apiDocs .templates/template.t.md (3 consumer(s))
 
 Consumers:
   =installGuide readme.md [linked]

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -31,7 +31,7 @@ cargo install mdt_cli
 
 ### CLI Commands
 
-- `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
+- `mdt init [--path <dir>]` — Create a sample `.templates/template.t.md` file and starter `mdt.toml`.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.

--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -54,11 +54,12 @@ pub struct MdtCli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-	/// Initialize mdt in a project by creating a sample template file.
+	/// Initialize mdt in a project by creating sample starter files.
 	///
-	/// Creates a `template.t.md` file in the project root with example provider
-	/// blocks and usage instructions. If the file already exists, this command
-	/// is a no-op and exits successfully.
+	/// Creates a `.templates/template.t.md` file in the project root with an
+	/// example provider block, plus an `mdt.toml` starter config when one does
+	/// not already exist. If the template file already exists, the command is a
+	/// no-op for that file and exits successfully.
 	Init,
 	/// Check that all consumer blocks are up to date.
 	///

--- a/mdt_mcp/readme.md
+++ b/mdt_mcp/readme.md
@@ -20,7 +20,7 @@
 - **`mdt_find_reuse`** — Find similar providers and where they are already consumed in markdown and source files to encourage reuse.
 - **`mdt_get_block`** — Get the content of a specific block by name.
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
-- **`mdt_init`** — Initialize a new mdt project with a sample template file.
+- **`mdt_init`** — Initialize a new mdt project with a sample `.templates/template.t.md` file and starter `mdt.toml`.
 
 ### Agent Workflow
 

--- a/mdt_mcp/src/__tests.rs
+++ b/mdt_mcp/src/__tests.rs
@@ -199,16 +199,28 @@ async fn init_creates_template_file() {
 		"expected creation message, got: {text}"
 	);
 	assert!(
-		tmp.path().join("template.t.md").exists(),
-		"template.t.md should exist"
+		text.contains("Created mdt.toml"),
+		"expected config creation message, got: {text}"
+	);
+	assert!(
+		tmp.path().join(".templates/template.t.md").exists(),
+		".templates/template.t.md should exist"
+	);
+	assert!(
+		tmp.path().join("mdt.toml").exists(),
+		"mdt.toml should exist"
 	);
 }
 
 #[tokio::test]
 async fn init_reports_existing_template() {
 	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
-	std::fs::write(tmp.path().join("template.t.md"), "existing content")
-		.unwrap_or_else(|e| panic!("write: {e}"));
+	std::fs::create_dir_all(tmp.path().join(".templates")).unwrap_or_else(|e| panic!("mkdir: {e}"));
+	std::fs::write(
+		tmp.path().join(".templates/template.t.md"),
+		"existing content",
+	)
+	.unwrap_or_else(|e| panic!("write: {e}"));
 
 	let server = MdtMcpServer::new();
 	let result = server
@@ -222,6 +234,14 @@ async fn init_reports_existing_template() {
 	assert!(
 		text.contains("already exists"),
 		"expected 'already exists' message, got: {text}"
+	);
+	assert!(
+		text.contains("Created mdt.toml"),
+		"expected config creation message, got: {text}"
+	);
+	assert!(
+		tmp.path().join("mdt.toml").exists(),
+		"mdt.toml should exist"
 	);
 }
 
@@ -1072,7 +1092,7 @@ async fn init_creates_file_with_provider_block() {
 		.await
 		.unwrap_or_else(|e| panic!("init: {e:?}"));
 
-	let content = std::fs::read_to_string(tmp.path().join("template.t.md"))
+	let content = std::fs::read_to_string(tmp.path().join(".templates/template.t.md"))
 		.unwrap_or_else(|e| panic!("read template: {e}"));
 	assert!(
 		content.contains("{@greeting}"),
@@ -2041,8 +2061,12 @@ async fn init_in_nested_directory() {
 		"expected creation message, got: {text}"
 	);
 	assert!(
-		nested.join("template.t.md").exists(),
+		nested.join(".templates/template.t.md").exists(),
 		"template should be created in nested dir"
+	);
+	assert!(
+		nested.join("mdt.toml").exists(),
+		"mdt.toml should be created"
 	);
 }
 

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -9,7 +9,7 @@
 //! - **`mdt_find_reuse`** — Find similar providers and where they are already consumed in markdown and source files to encourage reuse.
 //! - **`mdt_get_block`** — Get the content of a specific block by name.
 //! - **`mdt_preview`** — Preview the result of applying transformers to a block.
-//! - **`mdt_init`** — Initialize a new mdt project with a sample template file.
+//! - **`mdt_init`** — Initialize a new mdt project with a sample `.templates/template.t.md` file and starter `mdt.toml`.
 //!
 //! ### Agent Workflow
 //!
@@ -43,6 +43,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use mdt_core::BlockType;
+use mdt_core::MdtConfig;
 use mdt_core::apply_transformers;
 use mdt_core::check_project;
 use mdt_core::compute_updates;
@@ -664,34 +665,86 @@ impl MdtMcpServer {
 
 	#[tool(
 		name = "mdt_init",
-		description = "Initialize mdt in a project by creating a sample template.t.md file."
+		description = "Initialize mdt in a project by creating a sample \
+		               `.templates/template.t.md` file and starter `mdt.toml`."
 	)]
 	async fn init(
 		&self,
 		Parameters(params): Parameters<InitParam>,
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref());
-		let template_path = root.join("template.t.md");
+		let canonical_template_path = root.join(".templates/template.t.md");
+		let legacy_template_paths = [
+			root.join("template.t.md"),
+			root.join("templates/template.t.md"),
+		];
+		let template_path = if canonical_template_path.exists() {
+			canonical_template_path.clone()
+		} else {
+			legacy_template_paths
+				.iter()
+				.find(|path| path.exists())
+				.cloned()
+				.unwrap_or_else(|| canonical_template_path.clone())
+		};
+		let template_exists = template_path.exists();
 
-		if template_path.exists() {
-			return Ok(CallToolResult::success(vec![Content::text(format!(
-				"Template file already exists: {}",
-				template_path.display()
-			))]));
-		}
-
+		let config_path = root.join("mdt.toml");
+		let config_exists = MdtConfig::resolve_path(&root).is_some();
 		let sample_content = "<!-- {@greeting} -->\n\nHello from mdt! This is a provider \
 		                      block.\n\n<!-- {/greeting} -->\n";
+		let sample_config =
+			"# mdt configuration\n# See \
+			 https://ifiokjr.github.io/mdt/reference/configuration.html for full reference.\n\n# \
+			 Map data files to template namespaces.\n# Values from these files are available in \
+			 provider blocks as {{ namespace.key }}.\n# [data]\n# pkg = \"package.json\"\n# cargo \
+			 = \"Cargo.toml\"\n# version = { command = \"cat VERSION\", format = \"text\", watch \
+			 = [\"VERSION\"] }\n\n# Control blank lines between tags and content in source \
+			 files.\n# Recommended when using formatters (rustfmt, prettier, etc.).\n# \
+			 [padding]\n# before = 0\n# after = 0\n";
 
-		std::fs::write(&template_path, sample_content)
-			.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+		let mut parts = Vec::new();
 
-		Ok(CallToolResult::success(vec![Content::text(format!(
-			"Created template file: {}\n\nNext steps:\n1. Edit the template to define your \
-			 blocks\n2. Add consumer tags in your files: <!-- {{=greeting}} --> <!-- \
-			 {{/greeting}} -->\n3. Run mdt_update to sync content",
-			template_path.display()
-		))]))
+		if template_exists {
+			parts.push(format!(
+				"Template file already exists: {}",
+				template_path.display()
+			));
+		} else {
+			if let Some(parent) = template_path.parent() {
+				std::fs::create_dir_all(parent)
+					.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+			}
+			std::fs::write(&template_path, sample_content)
+				.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+			parts.push(format!(
+				"Created template file: {}",
+				template_path.display()
+			));
+		}
+
+		if !config_exists {
+			std::fs::write(&config_path, sample_config)
+				.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+			parts.push("Created mdt.toml".to_string());
+		}
+
+		if !template_exists {
+			parts.push(String::new());
+			parts.push("Next steps:".to_string());
+			parts.push(format!(
+				"1. Edit {} to define your template blocks",
+				template_path.display()
+			));
+			parts.push("2. Add consumer tags in your markdown files:".to_string());
+			parts.push("   <!-- {=greeting} -->".to_string());
+			parts.push("   <!-- {/greeting} -->".to_string());
+			parts.push("3. Run `mdt_update` to sync content".to_string());
+		}
+
+		Ok(CallToolResult::success(vec![Content::text(
+			parts.join("\n"),
+		)]))
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 
 ### CLI Commands
 
-- `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
+- `mdt init [--path <dir>]` — Create a sample `.templates/template.t.md` file and starter `mdt.toml`.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.

--- a/template.t.md
+++ b/template.t.md
@@ -8,7 +8,7 @@
 
 ### CLI Commands
 
-- `mdt init [--path <dir>]` — Create a sample `template.t.md` file with getting-started instructions.
+- `mdt init [--path <dir>]` — Create a sample `.templates/template.t.md` file and starter `mdt.toml`.
 - `mdt check [--path <dir>] [--verbose]` — Verify all consumer blocks are up-to-date. Exits non-zero if any are stale.
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
@@ -198,7 +198,7 @@ The server communicates over stdin/stdout using the Language Server Protocol.
 - **`mdt_find_reuse`** — Find similar providers and where they are already consumed in markdown and source files to encourage reuse.
 - **`mdt_get_block`** — Get the content of a specific block by name.
 - **`mdt_preview`** — Preview the result of applying transformers to a block.
-- **`mdt_init`** — Initialize a new mdt project with a sample template file.
+- **`mdt_init`** — Initialize a new mdt project with a sample `.templates/template.t.md` file and starter `mdt.toml`.
 
 ### Agent Workflow
 


### PR DESCRIPTION
## Summary
- align `mdt_init` with the CLI bootstrap flow
- create `.templates/template.t.md` and `mdt.toml` from MCP init
- update docs and generated READMEs to consistently describe the canonical `.templates/` layout

## Testing
- `cargo test -p mdt_mcp --quiet`
- `cargo test -p mdt_cli --test init --quiet`
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`

Closes #105
