### PR TITLE
feat(mdt_mcp): add structured JSON authoring responses

### DIFF
--- a/.changeset/issue-108-mcp-json.md
+++ b/.changeset/issue-108-mcp-json.md
@@ -1,0 +1,7 @@
+---
+mdt_mcp: minor
+---
+
+Make the MCP server more agent-friendly with structured JSON-first responses.
+
+`mdt_check`, `mdt_update`, `mdt_preview`, and `mdt_init` now return consistent JSON-oriented envelopes in MCP `structured_content`, while still preserving text content for compatibility. `mdt_preview` now acts as an authoring workflow by returning per-consumer rendered output, including parameterized consumer previews and render/mismatch details. The MCP surface also exposes undefined-variable warnings in `check` and `update` results.

--- a/mdt_mcp/readme.md
+++ b/mdt_mcp/readme.md
@@ -25,6 +25,8 @@
 ### Agent Workflow
 
 - Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+- Use the JSON-first tool responses as the source of truth. The MCP server returns structured payloads so agents can inspect results without parsing prose.
+- Use `mdt_preview` as an authoring workflow: inspect the provider template plus each consumer's rendered output before deciding whether to reuse, edit, or sync.
 - Keep provider names global and unique in the project to avoid collisions.
 - After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
 

--- a/mdt_mcp/src/__tests.rs
+++ b/mdt_mcp/src/__tests.rs
@@ -17,6 +17,14 @@ fn extract_text(result: &CallToolResult) -> &str {
 		.as_str()
 }
 
+fn extract_json(result: &CallToolResult) -> serde_json::Value {
+	if let Some(value) = result.structured_content.clone() {
+		return value;
+	}
+	serde_json::from_str(extract_text(result))
+		.unwrap_or_else(|e| panic!("invalid JSON result: {e}"))
+}
+
 // ---------------------------------------------------------------------------
 // Helper: create a minimal mdt project in a temp directory
 // ---------------------------------------------------------------------------
@@ -97,6 +105,26 @@ Old farewell content.
 	std::fs::write(root.join("readme.md"), readme).unwrap_or_else(|e| panic!("write readme: {e}"));
 }
 
+fn create_warning_project(root: &Path) {
+	std::fs::write(root.join("mdt.toml"), "[data]\npkg = \"package.json\"\n")
+		.unwrap_or_else(|e| panic!("write config: {e}"));
+	std::fs::write(
+		root.join("package.json"),
+		r#"{"name": "my-lib", "version": "1.0.0"}"#,
+	)
+	.unwrap_or_else(|e| panic!("write package: {e}"));
+	std::fs::write(
+		root.join("template.t.md"),
+		"<!-- {@install} -->\n\nnpm install {{ pkgg.name }}\n\n<!-- {/install} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write template: {e}"));
+	std::fs::write(
+		root.join("readme.md"),
+		"<!-- {=install} -->\n\nnpm install \n\n<!-- {/install} -->\n",
+	)
+	.unwrap_or_else(|e| panic!("write readme: {e}"));
+}
+
 // ===========================================================================
 // scan_ctx
 // ===========================================================================
@@ -149,15 +177,11 @@ async fn init_creates_template_file() {
 		.await
 		.unwrap_or_else(|e| panic!("init: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("Created template file"),
-		"expected creation message, got: {text}"
-	);
-	assert!(
-		text.contains("Created mdt.toml"),
-		"expected config creation message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "init");
+	assert_eq!(json["template_created"], true);
+	assert_eq!(json["config_created"], true);
 	assert!(
 		tmp.path().join(".templates/template.t.md").exists(),
 		".templates/template.t.md should exist"
@@ -186,14 +210,15 @@ async fn init_reports_existing_template() {
 		.await
 		.unwrap_or_else(|e| panic!("init: {e:?}"));
 
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["template_created"], false);
+	assert_eq!(json["config_created"], true);
 	assert!(
-		text.contains("already exists"),
-		"expected 'already exists' message, got: {text}"
-	);
-	assert!(
-		text.contains("Created mdt.toml"),
-		"expected config creation message, got: {text}"
+		json["summary"]
+			.as_str()
+			.is_some_and(|summary| summary.contains("already exists")),
+		"expected 'already exists' summary, got: {json}"
 	);
 	assert!(
 		tmp.path().join("mdt.toml").exists(),
@@ -217,11 +242,11 @@ async fn check_on_empty_project_reports_up_to_date() {
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("up to date"),
-		"expected up-to-date message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "check");
+	assert_eq!(json["stale"], serde_json::json!([]));
+	assert_eq!(json["render_errors"], serde_json::json!([]));
 }
 
 #[tokio::test]
@@ -237,11 +262,10 @@ async fn check_on_synced_project_reports_up_to_date() {
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("up to date"),
-		"expected up-to-date message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["stale"], serde_json::json!([]));
+	assert_eq!(json["render_errors"], serde_json::json!([]));
 }
 
 #[tokio::test]
@@ -257,15 +281,11 @@ async fn check_on_stale_project_reports_stale_blocks() {
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("stale"),
-		"expected stale message, got: {text}"
-	);
-	assert!(
-		text.contains("greeting"),
-		"expected block name in message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], false);
+	assert_eq!(json["action"], "check");
+	assert_eq!(json["stale"][0]["block_name"], "greeting");
+	assert_eq!(json["stale"][0]["file"], "readme.md");
 }
 
 // ===========================================================================
@@ -286,11 +306,11 @@ async fn update_on_up_to_date_project_reports_no_changes() {
 		.await
 		.unwrap_or_else(|e| panic!("update: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("already up to date"),
-		"expected no-changes message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "update");
+	assert_eq!(json["updated_count"], 0);
+	assert_eq!(json["dry_run"], false);
 }
 
 #[tokio::test]
@@ -307,11 +327,11 @@ async fn update_on_stale_project_applies_changes() {
 		.await
 		.unwrap_or_else(|e| panic!("update: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("Updated"),
-		"expected update confirmation, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "update");
+	assert_eq!(json["updated_count"], 1);
+	assert_eq!(json["updated_files"][0], "readme.md");
 
 	// Verify the file was actually written
 	let readme_content = std::fs::read_to_string(tmp.path().join("readme.md"))
@@ -340,11 +360,11 @@ async fn update_dry_run_does_not_write() {
 		.await
 		.unwrap_or_else(|e| panic!("update: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("Dry run"),
-		"expected dry-run message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "update");
+	assert_eq!(json["dry_run"], true);
+	assert_eq!(json["updated_count"], 1);
 
 	// Verify the file was NOT modified
 	let readme_content = std::fs::read_to_string(tmp.path().join("readme.md"))
@@ -369,11 +389,27 @@ async fn update_dry_run_lists_affected_files() {
 		.await
 		.unwrap_or_else(|e| panic!("update: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("readme.md"),
-		"dry run should list the affected file, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["updated_files"][0], "readme.md");
+}
+
+#[tokio::test]
+async fn update_includes_template_warnings_in_json() {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	create_warning_project(tmp.path());
+
+	let server = MdtMcpServer::new();
+	let result = server
+		.update(Parameters(UpdateParam {
+			path: Some(tmp.path().to_string_lossy().to_string()),
+			dry_run: true,
+		}))
+		.await
+		.unwrap_or_else(|e| panic!("update: {e:?}"));
+
+	let json = extract_json(&result);
+	assert_eq!(json["warnings"][0]["block_name"], "install");
+	assert_eq!(json["warnings"][0]["undefined_variables"][0], "pkgg.name");
 }
 
 // ===========================================================================
@@ -758,11 +794,13 @@ async fn get_block_for_nonexistent_returns_error() {
 		Some(true),
 		"result should be marked as error"
 	);
-
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], false);
 	assert!(
-		text.contains("No block named"),
-		"expected 'No block named' message, got: {text}"
+		json["summary"]
+			.as_str()
+			.is_some_and(|summary| summary.contains("No block named")),
+		"expected 'No block named' message, got: {json}"
 	);
 }
 
@@ -784,14 +822,15 @@ async fn preview_for_existing_provider_returns_rendered_content() {
 		.await
 		.unwrap_or_else(|e| panic!("preview: {e:?}"));
 
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], true);
+	assert_eq!(json["action"], "preview");
+	assert_eq!(json["provider"]["name"], "greeting");
 	assert!(
-		text.contains("Provider `greeting`"),
-		"expected provider heading, got: {text}"
-	);
-	assert!(
-		text.contains("Hello from mdt!"),
-		"expected rendered content, got: {text}"
+		json["provider"]["rendered_with_project_data"]
+			.as_str()
+			.is_some_and(|value| value.contains("Hello from mdt!")),
+		"expected rendered provider content, got: {json}"
 	);
 }
 
@@ -809,14 +848,14 @@ async fn preview_shows_consumer_info() {
 		.await
 		.unwrap_or_else(|e| panic!("preview: {e:?}"));
 
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["consumers"][0]["file"], "readme.md");
+	assert_eq!(json["consumers"][0]["is_stale"], true);
 	assert!(
-		text.contains("consumer(s)"),
-		"expected consumer section, got: {text}"
-	);
-	assert!(
-		text.contains("readme.md"),
-		"expected consumer file listed, got: {text}"
+		json["consumers"][0]["rendered_content"]
+			.as_str()
+			.is_some_and(|value| value.contains("Hello from mdt!")),
+		"expected rendered consumer preview, got: {json}"
 	);
 }
 
@@ -838,11 +877,13 @@ async fn preview_for_nonexistent_provider_returns_error() {
 		Some(true),
 		"result should be marked as error"
 	);
-
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], false);
 	assert!(
-		text.contains("No provider named"),
-		"expected 'No provider named' message, got: {text}"
+		json["summary"]
+			.as_str()
+			.is_some_and(|summary| summary.contains("No provider named")),
+		"expected missing-provider error, got: {json}"
 	);
 }
 
@@ -870,15 +911,9 @@ Nobody references me.
 		.await
 		.unwrap_or_else(|e| panic!("preview: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("Provider `lonely`"),
-		"expected provider heading, got: {text}"
-	);
-	assert!(
-		!text.contains("consumer(s)"),
-		"should not contain consumer section when there are no consumers"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["provider"]["name"], "lonely");
+	assert_eq!(json["consumers"], serde_json::json!([]));
 }
 
 // ===========================================================================
@@ -917,15 +952,27 @@ placeholder
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("missing providers"),
-		"expected missing providers message, got: {text}"
-	);
-	assert!(
-		text.contains("missing_block"),
-		"expected missing block name in message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], false);
+	assert_eq!(json["missing_provider_names"][0], "missing_block");
+}
+
+#[tokio::test]
+async fn check_includes_template_warnings_in_json() {
+	let tmp = tempfile::tempdir().unwrap_or_else(|e| panic!("tempdir: {e}"));
+	create_warning_project(tmp.path());
+
+	let server = MdtMcpServer::new();
+	let result = server
+		.check(Parameters(PathParam {
+			path: Some(tmp.path().to_string_lossy().to_string()),
+		}))
+		.await
+		.unwrap_or_else(|e| panic!("check: {e:?}"));
+
+	let json = extract_json(&result);
+	assert_eq!(json["warnings"][0]["block_name"], "install");
+	assert_eq!(json["warnings"][0]["undefined_variables"][0], "pkgg.name");
 }
 
 // ===========================================================================
@@ -1132,21 +1179,10 @@ placeholder
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
-	// Should mention stale blocks
-	assert!(
-		text.contains("stale"),
-		"expected stale message, got: {text}"
-	);
-	// Should mention missing providers
-	assert!(
-		text.contains("missing providers"),
-		"expected missing providers message, got: {text}"
-	);
-	assert!(
-		text.contains("nonexistent"),
-		"expected nonexistent in message, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["ok"], false);
+	assert_eq!(json["stale"][0]["block_name"], "greeting");
+	assert_eq!(json["missing_provider_names"][0], "nonexistent");
 }
 
 // ===========================================================================
@@ -1886,15 +1922,8 @@ Hello from mdt!
 		.await
 		.unwrap_or_else(|e| panic!("preview: {e:?}"));
 
-	let text = extract_text(&result);
-	assert!(
-		text.contains("Transformers:"),
-		"preview should list transformers, got: {text}"
-	);
-	assert!(
-		text.contains("trim"),
-		"preview should show trim transformer, got: {text}"
-	);
+	let json = extract_json(&result);
+	assert_eq!(json["consumers"][0]["transformers"][0], "trim");
 }
 
 // ===========================================================================
@@ -1914,18 +1943,14 @@ async fn check_stale_project_reports_block_name_and_file() {
 		.await
 		.unwrap_or_else(|e| panic!("check: {e:?}"));
 
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["stale"][0]["block_name"], "greeting");
+	assert_eq!(json["stale"][0]["file"], "readme.md");
 	assert!(
-		text.contains("greeting"),
-		"check output should include block name, got: {text}"
-	);
-	assert!(
-		text.contains("readme.md"),
-		"check output should include file name, got: {text}"
-	);
-	assert!(
-		text.contains("mdt_update"),
-		"check output should mention mdt_update, got: {text}"
+		json["summary"]
+			.as_str()
+			.is_some_and(|summary| summary.contains("stale consumer block")),
+		"check output should include summary, got: {json}"
 	);
 }
 
@@ -2650,21 +2675,13 @@ async fn preview_with_block_arguments_shows_provider_template() {
 		.await
 		.unwrap_or_else(|e| panic!("preview: {e:?}"));
 
-	let text = extract_text(&result);
+	let json = extract_json(&result);
+	assert_eq!(json["provider"]["name"], "badges");
+	assert_eq!(json["consumers"][0]["file"], "readme.md");
 	assert!(
-		text.contains("Provider `badges`"),
-		"expected provider heading, got: {text}"
-	);
-	// The preview shows the provider template.  Since provider has a
-	// parameter `crate_name` without base data, the raw template variable
-	// may or may not be present depending on render behaviour.  At minimum
-	// the consumer section should list the consumer file.
-	assert!(
-		text.contains("consumer(s)"),
-		"expected consumer section, got: {text}"
-	);
-	assert!(
-		text.contains("readme.md"),
-		"expected consumer file listed, got: {text}"
+		json["consumers"][0]["rendered_content"]
+			.as_str()
+			.is_some_and(|value| value.contains("mdt_core")),
+		"expected argument-aware consumer preview, got: {json}"
 	);
 }

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -14,6 +14,8 @@
 //! ### Agent Workflow
 //!
 //! - Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+//! - Use the JSON-first tool responses as the source of truth. The MCP server returns structured payloads so agents can inspect results without parsing prose.
+//! - Use `mdt_preview` as an authoring workflow: inspect the provider template plus each consumer's rendered output before deciding whether to reuse, edit, or sync.
 //! - Keep provider names global and unique in the project to avoid collisions.
 //! - After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
 //!
@@ -44,6 +46,7 @@ use std::path::Path;
 use mdt_core::BlockType;
 use mdt_core::MdtConfig;
 use mdt_core::apply_transformers;
+use mdt_core::build_render_context;
 use mdt_core::check_project;
 use mdt_core::compute_updates;
 use mdt_core::project::ProjectContext;
@@ -142,6 +145,50 @@ struct ReuseCandidate {
 	distance: Option<usize>,
 }
 
+#[derive(Debug, Serialize)]
+struct TemplateWarningInfo {
+	block_name: String,
+	file: String,
+	undefined_variables: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RenderErrorInfo {
+	block_name: String,
+	file: String,
+	line: usize,
+	column: usize,
+	message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct StaleEntryInfo {
+	block_name: String,
+	file: String,
+	line: usize,
+	column: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct PreviewProviderInfo {
+	name: String,
+	file: String,
+	raw_content: String,
+	rendered_with_project_data: String,
+	parameters: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PreviewConsumerInfo {
+	file: String,
+	transformers: Vec<String>,
+	arguments: Vec<String>,
+	rendered_content: Option<String>,
+	current_content: String,
+	is_stale: Option<bool>,
+	render_error: Option<String>,
+}
+
 /// The MCP server for mdt.
 #[derive(Debug, Clone)]
 pub struct MdtMcpServer {
@@ -154,11 +201,14 @@ impl ServerHandler for MdtMcpServer {
 		ServerInfo {
 			instructions: Some(
 				"mdt (manage markdown templates) keeps documentation synchronized across your \
-				 project using comment-based template tags. Use these tools to check, update, \
+				 project using comment-based template tags. MCP tool responses are JSON-first and \
+				 include structured content for agent use. Use these tools to check, update, \
 				 list, preview, and find reusable blocks. Before creating a new provider, run \
 				 mdt_find_reuse or mdt_list to discover similar block names and existing \
-				 markdown/source consumers. Prefer reuse over new provider names when possible, \
-				 then run mdt_check (and mdt_update if needed) to keep consumers synchronized."
+				 markdown/source consumers. Use mdt_preview as an authoring workflow to inspect \
+				 provider templates plus per-consumer rendered output. Prefer reuse over new \
+				 provider names when possible, then run mdt_check (and mdt_update if needed) to \
+				 keep consumers synchronized."
 					.into(),
 			),
 			capabilities: ServerCapabilities::builder().enable_tools().build(),
@@ -175,6 +225,38 @@ fn scan_ctx(root: &Path) -> Result<ProjectContext, McpError> {
 	scan_project_with_config(root).map_err(|e| McpError::internal_error(e.to_string(), None))
 }
 
+fn json_result(value: serde_json::Value) -> CallToolResult {
+	let text = serde_json::to_string_pretty(&value)
+		.unwrap_or_else(|_| "{\"ok\":false,\"summary\":\"failed to serialize\"}".to_string());
+	CallToolResult {
+		content: vec![Content::text(text)],
+		structured_content: Some(value),
+		is_error: Some(false),
+		meta: None,
+	}
+}
+
+fn json_error_result(value: serde_json::Value) -> CallToolResult {
+	let text = serde_json::to_string_pretty(&value)
+		.unwrap_or_else(|_| "{\"ok\":false,\"summary\":\"failed to serialize\"}".to_string());
+	CallToolResult {
+		content: vec![Content::text(text)],
+		structured_content: Some(value),
+		is_error: Some(true),
+		meta: None,
+	}
+}
+
+fn warning_info(warning: &mdt_core::TemplateWarning, root: &Path) -> TemplateWarningInfo {
+	let mut undefined_variables = warning.undefined_variables.clone();
+	undefined_variables.sort();
+	TemplateWarningInfo {
+		block_name: warning.block_name.clone(),
+		file: relative_display_path(&warning.provider_file, root),
+		undefined_variables,
+	}
+}
+
 #[tool_router]
 impl MdtMcpServer {
 	pub fn new() -> Self {
@@ -185,8 +267,8 @@ impl MdtMcpServer {
 
 	#[tool(
 		name = "mdt_check",
-		description = "Check if all consumer blocks are up to date. Returns an actionable summary \
-		               of any stale blocks with file paths and diffs."
+		description = "Check if all consumer blocks are up to date. Returns a JSON-first summary \
+		               of stale blocks, render errors, missing providers, and authoring warnings."
 	)]
 	async fn check(
 		&self,
@@ -195,62 +277,79 @@ impl MdtMcpServer {
 		let root = resolve_root(params.path.as_deref().map(Path::new));
 		let ctx = scan_ctx(&root)?;
 
-		let missing = ctx.find_missing_providers();
+		let mut missing = ctx.find_missing_providers();
+		missing.sort();
 		let result =
 			check_project(&ctx).map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
-		if result.is_ok() && missing.is_empty() {
-			return Ok(CallToolResult::success(vec![Content::text(
-				"All consumer blocks are up to date.",
-			)]));
-		}
+		let warnings: Vec<_> = result
+			.warnings
+			.iter()
+			.map(|warning| warning_info(warning, &root))
+			.collect();
+		let render_errors: Vec<_> = result
+			.render_errors
+			.iter()
+			.map(|err| {
+				RenderErrorInfo {
+					block_name: err.block_name.clone(),
+					file: relative_display_path(&err.file, &root),
+					line: err.line,
+					column: err.column,
+					message: err.message.clone(),
+				}
+			})
+			.collect();
+		let stale: Vec<_> = result
+			.stale
+			.iter()
+			.map(|entry| {
+				StaleEntryInfo {
+					block_name: entry.block_name.clone(),
+					file: relative_display_path(&entry.file, &root),
+					line: entry.line,
+					column: entry.column,
+				}
+			})
+			.collect();
 
-		let mut parts = Vec::new();
-
-		if !result.render_errors.is_empty() {
-			parts.push(format!(
-				"{} template render error(s):",
-				result.render_errors.len()
-			));
-			for err in &result.render_errors {
-				let rel = relative_display_path(&err.file, &root);
-				parts.push(format!(
-					"  - `{}` in {rel}: {}",
-					err.block_name, err.message
-				));
+		let ok = result.is_ok() && missing.is_empty();
+		let summary = if ok {
+			"All consumer blocks are up to date.".to_string()
+		} else {
+			let mut parts = Vec::new();
+			if !render_errors.is_empty() {
+				parts.push(format!("{} render error(s)", render_errors.len()));
 			}
-		}
-
-		if !result.stale.is_empty() {
-			parts.push(format!(
-				"{} consumer block(s) are stale:",
-				result.stale.len()
-			));
-			for entry in &result.stale {
-				let rel = relative_display_path(&entry.file, &root);
-				parts.push(format!("  - `{}` in {rel}", entry.block_name));
+			if !stale.is_empty() {
+				parts.push(format!("{} stale consumer block(s)", stale.len()));
 			}
-			parts.push(String::new());
-			parts.push("Run mdt_update to synchronize them.".to_string());
-		}
+			if !missing.is_empty() {
+				parts.push(format!("{} missing provider name(s)", missing.len()));
+			}
+			if parts.is_empty() {
+				"Check completed with warnings.".to_string()
+			} else {
+				format!("Check found {}.", parts.join(", "))
+			}
+		};
 
-		if !missing.is_empty() {
-			parts.push(format!(
-				"\n{} consumer block(s) reference missing providers: {}",
-				missing.len(),
-				missing.join(", ")
-			));
-		}
-
-		Ok(CallToolResult::success(vec![Content::text(
-			parts.join("\n"),
-		)]))
+		Ok(json_result(serde_json::json!({
+			"ok": ok,
+			"action": "check",
+			"summary": summary,
+			"stale": stale,
+			"render_errors": render_errors,
+			"warnings": warnings,
+			"missing_provider_names": missing,
+		})))
 	}
 
 	#[tool(
 		name = "mdt_update",
-		description = "Update all stale consumer blocks with latest provider content. Supports \
-		               dry_run mode to preview changes without writing."
+		description = "Update all stale consumer blocks with latest provider content. Returns a \
+		               JSON-first summary and supports dry_run mode to preview changes without \
+		               writing."
 	)]
 	async fn update(
 		&self,
@@ -258,44 +357,63 @@ impl MdtMcpServer {
 	) -> Result<CallToolResult, McpError> {
 		let root = resolve_root(params.path.as_deref().map(Path::new));
 		let ctx = scan_ctx(&root)?;
+		let mut missing_provider_names = ctx.find_missing_providers();
+		missing_provider_names.sort();
 		let updates =
 			compute_updates(&ctx).map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-		if updates.updated_count == 0 {
-			return Ok(CallToolResult::success(vec![Content::text(
-				"All consumer blocks are already up to date. No changes needed.",
-			)]));
-		}
-
-		if params.dry_run {
-			let files: Vec<String> = updates
-				.updated_files
-				.keys()
-				.map(|p| format!("  - {}", relative_display_path(p, &root)))
-				.collect();
-			let msg = format!(
-				"Dry run: would update {} block(s) in {} file(s):\n{}",
-				updates.updated_count,
-				updates.updated_files.len(),
-				files.join("\n")
-			);
-			return Ok(CallToolResult::success(vec![Content::text(msg)]));
-		}
-
-		write_updates(&updates).map_err(|e| McpError::internal_error(e.to_string(), None))?;
-
-		let files: Vec<String> = updates
+		let warnings: Vec<_> = updates
+			.warnings
+			.iter()
+			.map(|warning| warning_info(warning, &root))
+			.collect();
+		let mut updated_files: Vec<String> = updates
 			.updated_files
 			.keys()
-			.map(|p| relative_display_path(p, &root))
+			.map(|path| relative_display_path(path, &root))
 			.collect();
-		let msg = format!(
-			"Updated {} block(s) in {} file(s): {}",
-			updates.updated_count,
-			updates.updated_files.len(),
-			files.join(", ")
-		);
-		Ok(CallToolResult::success(vec![Content::text(msg)]))
+		updated_files.sort();
+
+		if updates.updated_count == 0 {
+			return Ok(json_result(serde_json::json!({
+				"ok": true,
+				"action": "update",
+				"dry_run": params.dry_run,
+				"summary": "All consumer blocks are already up to date. No changes needed.",
+				"updated_count": 0,
+				"updated_files": updated_files,
+				"warnings": warnings,
+				"missing_provider_names": missing_provider_names,
+			})));
+		}
+
+		if !params.dry_run {
+			write_updates(&updates).map_err(|e| McpError::internal_error(e.to_string(), None))?;
+		}
+
+		let summary = if params.dry_run {
+			format!(
+				"Dry run: would update {} block(s) in {} file(s).",
+				updates.updated_count,
+				updated_files.len()
+			)
+		} else {
+			format!(
+				"Updated {} block(s) in {} file(s).",
+				updates.updated_count,
+				updated_files.len()
+			)
+		};
+
+		Ok(json_result(serde_json::json!({
+			"ok": true,
+			"action": "update",
+			"dry_run": params.dry_run,
+			"summary": summary,
+			"updated_count": updates.updated_count,
+			"updated_files": updated_files,
+			"warnings": warnings,
+			"missing_provider_names": missing_provider_names,
+		})))
 	}
 
 	#[tool(
@@ -338,8 +456,8 @@ impl MdtMcpServer {
 			.iter()
 			.map(|c| {
 				let is_stale = ctx.project.providers.get(&c.block.name).is_some_and(|p| {
-					let render_data = mdt_core::build_render_context(&ctx.data, p, c)
-						.unwrap_or_else(|| ctx.data.clone());
+					let render_data =
+						build_render_context(&ctx.data, p, c).unwrap_or_else(|| ctx.data.clone());
 					let rendered = render_template(&p.content, &render_data)
 						.unwrap_or_else(|_| p.content.clone());
 					let expected = apply_transformers(&rendered, &c.block.transformers);
@@ -369,10 +487,7 @@ impl MdtMcpServer {
 			),
 		});
 
-		Ok(CallToolResult::success(vec![Content::text(
-			serde_json::to_string_pretty(&output)
-				.unwrap_or_else(|_| "Failed to serialize output".to_string()),
-		)]))
+		Ok(json_result(output))
 	}
 
 	#[tool(
@@ -461,10 +576,7 @@ impl MdtMcpServer {
 			],
 		});
 
-		Ok(CallToolResult::success(vec![Content::text(
-			serde_json::to_string_pretty(&output)
-				.unwrap_or_else(|_| "Failed to serialize output".to_string()),
-		)]))
+		Ok(json_result(output))
 	}
 
 	#[tool(
@@ -508,10 +620,7 @@ impl MdtMcpServer {
 				"consumer_files": consumer_files,
 			});
 
-			return Ok(CallToolResult::success(vec![Content::text(
-				serde_json::to_string_pretty(&output)
-					.unwrap_or_else(|_| "Failed to serialize".to_string()),
-			)]));
+			return Ok(json_result(output));
 		}
 
 		let consumer_entries: Vec<&mdt_core::project::ConsumerEntry> = ctx
@@ -522,17 +631,19 @@ impl MdtMcpServer {
 			.collect();
 
 		if consumer_entries.is_empty() {
-			return Ok(CallToolResult::error(vec![Content::text(format!(
-				"No block named `{}` found in the project.",
-				params.block_name
-			))]));
+			return Ok(json_error_result(serde_json::json!({
+				"ok": false,
+				"action": "get_block",
+				"summary": format!("No block named `{}` found in the project.", params.block_name),
+				"block_name": params.block_name,
+			})));
 		}
 
 		let mut entries = Vec::new();
 		for c in &consumer_entries {
 			let is_stale = ctx.project.providers.get(&c.block.name).is_some_and(|p| {
-				let render_data = mdt_core::build_render_context(&ctx.data, p, c)
-					.unwrap_or_else(|| ctx.data.clone());
+				let render_data =
+					build_render_context(&ctx.data, p, c).unwrap_or_else(|| ctx.data.clone());
 				let rendered =
 					render_template(&p.content, &render_data).unwrap_or_else(|_| p.content.clone());
 				let expected = apply_transformers(&rendered, &c.block.transformers);
@@ -548,16 +659,14 @@ impl MdtMcpServer {
 			}));
 		}
 
-		Ok(CallToolResult::success(vec![Content::text(
-			serde_json::to_string_pretty(&entries)
-				.unwrap_or_else(|_| "Failed to serialize".to_string()),
-		)]))
+		Ok(json_result(serde_json::Value::Array(entries)))
 	}
 
 	#[tool(
 		name = "mdt_preview",
-		description = "Preview the rendered content for a specific block after template \
-		               interpolation and transformer application."
+		description = "Preview a provider as an authoring workflow. Returns JSON with the \
+		               provider template plus per-consumer rendered output after interpolation \
+		               and transformers."
 	)]
 	async fn preview(
 		&self,
@@ -567,61 +676,110 @@ impl MdtMcpServer {
 		let ctx = scan_ctx(&root)?;
 
 		let Some(provider) = ctx.project.providers.get(&params.block_name) else {
-			return Ok(CallToolResult::error(vec![Content::text(format!(
-				"No provider named `{}` found.",
-				params.block_name
-			))]));
+			return Ok(json_error_result(serde_json::json!({
+				"ok": false,
+				"action": "preview",
+				"summary": format!("No provider named `{}` found.", params.block_name),
+				"block_name": params.block_name,
+			})));
 		};
 
-		let rendered = render_template(&provider.content, &ctx.data)
-			.map_err(|e| McpError::internal_error(e.to_string(), None))?;
+		let rendered_with_project_data = render_template(&provider.content, &ctx.data)
+			.unwrap_or_else(|_| provider.content.clone());
 
 		let consumers: Vec<_> = ctx
 			.project
 			.consumers
 			.iter()
-			.filter(|c| c.block.name == params.block_name)
+			.filter(|consumer| consumer.block.name == params.block_name)
 			.collect();
-
-		let mut parts = Vec::new();
-		parts.push(format!(
-			"## Provider `{}`\n\nRendered content:\n```\n{}\n```",
-			params.block_name,
-			rendered.trim()
-		));
-
-		if !consumers.is_empty() {
-			parts.push(format!("\n## {} consumer(s):", consumers.len()));
-			for c in &consumers {
-				let transformed = apply_transformers(&rendered, &c.block.transformers);
-				let rel = relative_display_path(&c.file, &root);
-				let tf_names: Vec<String> = c
+		let consumer_previews: Vec<_> = consumers
+			.iter()
+			.map(|consumer| {
+				let transformers = consumer
 					.block
 					.transformers
 					.iter()
-					.map(|t| t.r#type.to_string())
-					.collect();
-				let tf_str = if tf_names.is_empty() {
-					"(none)".to_string()
-				} else {
-					tf_names.join(" | ")
-				};
-				parts.push(format!(
-					"\n### {rel}\nTransformers: {tf_str}\n```\n{}\n```",
-					transformed.trim()
-				));
-			}
-		}
+					.map(|transformer| transformer.r#type.to_string())
+					.collect::<Vec<_>>();
+				let arguments = consumer.block.arguments.clone();
+				let rel = relative_display_path(&consumer.file, &root);
 
-		Ok(CallToolResult::success(vec![Content::text(
-			parts.join("\n"),
-		)]))
+				let (rendered_content, is_stale, render_error) =
+					match build_render_context(&ctx.data, provider, consumer) {
+						Some(render_data) => {
+							match render_template(&provider.content, &render_data) {
+								Ok(rendered) => {
+									let transformed =
+										apply_transformers(&rendered, &consumer.block.transformers);
+									let stale = consumer.content != transformed;
+									(Some(transformed), Some(stale), None)
+								}
+								Err(error) => (None, None, Some(error.to_string())),
+							}
+						}
+						None => {
+							(
+								None,
+								None,
+								Some(format!(
+									"argument count mismatch: provider `{}` declares {} \
+									 parameter(s), but consumer passes {}",
+									params.block_name,
+									provider.block.arguments.len(),
+									consumer.block.arguments.len()
+								)),
+							)
+						}
+					};
+
+				PreviewConsumerInfo {
+					file: rel,
+					transformers,
+					arguments,
+					rendered_content,
+					current_content: consumer.content.clone(),
+					is_stale,
+					render_error,
+				}
+			})
+			.collect();
+
+		let provider_preview = PreviewProviderInfo {
+			name: params.block_name.clone(),
+			file: relative_display_path(&provider.file, &root),
+			raw_content: provider.content.clone(),
+			rendered_with_project_data,
+			parameters: provider.block.arguments.clone(),
+		};
+		let summary = if consumer_previews.is_empty() {
+			format!(
+				"Previewed provider `{}` with no consumers.",
+				params.block_name
+			)
+		} else {
+			format!(
+				"Previewed provider `{}` for {} consumer(s).",
+				params.block_name,
+				consumer_previews.len()
+			)
+		};
+
+		Ok(json_result(serde_json::json!({
+			"ok": true,
+			"action": "preview",
+			"summary": summary,
+			"block_name": params.block_name,
+			"provider": provider_preview,
+			"consumers": consumer_previews,
+		})))
 	}
 
 	#[tool(
 		name = "mdt_init",
 		description = "Initialize mdt in a project by creating a sample \
-		               `.templates/template.t.md` file and starter `mdt.toml`."
+		               `.templates/template.t.md` file and starter `mdt.toml`. Returns a \
+		               JSON-first summary of created files and next steps."
 	)]
 	async fn init(
 		&self,
@@ -658,48 +816,50 @@ impl MdtMcpServer {
 			 files.\n# Recommended when using formatters (rustfmt, prettier, etc.).\n# \
 			 [padding]\n# before = 0\n# after = 0\n";
 
-		let mut parts = Vec::new();
-
-		if template_exists {
-			parts.push(format!(
-				"Template file already exists: {}",
-				template_path.display()
-			));
-		} else {
+		if !template_exists {
 			if let Some(parent) = template_path.parent() {
 				std::fs::create_dir_all(parent)
 					.map_err(|e| McpError::internal_error(e.to_string(), None))?;
 			}
 			std::fs::write(&template_path, sample_content)
 				.map_err(|e| McpError::internal_error(e.to_string(), None))?;
-			parts.push(format!(
-				"Created template file: {}",
-				template_path.display()
-			));
 		}
 
 		if !config_exists {
 			std::fs::write(&config_path, sample_config)
 				.map_err(|e| McpError::internal_error(e.to_string(), None))?;
-			parts.push("Created mdt.toml".to_string());
 		}
 
-		if !template_exists {
-			parts.push(String::new());
-			parts.push("Next steps:".to_string());
-			parts.push(format!(
-				"1. Edit {} to define your template blocks",
-				template_path.display()
-			));
-			parts.push("2. Add consumer tags in your markdown files:".to_string());
-			parts.push("   <!-- {=greeting} -->".to_string());
-			parts.push("   <!-- {/greeting} -->".to_string());
-			parts.push("3. Run `mdt_update` to sync content".to_string());
-		}
+		let next_steps = if template_exists {
+			Vec::new()
+		} else {
+			vec![
+				format!(
+					"Edit {} to define your template blocks",
+					template_path.display()
+				),
+				"Add consumer tags in your markdown files: <!-- {{=greeting}} --> ... <!-- \
+				 {{/greeting}} -->"
+					.to_string(),
+				"Run `mdt_update` to sync content".to_string(),
+			]
+		};
+		let summary = if template_exists {
+			format!("Template file already exists: {}", template_path.display())
+		} else {
+			format!("Created template file: {}", template_path.display())
+		};
 
-		Ok(CallToolResult::success(vec![Content::text(
-			parts.join("\n"),
-		)]))
+		Ok(json_result(serde_json::json!({
+			"ok": true,
+			"action": "init",
+			"summary": summary,
+			"template_file": template_path.display().to_string(),
+			"template_created": !template_exists,
+			"config_file": config_path.display().to_string(),
+			"config_created": !config_exists,
+			"next_steps": next_steps,
+		})))
 	}
 }
 

--- a/template.t.md
+++ b/template.t.md
@@ -204,6 +204,8 @@ The server communicates over stdin/stdout using the Language Server Protocol.
 ### Agent Workflow
 
 - Prefer reuse before creation: call `mdt_find_reuse` (or `mdt_list`) before introducing a new provider block.
+- Use the JSON-first tool responses as the source of truth. The MCP server returns structured payloads so agents can inspect results without parsing prose.
+- Use `mdt_preview` as an authoring workflow: inspect the provider template plus each consumer's rendered output before deciding whether to reuse, edit, or sync.
 - Keep provider names global and unique in the project to avoid collisions.
 - After edits, run `mdt_check` (and optionally `mdt_update`) so consumer blocks stay synchronized.
 


### PR DESCRIPTION
## Summary
- make key MCP tools JSON-first with structured MCP content
- expose authoring warnings from `mdt_check` and `mdt_update`
- turn `mdt_preview` into a structured authoring workflow with per-consumer rendered output
- improve preview correctness for parameterized consumers

## Testing
- `cargo test -p mdt_mcp --quiet`
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`

## Notes
- this branch is currently based on `feat/issue-105-bootstrap` / PR #112 so it can reuse the unified init flow

Closes #108
