### PR TITLE
feat(mdt_cli): add assistant setup profiles

### DIFF
--- a/.changeset/issue-109-assist.md
+++ b/.changeset/issue-109-assist.md
@@ -1,0 +1,9 @@
+---
+mdt_cli: major
+---
+
+Add an `mdt assist` command that prints official assistant setup profiles.
+
+This first slice focuses on practical adoption rather than a plugin marketplace: the command prints ready-to-copy MCP configuration snippets and suggested repo-local guidance for assistants like Claude, Cursor, Copilot, Pi, and generic MCP clients.
+
+This is marked major because it adds a new public `Commands::Assist` variant to `mdt_cli`'s public CLI model.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Installation](./getting-started/installation.md)
 - [Quick Start](./getting-started/quick-start.md)
+- [Assistant Setup](./getting-started/assistant-setup.md)
 - [Proof of Value](./getting-started/proof-of-value.md)
 - [Migration Walkthrough](./getting-started/migration-walkthrough.md)
 

--- a/docs/src/getting-started/assistant-setup.md
+++ b/docs/src/getting-started/assistant-setup.md
@@ -1,0 +1,51 @@
+# Assistant Setup
+
+mdt's official assistant profiles are intentionally lightweight: they provide ready-to-copy MCP configuration snippets and repo-local guidance, not a marketplace or plugin registry.
+
+## Recommended workflow
+
+1. Run `mdt assist <assistant>` to print an official setup profile.
+2. Copy the MCP snippet into your assistant's configuration.
+3. Add the suggested repo-local guidance to your project instructions.
+4. Let the assistant inspect and synchronize docs through `mdt mcp`.
+
+## Example
+
+```sh
+mdt assist claude
+```
+
+This prints:
+
+- an MCP server configuration snippet that runs `mdt mcp`
+- repo-local guidance such as reusing providers before creating new ones
+- assistant-specific notes for the selected profile
+
+## Why this approach
+
+The goal is to reduce setup friction without inventing a new extension ecosystem.
+
+The first official profiles focus on:
+
+- **portable MCP configuration** — the same `mdt mcp` server can be reused across assistants
+- **repo-local guidance** — your assistant should follow the same mdt workflow every time
+- **human-controlled adoption** — you can copy, review, and customize the generated setup before using it
+
+## Repo-local guidance to keep
+
+Regardless of assistant, keep guidance like this close to your project instructions:
+
+- Prefer reuse before creation: run `mdt_find_reuse` or `mdt_list` before introducing a new provider block.
+- Use `.templates/` as the canonical template location.
+- Use `mdt_preview` to inspect provider and consumer output before syncing changes.
+- Run `mdt_check` after documentation edits and `mdt_update` when consumer blocks are stale.
+
+## Supported first-slice profiles
+
+- `generic`
+- `claude`
+- `cursor`
+- `copilot`
+- `pi`
+
+As the project evolves, these profiles can grow into richer setup helpers, but the initial focus is pragmatic: make assistant setup reproducible and easy to adopt.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -192,6 +192,34 @@ Checks include:
 
 Text output prints one line per check with a status tag (`PASS`, `WARN`, `FAIL`, `SKIP`) and optional hints. JSON output includes `ok`, `summary`, and a detailed `checks` array.
 
+### `mdt assist`
+
+Print an official assistant setup profile. This first slice focuses on practical presets: mdt prints MCP configuration snippets and repo-local guidance rather than introducing a plugin marketplace.
+
+```sh
+mdt assist claude
+mdt assist cursor
+mdt assist pi --format json
+```
+
+Supported assistants:
+
+- `generic`
+- `claude`
+- `cursor`
+- `copilot`
+- `pi`
+
+`text` output includes:
+
+- a ready-to-copy MCP config snippet
+- suggested repo-local guidance for your assistant instructions
+- assistant-specific notes for the chosen profile
+
+`json` output returns the same setup information in a machine-readable shape, including `mcp_config`, `repo_guidance`, and `notes`.
+
+Use this command when you want a quick, official starting point for wiring `mdt mcp` into an assistant workflow.
+
 ### `mdt lsp`
 
 Start the language server for editor integration. Communicates over stdin/stdout using the Language Server Protocol.

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -36,6 +36,7 @@ cargo install mdt_cli
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
 - `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
+- `mdt assist <assistant> [--format text|json]` — Print an official assistant setup profile with MCP config and repo-local guidance.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 

--- a/mdt_cli/src/lib.rs
+++ b/mdt_cli/src/lib.rs
@@ -15,7 +15,8 @@ use clap::ValueEnum;
 	              markdown files, code comments, READMEs, and more.\n\nQuick start:\n  mdt init    \
 	              Create a template file\n  mdt update  Sync all consumer blocks\n  mdt check   \
 	              Verify everything is up to date\n  mdt info    Inspect project diagnostics\n  \
-	              mdt doctor  Run project health checks"
+	              mdt doctor  Run project health checks\n  mdt assist  Print assistant setup \
+	              snippets"
 )]
 #[allow(clippy::struct_excessive_bools)]
 pub struct MdtCli {
@@ -135,6 +136,21 @@ pub enum Commands {
 		#[arg(long, value_enum, default_value_t = DoctorOutputFormat::Text)]
 		format: DoctorOutputFormat,
 	},
+	/// Print an official assistant setup profile.
+	///
+	/// This command prints a ready-to-copy MCP configuration snippet plus
+	/// repo-local guidance for an assistant workflow. The first slice is
+	/// intentionally lightweight: mdt ships presets and guidance, not a
+	/// marketplace or plugin system.
+	Assist {
+		/// Which assistant profile to print.
+		#[arg(value_enum)]
+		assistant: Assistant,
+
+		/// Output format for the setup profile.
+		#[arg(long, value_enum, default_value_t = AssistOutputFormat::Text)]
+		format: AssistOutputFormat,
+	},
 	/// Start the mdt language server (LSP).
 	///
 	/// Communicates over stdin/stdout using the Language Server Protocol.
@@ -179,6 +195,28 @@ pub enum InfoOutputFormat {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum DoctorOutputFormat {
 	/// Human-readable text output with colors and formatting.
+	Text,
+	/// JSON output for programmatic consumption.
+	Json,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum Assistant {
+	/// Generic MCP client configuration.
+	Generic,
+	/// Anthropic Claude / Claude Code style setup.
+	Claude,
+	/// Cursor editor MCP setup.
+	Cursor,
+	/// GitHub Copilot / VS Code MCP-style setup.
+	Copilot,
+	/// Pi coding agent setup.
+	Pi,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum AssistOutputFormat {
+	/// Human-readable setup instructions.
 	Text,
 	/// JSON output for programmatic consumption.
 	Json,

--- a/mdt_cli/src/main.rs
+++ b/mdt_cli/src/main.rs
@@ -7,6 +7,8 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use clap::Parser;
+use mdt_cli::AssistOutputFormat;
+use mdt_cli::Assistant;
 use mdt_cli::Commands;
 use mdt_cli::DoctorOutputFormat;
 use mdt_cli::InfoOutputFormat;
@@ -101,6 +103,7 @@ fn main() {
 		Some(Commands::List) => run_list(&args),
 		Some(Commands::Info { format }) => run_info(&args, format),
 		Some(Commands::Doctor { format }) => run_doctor(&args, format),
+		Some(Commands::Assist { assistant, format }) => run_assist(assistant, format),
 		Some(Commands::Lsp) => run_lsp(),
 		Some(Commands::Mcp) => run_mcp(),
 		None => {
@@ -1835,6 +1838,141 @@ fn run_lsp() -> Result<(), Box<dyn std::error::Error>> {
 fn run_mcp() -> Result<(), Box<dyn std::error::Error>> {
 	let rt = tokio::runtime::Runtime::new()?;
 	rt.block_on(mdt_mcp::run_server());
+	Ok(())
+}
+
+fn assistant_display_name(assistant: Assistant) -> &'static str {
+	match assistant {
+		Assistant::Generic => "Generic MCP client",
+		Assistant::Claude => "Claude",
+		Assistant::Cursor => "Cursor",
+		Assistant::Copilot => "GitHub Copilot",
+		Assistant::Pi => "Pi",
+	}
+}
+
+fn assistant_setup_payload(assistant: Assistant) -> serde_json::Value {
+	let mcp_config = serde_json::json!({
+		"mcpServers": {
+			"mdt": {
+				"command": "mdt",
+				"args": ["mcp"]
+			}
+		}
+	});
+	let guidance = vec![
+		"Prefer reuse before creation: run `mdt_find_reuse` or `mdt_list` before introducing a \
+		 new provider block."
+			.to_string(),
+		"Use `.templates/` as the canonical location for template files.".to_string(),
+		"Run `mdt_check` after documentation edits and `mdt_update` when consumers are stale."
+			.to_string(),
+		"Use `mdt_preview` to inspect provider and consumer output before syncing changes."
+			.to_string(),
+	];
+	let notes = match assistant {
+		Assistant::Generic => {
+			vec![
+				"Add the MCP snippet to any client that supports stdio MCP servers.".to_string(),
+				"Store the repo-local guidance in your assistant instructions so it follows the \
+				 same mdt workflow every time."
+					.to_string(),
+			]
+		}
+		Assistant::Claude => {
+			vec![
+				"Add the MCP snippet to Claude's MCP server configuration.".to_string(),
+				"Keep the repo-local guidance in your project instructions so Claude reuses \
+				 providers before creating new ones."
+					.to_string(),
+			]
+		}
+		Assistant::Cursor => {
+			vec![
+				"Add the MCP snippet to Cursor's MCP settings for the workspace or user profile."
+					.to_string(),
+				"Pair the MCP server with repo-local guidance so Cursor agents run `mdt_check` \
+				 after edits."
+					.to_string(),
+			]
+		}
+		Assistant::Copilot => {
+			vec![
+				"Use this MCP snippet in Copilot or VS Code environments that support \
+				 MCP-compatible server configuration."
+					.to_string(),
+				"Keep the repo-local guidance in workspace instructions so Copilot reuses \
+				 providers and respects `.templates/`."
+					.to_string(),
+			]
+		}
+		Assistant::Pi => {
+			vec![
+				"Configure Pi to run `mdt mcp` so agents can inspect and synchronize providers \
+				 and consumers."
+					.to_string(),
+				"Add the repo-local guidance to your agent instructions so Pi follows the same \
+				 reuse-and-check workflow."
+					.to_string(),
+			]
+		}
+	};
+
+	serde_json::json!({
+		"assistant": assistant_display_name(assistant),
+		"strategy": {
+			"type": "official-profile",
+			"scope": "config-snippets-and-guidance",
+			"summary": "mdt ships assistant setup presets and repo-local guidance, not a plugin marketplace."
+		},
+		"mcp_config": mcp_config,
+		"repo_guidance": guidance,
+		"notes": notes,
+	})
+}
+
+fn run_assist(
+	assistant: Assistant,
+	format: AssistOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+	let payload = assistant_setup_payload(assistant);
+
+	match format {
+		AssistOutputFormat::Json => {
+			println!("{}", serde_json::to_string_pretty(&payload)?);
+		}
+		AssistOutputFormat::Text => {
+			let mcp_config = serde_json::to_string_pretty(&payload["mcp_config"])?;
+			println!("{}", colored!("mdt assist", bold));
+			println!();
+			println!(
+				"Assistant                 {}",
+				payload["assistant"].as_str().unwrap_or_default()
+			);
+			println!(
+				"Strategy                  {}",
+				payload["strategy"]["summary"].as_str().unwrap_or_default()
+			);
+			println!();
+			println!("MCP config snippet:");
+			println!("{mcp_config}");
+			println!();
+			println!("Suggested repo-local guidance:");
+			for item in payload["repo_guidance"].as_array().into_iter().flatten() {
+				if let Some(text) = item.as_str() {
+					println!("- {text}");
+				}
+			}
+			println!();
+			println!("Notes for {}:", assistant_display_name(assistant));
+			for item in payload["notes"].as_array().into_iter().flatten() {
+				if let Some(text) = item.as_str() {
+					println!("- {text}");
+				}
+			}
+		}
+	}
+
 	Ok(())
 }
 

--- a/mdt_cli/tests/assist.rs
+++ b/mdt_cli/tests/assist.rs
@@ -1,0 +1,51 @@
+mod common;
+
+use mdt_core::AnyEmptyResult;
+use predicates::prelude::*;
+
+#[test]
+fn assist_text_prints_mcp_snippet_and_guidance() {
+	let mut cmd = common::mdt_cmd();
+	cmd.arg("assist").arg("claude");
+	cmd.assert()
+		.success()
+		.stdout(predicate::str::contains("Claude"))
+		.stdout(predicate::str::contains("\"mcpServers\": {"))
+		.stdout(predicate::str::contains("\"command\": \"mdt\""))
+		.stdout(predicate::str::contains("Prefer reuse before creation"))
+		.stdout(predicate::str::contains(
+			"Use `.templates/` as the canonical location",
+		));
+}
+
+#[test]
+fn assist_json_prints_machine_readable_profile() -> AnyEmptyResult {
+	let mut cmd = common::mdt_cmd();
+	let output = cmd
+		.arg("assist")
+		.arg("pi")
+		.arg("--format")
+		.arg("json")
+		.assert()
+		.success()
+		.get_output()
+		.stdout
+		.clone();
+
+	let json: serde_json::Value = serde_json::from_slice(&output)?;
+	assert_eq!(json["assistant"], "Pi");
+	assert_eq!(json["mcp_config"]["mcpServers"]["mdt"]["command"], "mdt");
+	assert_eq!(json["mcp_config"]["mcpServers"]["mdt"]["args"][0], "mcp");
+	assert!(
+		json["repo_guidance"]
+			.as_array()
+			.is_some_and(|items| !items.is_empty())
+	);
+	assert!(
+		json["notes"]
+			.as_array()
+			.is_some_and(|items| !items.is_empty())
+	);
+
+	Ok(())
+}

--- a/mdt_cli/tests/check.rs
+++ b/mdt_cli/tests/check.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use mdt_cli::AssistOutputFormat;
+use mdt_cli::Assistant;
 use mdt_cli::Commands;
 use mdt_cli::DoctorOutputFormat;
 use mdt_cli::InfoOutputFormat;
@@ -381,6 +383,29 @@ fn doctor_command_is_accepted_by_cli_parser() {
 			assert!(matches!(format, DoctorOutputFormat::Json));
 		}
 		_ => panic!("expected Doctor command"),
+	}
+}
+
+#[test]
+fn assist_command_is_accepted_by_cli_parser() {
+	use clap::Parser;
+
+	let cli = MdtCli::parse_from(["mdt", "assist", "claude"]);
+	match cli.command {
+		Some(Commands::Assist { assistant, format }) => {
+			assert!(matches!(assistant, Assistant::Claude));
+			assert!(matches!(format, AssistOutputFormat::Text));
+		}
+		_ => panic!("expected Assist command"),
+	}
+
+	let cli = MdtCli::parse_from(["mdt", "assist", "pi", "--format", "json"]);
+	match cli.command {
+		Some(Commands::Assist { assistant, format }) => {
+			assert!(matches!(assistant, Assistant::Pi));
+			assert!(matches!(format, AssistOutputFormat::Json));
+		}
+		_ => panic!("expected Assist command"),
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Available transformers: `trim`, `trimStart`, `trimEnd`, `indent`, `prefix`, `suf
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
 - `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
+- `mdt assist <assistant> [--format text|json]` — Print an official assistant setup profile with MCP config and repo-local guidance.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 

--- a/template.t.md
+++ b/template.t.md
@@ -13,6 +13,7 @@
 - `mdt update [--path <dir>] [--verbose] [--dry-run]` — Update all consumer blocks with latest provider content.
 - `mdt info [--path <dir>]` — Print project diagnostics and cache observability metrics.
 - `mdt doctor [--path <dir>] [--format text|json]` — Run health checks with actionable hints, including cache validity and efficiency.
+- `mdt assist <assistant> [--format text|json]` — Print an official assistant setup profile with MCP config and repo-local guidance.
 - `mdt lsp` — Start the mdt language server (LSP) for editor integration. Communicates over stdin/stdout.
 - `mdt mcp` — Start the mdt MCP server for AI assistants. Communicates over stdin/stdout.
 


### PR DESCRIPTION
## Summary
- add `mdt assist` for official assistant setup profiles
- print MCP config snippets plus repo-local guidance instead of introducing a marketplace
- document the first-slice assistant profile strategy in the CLI docs and mdBook
- add CLI parser and integration tests for the new setup surface

## Testing
- `cargo test -p mdt_cli --test assist --quiet`
- `cargo test -p mdt_cli --test check --quiet`
- `cargo test -p mdt_cli --quiet`
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`

Closes #109
