### PR TITLE
docs: add proof-of-value walkthroughs

### DIFF
--- a/.changeset/issue-110-examples.md
+++ b/.changeset/issue-110-examples.md
@@ -1,0 +1,5 @@
+---
+mdt_cli: docs
+---
+
+Add proof-of-value and migration walkthrough documentation that shows how to adopt mdt for README, source-doc, and docs-site synchronization.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,8 @@
 
 - [Installation](./getting-started/installation.md)
 - [Quick Start](./getting-started/quick-start.md)
+- [Proof of Value](./getting-started/proof-of-value.md)
+- [Migration Walkthrough](./getting-started/migration-walkthrough.md)
 
 # Core Concepts
 

--- a/docs/src/getting-started/migration-walkthrough.md
+++ b/docs/src/getting-started/migration-walkthrough.md
@@ -1,0 +1,158 @@
+# Migration Walkthrough
+
+This walkthrough shows how to adopt `mdt` in a project that already has documentation drift.
+
+The example is intentionally realistic: the same installation instructions appear in a README, a Rust doc comment, and a docs page.
+
+## Before: three copies to maintain
+
+Imagine these three files already exist.
+
+### `readme.md`
+
+```markdown
+## Installation
+
+npm install my-lib
+```
+
+### `src/lib.rs`
+
+```rust
+//! ## Installation
+//!
+//! npm install my-lib
+```
+
+### `docs/src/getting-started.md`
+
+```markdown
+## Installation
+
+npm install my-lib
+```
+
+At first this seems harmless. Then the command changes to `npm install my-lib@latest`, or the project switches to `pnpm`, or you want to add a second setup note.
+
+Now you have three edits to make, and one of them eventually gets missed.
+
+## After: one provider, three consumers
+
+### 1. Initialize `mdt`
+
+```sh
+mdt init
+```
+
+This creates a starter template file at `.templates/template.t.md`.
+
+### 2. Define one provider
+
+Add a provider block to `.templates/template.t.md`:
+
+```markdown
+<!-- {@install} -->
+
+## Installation
+
+npm install my-lib@latest
+
+<!-- {/install} -->
+```
+
+### 3. Replace the README copy with a consumer
+
+```markdown
+<!-- {=install} -->
+
+Old copied content
+
+<!-- {/install} -->
+```
+
+### 4. Replace the docs-page copy with a consumer
+
+```markdown
+<!-- {=install} -->
+
+Old copied content
+
+<!-- {/install} -->
+```
+
+### 5. Replace the Rust doc comment with a transformed consumer
+
+```rust
+//! <!-- {=install|trim|linePrefix:"//! ":true} -->
+//! Old copied content
+//! <!-- {/install} -->
+```
+
+If your project uses source-file consumers heavily, add padding settings in `mdt.toml` so formatters do not collapse content awkwardly:
+
+```toml
+[padding]
+before = 0
+after = 0
+```
+
+### 6. Sync everything
+
+```sh
+mdt update
+```
+
+After the update, all three places render from the same provider.
+
+## What changed structurally
+
+### Before
+
+- each surface owned its own copy
+- wording changes required repeated manual edits
+- CI could not reliably detect drift
+
+### After
+
+- the provider in `.templates/template.t.md` becomes the source of truth
+- each surface keeps only a consumer tag
+- `mdt check` can fail CI when a consumer is stale
+
+## The day-two workflow
+
+Once the migration is done, the maintenance loop is simple:
+
+1. edit the provider block
+2. run `mdt update`
+3. run `mdt check`
+4. commit the synchronized result
+
+That is the real adoption win: not just fewer edits, but a repeatable workflow that prevents drift from coming back.
+
+## A small migration strategy that works well
+
+Do not try to template your entire docs set in one pass.
+
+Start with content that is:
+
+- repeated in 2 or more places
+- easy to recognize when it drifts
+- expensive or embarrassing when it diverges
+
+Good first candidates:
+
+- installation instructions
+- support policy / compatibility notes
+- API overview paragraphs
+- badge/link sections
+- CLI usage summaries
+
+## How to know the migration paid off
+
+A migration is usually worth it when one of these becomes true:
+
+- you can point to a provider that replaced three or more manual copies
+- CI now catches stale docs that previously slipped through
+- README, source docs, and docs pages no longer need separate wording updates
+
+If you want to see this pattern in a real codebase, inspect the repo-backed examples in [Proof of Value](./proof-of-value.md).

--- a/docs/src/getting-started/proof-of-value.md
+++ b/docs/src/getting-started/proof-of-value.md
@@ -1,0 +1,107 @@
+# Proof of Value
+
+If you want to know whether `mdt` is solving a real problem, this repository is the best example.
+
+The project already uses provider blocks from `template.t.md` to keep repeated content synchronized across multiple surfaces:
+
+- root and crate READMEs
+- crate-level Rust docs
+- mdBook pages
+
+That is the core value proposition in one repo: write shared content once, then fan it out wherever people actually read it.
+
+## 1. README synchronization
+
+The provider block `mdtCliUsage` lives in [`template.t.md`](../../../template.t.md).
+
+It is consumed in multiple README-style surfaces:
+
+- [`readme.md`](../../../readme.md)
+- [`mdt_cli/readme.md`](../../../mdt_cli/readme.md)
+
+That means the command list and diagnostics workflow stay aligned without copying edits by hand.
+
+## 2. Source-doc synchronization
+
+The provider block `mdtLspOverview` also lives in [`template.t.md`](../../../template.t.md), but it fans out into both markdown and Rust source docs:
+
+- [`mdt_lsp/readme.md`](../../../mdt_lsp/readme.md)
+- [`mdt_lsp/src/lib.rs`](../../../mdt_lsp/src/lib.rs)
+
+The source file uses a transformer chain so markdown content becomes Rust crate documentation comments:
+
+```rust
+//! <!-- {=mdtLspOverview|trim|linePrefix:"//! ":true} -->
+//! <!-- {/mdtLspOverview} -->
+```
+
+The same pattern is used for:
+
+- [`mdt_core/src/lib.rs`](../../../mdt_core/src/lib.rs)
+- [`mdt_mcp/src/lib.rs`](../../../mdt_mcp/src/lib.rs)
+- [`mdt_core/src/parser.rs`](../../../mdt_core/src/parser.rs)
+
+This is the practical payoff: you do not maintain one explanation for README readers and a second explanation for API docs readers.
+
+## 3. Docs-site synchronization
+
+The mdBook docs also consume shared provider blocks.
+
+For example, `mdtInlineBlocksGuide` is reused in more than one docs page:
+
+- [`docs/src/reference/template-syntax.md`](../reference/template-syntax.md)
+- [`docs/src/advanced/inline-blocks.md`](../advanced/inline-blocks.md)
+
+This keeps the conceptual explanation of inline blocks consistent across both a reference page and a guide page.
+
+## Why this matters
+
+Without `mdt`, these edits drift in predictable ways:
+
+- the README gets the newest wording
+- the source-doc comment keeps an older explanation
+- the docs site uses slightly different examples
+- command lists diverge across pages
+
+With `mdt`, one provider update can refresh all of those consumers in one run:
+
+```sh
+mdt update
+mdt check
+```
+
+## What to look at in this repo
+
+If you are evaluating adoption, inspect these files together:
+
+### Shared providers
+
+- [`template.t.md`](../../../template.t.md)
+
+### README consumers
+
+- [`readme.md`](../../../readme.md)
+- [`mdt_cli/readme.md`](../../../mdt_cli/readme.md)
+- [`mdt_core/readme.md`](../../../mdt_core/readme.md)
+- [`mdt_lsp/readme.md`](../../../mdt_lsp/readme.md)
+- [`mdt_mcp/readme.md`](../../../mdt_mcp/readme.md)
+
+### Source-doc consumers
+
+- [`mdt_core/src/lib.rs`](../../../mdt_core/src/lib.rs)
+- [`mdt_core/src/parser.rs`](../../../mdt_core/src/parser.rs)
+- [`mdt_lsp/src/lib.rs`](../../../mdt_lsp/src/lib.rs)
+- [`mdt_mcp/src/lib.rs`](../../../mdt_mcp/src/lib.rs)
+
+### Docs-site consumers
+
+- [`docs/src/reference/template-syntax.md`](../reference/template-syntax.md)
+- [`docs/src/advanced/inline-blocks.md`](../advanced/inline-blocks.md)
+
+## The shortest convincing story
+
+A good way to describe `mdt` to a teammate is:
+
+> We keep a few pieces of documentation repeated across our README, crate docs, and docs site. `mdt` lets us define those pieces once, reuse them everywhere, and verify in CI that they never drift apart.
+
+If that story matches your project, the tool is probably worth trying.

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -129,6 +129,8 @@ Consumers:
 
 ## Next steps
 
+- Read [Proof of Value](./proof-of-value.md) to see how this repository uses mdt across READMEs, Rust source docs, and mdBook pages
+- Follow the [Migration Walkthrough](./migration-walkthrough.md) to convert repeated docs into a provider-plus-consumer workflow
 - Learn about [providers and consumers](../concepts/providers-and-consumers.md) in depth
 - Add [data interpolation](../guide/data-interpolation.md) to pull values from project files
 - Use [transformers](../guide/transformers.md) to adapt content for different contexts

--- a/docs/src/readme.md
+++ b/docs/src/readme.md
@@ -42,6 +42,13 @@ This content gets replaced automatically.
 
 After running `mdt update`, every consumer named `install` has identical content — sourced from the single provider definition.
 
+## See It in Practice
+
+If you want concrete adoption examples instead of abstract syntax:
+
+- read [Proof of Value](./getting-started/proof-of-value.md) to see how this repository already keeps README content, Rust source docs, and mdBook pages synchronized
+- read [Migration Walkthrough](./getting-started/migration-walkthrough.md) for a before/after adoption path you can copy into your own project
+
 ## Key Features
 
 - **Comment-based tags** — HTML comments are invisible in rendered markdown, so your docs look clean

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,11 @@ cargo install mdt_cli@0.7.0
 
 <!-- {/mdtCliInstall} -->
 
+## See It in Practice
+
+- [Proof of Value](./docs/src/getting-started/proof-of-value.md) shows how this repository already syncs README content, Rust source docs, and mdBook pages from shared providers.
+- [Migration Walkthrough](./docs/src/getting-started/migration-walkthrough.md) shows a before/after adoption path for moving repeated docs onto `mdt`.
+
 <!-- {=mdtTemplateSyntax} -->
 
 ### Template Syntax


### PR DESCRIPTION
## Summary
- add repo-backed proof-of-value docs that show how mdt already synchronizes README, source-doc, and mdBook content
- add a migration walkthrough with a before/after adoption path for repeated installation docs
- link the new walkthroughs from the docs introduction, quick start, summary nav, and root README

## Testing
- `mdbook build docs`
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`
- `git diff --check`

Closes #110
