### PR TITLE
docs: improve installation and first-run onboarding

### DIFF
--- a/.changeset/issue-106-onboarding.md
+++ b/.changeset/issue-106-onboarding.md
@@ -1,0 +1,7 @@
+---
+mdt_cli: docs
+---
+
+Improve installation and quick-start documentation for first-time users.
+
+The docs now recommend prebuilt release binaries for non-Rust projects, remove stale versioned install snippets, and show a 10-minute quick start that keeps a README section and a source-doc comment in sync from one provider.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,8 +1,14 @@
 # Installation
 
-## From crates.io
+## Recommended for most users
 
-Install the CLI with cargo:
+Download the prebuilt binary for your platform from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest) and place the `mdt` binary somewhere on your `PATH`.
+
+This is the easiest option if you want to use mdt in a JavaScript, Python, Go, or other non-Rust project without installing the Rust toolchain first.
+
+## If you already use Cargo
+
+Install the CLI from crates.io:
 
 ```sh
 cargo install mdt_cli
@@ -12,7 +18,7 @@ This installs the `mdt` binary.
 
 ## From source
 
-Clone the repository and build:
+Clone the repository and build from the workspace:
 
 ```sh
 git clone https://github.com/ifiokjr/mdt.git
@@ -22,11 +28,11 @@ cargo install --path mdt_cli
 
 ## As a library
 
-To use the mdt core library in your own Rust project:
+To use the core engine in your own Rust project:
 
 ```toml
 [dependencies]
-mdt_core = "0.2.0"
+mdt_core = "0.7.0"
 ```
 
 ## Verify installation
@@ -35,4 +41,4 @@ mdt_core = "0.2.0"
 mdt --help
 ```
 
-You should see the available commands: `init`, `check`, `update`, `list`, `lsp`, and `mcp`.
+You should see the available commands: `init`, `check`, `update`, `list`, `info`, `doctor`, `lsp`, and `mcp`.

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -1,17 +1,22 @@
 # Quick Start
 
-This walkthrough creates a small project that uses mdt to keep a README in sync with a template.
+This walkthrough creates a small project that uses mdt to keep a README section and a Rust doc comment in sync from one provider.
 
 ## 1. Initialize a project
 
-Create a new directory and generate a starter template:
+Create a new directory and generate the starter files:
 
 ```sh
 mkdir my-project && cd my-project
 mdt init
 ```
 
-This creates `.templates/template.t.md` with a sample provider block:
+This creates:
+
+- `.templates/template.t.md` — your starter provider file
+- `mdt.toml` — a starter config with commented examples
+
+The starter template contains:
 
 ```markdown
 <!-- {@greeting} -->
@@ -21,7 +26,7 @@ Hello from mdt! This is a provider block.
 <!-- {/greeting} -->
 ```
 
-## 2. Add a consumer
+## 2. Add a README consumer
 
 Create a `readme.md` that references the provider:
 
@@ -37,9 +42,27 @@ This will be replaced by mdt.
 <!-- {/greeting} -->
 ```
 
-The `{=greeting}` tag marks this as a **consumer** of the `greeting` provider. The content between the opening and closing tags will be replaced.
+The `{=greeting}` tag marks this as a **consumer** of the `greeting` provider.
 
-## 3. Update
+## 3. Add a source-doc consumer
+
+Create `src/lib.rs` with a doc comment consumer that reuses the same provider:
+
+```rust
+//! <!-- {=greeting|trim|linePrefix:"//! "} -->
+//!
+//! This will be replaced by mdt.
+//!
+//! <!-- {/greeting} -->
+
+pub fn hello() {}
+```
+
+The `linePrefix:"//! "` transformer adapts the provider content so it becomes valid Rust doc comments.
+
+> Not using Rust? The same pattern works in other source files too — use a comment style and transformers that match your language.
+
+## 4. Update
 
 Run the update command:
 
@@ -50,10 +73,12 @@ mdt update
 Output:
 
 ```
-Updated 1 block(s) in 1 file(s).
+Updated 2 block(s) in 2 file(s).
 ```
 
-Now `readme.md` contains:
+Now both files are synchronized from the same provider.
+
+`readme.md` contains:
 
 ```markdown
 # My Project
@@ -67,9 +92,19 @@ Hello from mdt! This is a provider block.
 <!-- {/greeting} -->
 ```
 
-The content between the consumer tags has been replaced with the provider's content.
+And `src/lib.rs` contains:
 
-## 4. Check for staleness
+```rust
+//! <!-- {=greeting|trim|linePrefix:"//! "} -->
+//!
+//! Hello from mdt! This is a provider block.
+//!
+//! <!-- {/greeting} -->
+
+pub fn hello() {}
+```
+
+## 5. Check for staleness
 
 Edit the provider in `.templates/template.t.md`:
 
@@ -90,14 +125,20 @@ mdt check
 Output:
 
 ```
-Stale: block `greeting` in readme.md
+Check failed.
+  render errors: 0
+  stale consumers: 2
 
-1 consumer block(s) are out of date. Run `mdt update` to fix.
+Stale consumers:
+  block `greeting` at readme.md:5:1
+  block `greeting` at src/lib.rs:1:5
+
+2 consumer block(s) are out of date. Run `mdt update` to fix.
 ```
 
 The check command exits with a non-zero status code when blocks are stale, making it useful in CI pipelines.
 
-## 5. See what changed
+## 6. See what changed
 
 Use the `--diff` flag to see exactly what's different:
 
@@ -107,7 +148,7 @@ mdt check --diff
 
 This shows a colorized unified diff between the current consumer content and what the provider would produce.
 
-## 6. List all blocks
+## 7. List all blocks
 
 See all providers and consumers in the project:
 
@@ -119,12 +160,13 @@ Output:
 
 ```
 Providers:
-  @greeting .templates/template.t.md (1 consumer(s))
+  @greeting .templates/template.t.md (2 consumer(s))
 
 Consumers:
   =greeting readme.md [linked]
+  =greeting src/lib.rs |trim|linePrefix [linked]
 
-1 provider(s), 1 consumer(s)
+1 provider(s), 2 consumer(s)
 ```
 
 ## Next steps

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -18,8 +18,11 @@
 
 <!-- {=mdtCliInstall} -->
 
+- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Or install with Cargo:
+
 ```sh
-cargo install mdt_cli@0.7.0
+cargo install mdt_cli
 ```
 
 <!-- {/mdtCliInstall} -->

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,11 @@
 
 <!-- {=mdtCliInstall} -->
 
+- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Or install with Cargo:
+
 ```sh
-cargo install mdt_cli@0.7.0
+cargo install mdt_cli
 ```
 
 <!-- {/mdtCliInstall} -->

--- a/template.t.md
+++ b/template.t.md
@@ -274,8 +274,11 @@ mdt_mcp = "{{ cargo.workspace.package.version }}"
 
 <!-- {@mdtCliInstall} -->
 
+- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Or install with Cargo:
+
 ```sh
-cargo install mdt_cli@{{ cargo.workspace.package.version }}
+cargo install mdt_cli
 ```
 
 <!-- {/mdtCliInstall} -->


### PR DESCRIPTION
## Summary
- recommend prebuilt release binaries for non-Rust users
- remove stale version-pinned install snippets from the README install section
- expand the quick start to sync both a README section and a source-doc consumer

## Testing
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`

Closes #106
