### PR TITLE
feat(mdt_cli): add npm binary distribution

### DIFF
--- a/.changeset/npm-cli-install.md
+++ b/.changeset/npm-cli-install.md
@@ -1,0 +1,7 @@
+---
+mdt_cli: minor
+---
+
+Add an official npm distribution channel for the `mdt` CLI.
+
+Releases now prepare a top-level `@ifi/mdt` package plus platform-specific binary packages for Linux, macOS, and Windows so users can install the CLI with `npm install -g @ifi/mdt` or run it with `npx @ifi/mdt`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,23 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
 
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: setup
         uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: run tests
+      - name: run rust tests
         run: test:all
         shell: devenv shell -c -- bash -e {0}
+
+      - name: run npm integration tests
+        run: |
+          node --test npm/tests/*.test.mjs scripts/npm/tests/*.test.mjs
 
   build:
     timeout-minutes: 60

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,101 @@
+name: "npm-publish"
+
+on:
+  workflow_run:
+    workflows: ["release"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to npm (for example `v0.7.0`)."
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag || github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  publish_npm:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    if: >-
+      github.repository_owner == 'ifiokjr' &&
+      (
+        github.event_name != 'workflow_run' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: resolve release tag
+        id: release_tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG='${{ inputs.tag }}'
+          else
+            mkdir -p "$RUNNER_TEMP/release-metadata"
+            gh run download "$WORKFLOW_RUN_ID" \
+              --repo "$GITHUB_REPOSITORY" \
+              --name npm-publish-metadata \
+              --dir "$RUNNER_TEMP/release-metadata"
+            TAG=$(cat "$RUNNER_TEMP/release-metadata/release-tag.txt")
+          fi
+
+          case "$TAG" in
+            v*) ;;
+            *)
+              echo "expected a v-prefixed tag, got: $TAG" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag: $TAG"
+
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release_tag.outputs.tag }}
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          scope: "@ifi"
+
+      - name: download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "mdt-*-${RELEASE_TAG}.tar.gz" \
+            --pattern "mdt-*-${RELEASE_TAG}.zip" \
+            --dir "$RUNNER_TEMP/release-assets"
+
+      - name: build npm packages
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          node scripts/npm/build-packages.mjs \
+            --version "$VERSION" \
+            --release-tag "$RELEASE_TAG" \
+            --assets-dir "$RUNNER_TEMP/release-assets" \
+            --out-dir "$RUNNER_TEMP/npm-packages"
+
+      - name: publish npm packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          node scripts/npm/publish-packages.mjs \
+            --packages-dir "$RUNNER_TEMP/npm-packages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,24 @@ jobs:
           zip: windows
           token: ${{ secrets.GITHUB_TOKEN }}
           checksum: sha256,sha512
+
+  npm_publish_metadata:
+    needs: upload_assets
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+    if: >-
+      github.repository_owner == 'ifiokjr' &&
+      startsWith(inputs.tag || github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: write release tag metadata
+        run: |
+          mkdir -p "$RUNNER_TEMP/npm-publish-metadata"
+          printf '%s\n' "$RELEASE_TAG" > "$RUNNER_TEMP/npm-publish-metadata/release-tag.txt"
+
+      - name: upload npm publish metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-publish-metadata
+          path: ${{ runner.temp }}/npm-publish-metadata/release-tag.txt

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -39,3 +39,15 @@ dprint fmt .changeset/* --allow-no-files
 
 - Use detailed, concrete changeset descriptions.
 - Conventional commit scopes should match the affected package when possible.
+
+## npm publishing
+
+npm publishing is handled by a separate `npm-publish` workflow when `NPM_TOKEN` is configured.
+
+- The `release` workflow builds and uploads the GitHub release binaries, then publishes a small metadata artifact containing the release tag.
+- The `npm-publish` workflow runs after the `release` workflow completes successfully, downloads that metadata artifact, then repackages the exact release binaries into npm packages.
+- The top-level package is `@ifi/mdt`.
+- Platform packages are published first (for Linux, macOS, and Windows targets).
+- The top-level package is published last and depends on those platform packages through `optionalDependencies`.
+- The `npm-publish` workflow can also be run manually with a `tag` input to republish or recover a specific release.
+- Re-running npm publish is safe: packages that are already published at the target version are skipped.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -1,10 +1,28 @@
 # Installation
 
-## Recommended for most users
+## Recommended for Node.js users
+
+Install the CLI from npm:
+
+```sh
+npm install -g @ifi/mdt
+```
+
+This installs the `mdt` command and pulls in the prebuilt binary package that matches your platform.
+
+You can also run it without a global install:
+
+```sh
+npx @ifi/mdt --help
+```
+
+This path is ideal for JavaScript and TypeScript projects that already use npm and do not want to install the Rust toolchain.
+
+## Recommended for most non-Rust users
 
 Download the prebuilt binary for your platform from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest) and place the `mdt` binary somewhere on your `PATH`.
 
-This is the easiest option if you want to use mdt in a JavaScript, Python, Go, or other non-Rust project without installing the Rust toolchain first.
+This is the simplest option if you want to use mdt in a Python, Go, or other non-Rust project without installing the Rust toolchain first.
 
 ## If you already use Cargo
 
@@ -41,4 +59,4 @@ mdt_core = "0.7.0"
 mdt --help
 ```
 
-You should see the available commands: `init`, `check`, `update`, `list`, `info`, `doctor`, `lsp`, and `mcp`.
+You should see the available commands: `init`, `check`, `update`, `list`, `info`, `doctor`, `assist`, `lsp`, and `mcp`.

--- a/mdt_cli/readme.md
+++ b/mdt_cli/readme.md
@@ -18,7 +18,19 @@
 
 <!-- {=mdtCliInstall} -->
 
-- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Install with npm:
+
+```sh
+npm install -g @ifi/mdt
+```
+
+- Or run it without installing:
+
+```sh
+npx @ifi/mdt --help
+```
+
+- Or download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
 - Or install with Cargo:
 
 ```sh

--- a/npm/bin/mdt.js
+++ b/npm/bin/mdt.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const PLATFORM_PACKAGES = {
+	darwin: {
+		arm64: ["@ifi/mdt-darwin-arm64"],
+		x64: ["@ifi/mdt-darwin-x64"],
+	},
+	linux: {
+		arm64: ["@ifi/mdt-linux-arm64-gnu", "@ifi/mdt-linux-arm64-musl"],
+		x64: ["@ifi/mdt-linux-x64-gnu", "@ifi/mdt-linux-x64-musl"],
+	},
+	win32: {
+		arm64: ["@ifi/mdt-win32-arm64-msvc"],
+		x64: ["@ifi/mdt-win32-x64-msvc"],
+	},
+};
+
+function getCandidatePackages() {
+	return PLATFORM_PACKAGES[process.platform]?.[process.arch] ?? [];
+}
+
+function resolveBinary(pkgName) {
+	try {
+		const packageJsonPath = require.resolve(`${pkgName}/package.json`);
+		const packageDir = path.dirname(packageJsonPath);
+		const binaryName = process.platform === "win32" ? "mdt.exe" : "mdt";
+		const binaryPath = path.join(packageDir, "bin", binaryName);
+		if (fs.existsSync(binaryPath)) {
+			return binaryPath;
+		}
+	} catch {
+		// Ignore missing optional dependencies and continue trying candidates.
+	}
+
+	return null;
+}
+
+function shouldTryNextPackage(result) {
+	if (result.error) {
+		return true;
+	}
+
+	if (result.status !== 127) {
+		return false;
+	}
+
+	const stderr = result.stderr ?? "";
+	return /not found|no such file or directory|exec format error/i.test(stderr);
+}
+
+function forwardOutput(result) {
+	if (result.stdout) {
+		process.stdout.write(result.stdout);
+	}
+	if (result.stderr) {
+		process.stderr.write(result.stderr);
+	}
+}
+
+function main() {
+	const candidates = getCandidatePackages();
+	if (candidates.length === 0) {
+		console.error(
+			`mdt does not currently publish npm binaries for ${process.platform}/${process.arch}. ` +
+				"Install from the GitHub release page or with `cargo install mdt_cli` instead.",
+		);
+		process.exit(1);
+	}
+
+	const failures = [];
+	for (const pkgName of candidates) {
+		const binaryPath = resolveBinary(pkgName);
+		if (!binaryPath) {
+			continue;
+		}
+
+		const result = spawnSync(binaryPath, process.argv.slice(2), {
+			encoding: "utf8",
+			stdio: ["inherit", "pipe", "pipe"],
+			windowsHide: false,
+		});
+
+		if (shouldTryNextPackage(result)) {
+			const detail = result.error?.message ?? result.stderr?.trim() ??
+				"failed to launch";
+			failures.push(`${pkgName}: ${detail}`);
+			continue;
+		}
+
+		forwardOutput(result);
+		process.exit(result.status ?? 0);
+	}
+
+	console.error(
+		"Unable to find a compatible mdt binary in the installed npm packages.",
+	);
+	console.error(`Tried: ${candidates.join(", ")}`);
+	if (failures.length > 0) {
+		console.error(failures.join("\n"));
+	}
+	console.error(
+		"Reinstall with `npm install -g @ifi/mdt`, download a binary from GitHub releases, or use `cargo install mdt_cli`.",
+	);
+	process.exit(1);
+}
+
+main();

--- a/npm/tests/mdt-bin.test.mjs
+++ b/npm/tests/mdt-bin.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	cpSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+const launcherPath = join(process.cwd(), "npm/bin/mdt.js");
+
+const platformPackages = {
+	darwin: {
+		arm64: ["@ifi/mdt-darwin-arm64"],
+		x64: ["@ifi/mdt-darwin-x64"],
+	},
+	linux: {
+		arm64: ["@ifi/mdt-linux-arm64-gnu", "@ifi/mdt-linux-arm64-musl"],
+		x64: ["@ifi/mdt-linux-x64-gnu", "@ifi/mdt-linux-x64-musl"],
+	},
+	win32: {
+		arm64: ["@ifi/mdt-win32-arm64-msvc"],
+		x64: ["@ifi/mdt-win32-x64-msvc"],
+	},
+};
+
+function makeTempDir(name) {
+	return join(tmpdir(), `mdt-npm-test-${name}-${process.pid}-${Date.now()}`);
+}
+
+function setupLauncherRoot(name) {
+	const root = makeTempDir(name);
+	mkdirSync(join(root, "bin"), { recursive: true });
+	mkdirSync(join(root, "node_modules"), { recursive: true });
+	cpSync(launcherPath, join(root, "bin", "mdt.js"));
+	return root;
+}
+
+function createPackage(root, pkgName, binaryContent) {
+	const packageDir = join(root, "node_modules", ...pkgName.split("/"));
+	const binDir = join(packageDir, "bin");
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(
+		join(packageDir, "package.json"),
+		JSON.stringify({ name: pkgName, version: "0.0.0" }, null, 2),
+	);
+
+	if (process.platform === "win32") {
+		writeFileSync(join(binDir, "mdt.exe"), binaryContent);
+	} else {
+		writeFileSync(join(binDir, "mdt"), binaryContent, { mode: 0o755 });
+	}
+}
+
+function runLauncher(root, args) {
+	return spawnSync("node", [join(root, "bin", "mdt.js"), ...args], {
+		cwd: root,
+		encoding: "utf8",
+	});
+}
+
+function currentCandidates() {
+	return platformPackages[process.platform]?.[process.arch] ?? [];
+}
+
+test("launcher executes the installed platform binary", () => {
+	const root = setupLauncherRoot("run");
+	try {
+		const [pkgName] = currentCandidates();
+		assert.ok(pkgName, "expected a package mapping for the current platform");
+		const binary = process.platform === "win32"
+			? "@echo off\r\necho launcher-ok %*\r\n"
+			: '#!/bin/sh\necho launcher-ok "$@"\n';
+		createPackage(root, pkgName, binary);
+
+		const result = runLauncher(root, ["check", "--verbose"]);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stdout, /launcher-ok/);
+		assert.match(result.stdout, /check/);
+		assert.match(result.stdout, /verbose/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test("launcher shows a helpful error when no platform package is installed", () => {
+	const root = setupLauncherRoot("missing");
+	try {
+		const result = runLauncher(root, ["--help"]);
+		assert.notEqual(result.status, 0);
+		assert.match(result.stderr, /Unable to find a compatible mdt binary/);
+		assert.match(result.stderr, /Reinstall with `npm install -g @ifi\/mdt`/);
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test(
+	"launcher falls back to the secondary linux package when the first one fails to launch",
+	{
+		skip: process.platform !== "linux" || currentCandidates().length < 2,
+	},
+	() => {
+		const root = setupLauncherRoot("fallback");
+		try {
+			const [firstPackage, secondPackage] = currentCandidates();
+			createPackage(root, firstPackage, "#!/missing/interpreter\n");
+			createPackage(root, secondPackage, '#!/bin/sh\necho fallback-ok "$@"\n');
+
+			const result = runLauncher(root, ["doctor"]);
+			assert.equal(result.status, 0, result.stderr);
+			assert.match(result.stdout, /fallback-ok/);
+			assert.match(result.stdout, /doctor/);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	},
+);

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,19 @@
 
 <!-- {=mdtCliInstall} -->
 
-- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Install with npm:
+
+```sh
+npm install -g @ifi/mdt
+```
+
+- Or run it without installing:
+
+```sh
+npx @ifi/mdt --help
+```
+
+- Or download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
 - Or install with Cargo:
 
 ```sh

--- a/scripts/npm/build-packages.mjs
+++ b/scripts/npm/build-packages.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+
+const platforms = [
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "arm64",
+		label: "Linux arm64 (glibc)",
+		libc: "glibc",
+		os: "linux",
+		packageName: "@ifi/mdt-linux-arm64-gnu",
+		target: "aarch64-unknown-linux-gnu",
+	},
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "arm64",
+		label: "Linux arm64 (musl)",
+		libc: "musl",
+		os: "linux",
+		packageName: "@ifi/mdt-linux-arm64-musl",
+		target: "aarch64-unknown-linux-musl",
+	},
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "arm64",
+		label: "macOS arm64",
+		os: "darwin",
+		packageName: "@ifi/mdt-darwin-arm64",
+		target: "aarch64-apple-darwin",
+	},
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "x64",
+		label: "Linux x64 (glibc)",
+		libc: "glibc",
+		os: "linux",
+		packageName: "@ifi/mdt-linux-x64-gnu",
+		target: "x86_64-unknown-linux-gnu",
+	},
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "x64",
+		label: "Linux x64 (musl)",
+		libc: "musl",
+		os: "linux",
+		packageName: "@ifi/mdt-linux-x64-musl",
+		target: "x86_64-unknown-linux-musl",
+	},
+	{
+		archiveExt: "tar.gz",
+		binaryName: "mdt",
+		cpu: "x64",
+		label: "macOS x64",
+		os: "darwin",
+		packageName: "@ifi/mdt-darwin-x64",
+		target: "x86_64-apple-darwin",
+	},
+	{
+		archiveExt: "zip",
+		binaryName: "mdt.exe",
+		cpu: "x64",
+		label: "Windows x64",
+		os: "win32",
+		packageName: "@ifi/mdt-win32-x64-msvc",
+		target: "x86_64-pc-windows-msvc",
+	},
+	{
+		archiveExt: "zip",
+		binaryName: "mdt.exe",
+		cpu: "arm64",
+		label: "Windows arm64",
+		os: "win32",
+		packageName: "@ifi/mdt-win32-arm64-msvc",
+		target: "aarch64-pc-windows-msvc",
+	},
+];
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const key = argv[index];
+		const value = argv[index + 1];
+		if (!key.startsWith("--") || value === undefined) {
+			continue;
+		}
+		args[key.slice(2)] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function ensureDirectory(path) {
+	mkdirSync(path, { recursive: true });
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		stdio: options.stdio ?? "pipe",
+		cwd: options.cwd,
+	});
+	if (result.status !== 0) {
+		const detail = result.stderr || result.stdout ||
+			`exit code ${result.status ?? "unknown"}`;
+		throw new Error(`${command} ${args.join(" ")} failed: ${detail}`);
+	}
+	return result;
+}
+
+function findArchive(assetsDir, target, releaseTag, archiveExt) {
+	const archiveName = `mdt-${target}-${releaseTag}.${archiveExt}`;
+	const archivePath = join(assetsDir, archiveName);
+	if (!existsSync(archivePath)) {
+		throw new Error(`missing release asset: ${archiveName}`);
+	}
+	return archivePath;
+}
+
+function* walk(dir) {
+	const entries = readdirSync(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		const entryPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			yield* walk(entryPath);
+		} else {
+			yield entryPath;
+		}
+	}
+}
+
+function extractArchive(archivePath, destinationDir) {
+	ensureDirectory(destinationDir);
+	if (archivePath.endsWith(".zip")) {
+		run("unzip", ["-q", archivePath, "-d", destinationDir]);
+		return;
+	}
+	if (archivePath.endsWith(".tar.gz")) {
+		run("tar", ["-xzf", archivePath, "-C", destinationDir]);
+		return;
+	}
+	throw new Error(`unsupported archive: ${basename(archivePath)}`);
+}
+
+function findBinary(extractedDir, binaryName) {
+	for (const filePath of walk(extractedDir)) {
+		if (basename(filePath) === binaryName) {
+			return filePath;
+		}
+	}
+	throw new Error(`could not find ${binaryName} in ${extractedDir}`);
+}
+
+function writeJson(path, value) {
+	writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createPlatformPackage(
+	{ outDir, spec, version, releaseTag, assetsDir },
+) {
+	const archivePath = findArchive(
+		assetsDir,
+		spec.target,
+		releaseTag,
+		spec.archiveExt,
+	);
+	const extractedDir = join(outDir, ".tmp", spec.target);
+	const packageDir = join(
+		outDir,
+		"platform",
+		spec.packageName.replace("/", "__"),
+	);
+	const binDir = join(packageDir, "bin");
+
+	extractArchive(archivePath, extractedDir);
+	const binaryPath = findBinary(extractedDir, spec.binaryName);
+
+	ensureDirectory(binDir);
+	copyFileSync(binaryPath, join(binDir, spec.binaryName));
+	if (spec.binaryName === "mdt") {
+		chmodSync(join(binDir, spec.binaryName), 0o755);
+	}
+	copyFileSync(join(repoRoot, "license"), join(packageDir, "LICENSE"));
+
+	const packageJson = {
+		name: spec.packageName,
+		version,
+		description: `Prebuilt mdt binary for ${spec.label}`,
+		license: "Unlicense",
+		repository: {
+			type: "git",
+			url: "git+https://github.com/ifiokjr/mdt.git",
+		},
+		homepage: "https://github.com/ifiokjr/mdt",
+		bugs: {
+			url: "https://github.com/ifiokjr/mdt/issues",
+		},
+		os: [spec.os],
+		cpu: [spec.cpu],
+		files: ["bin", "LICENSE"],
+		publishConfig: {
+			access: "public",
+			provenance: true,
+		},
+	};
+	if (spec.libc) {
+		packageJson.libc = [spec.libc];
+	}
+
+	writeJson(join(packageDir, "package.json"), packageJson);
+}
+
+function createRootPackage({ outDir, version }) {
+	const packageDir = join(outDir, "root");
+	const binDir = join(packageDir, "bin");
+	ensureDirectory(binDir);
+	copyFileSync(join(repoRoot, "npm/bin/mdt.js"), join(binDir, "mdt.js"));
+	chmodSync(join(binDir, "mdt.js"), 0o755);
+	copyFileSync(join(repoRoot, "readme.md"), join(packageDir, "README.md"));
+	copyFileSync(join(repoRoot, "license"), join(packageDir, "LICENSE"));
+
+	const optionalDependencies = Object.fromEntries(
+		platforms.map((spec) => [spec.packageName, version]),
+	);
+
+	writeJson(join(packageDir, "package.json"), {
+		name: "@ifi/mdt",
+		version,
+		description: "CLI for managing markdown templates across your project",
+		license: "Unlicense",
+		repository: {
+			type: "git",
+			url: "git+https://github.com/ifiokjr/mdt.git",
+		},
+		homepage: "https://github.com/ifiokjr/mdt",
+		bugs: {
+			url: "https://github.com/ifiokjr/mdt/issues",
+		},
+		keywords: ["markdown", "templates", "docs", "cli", "mcp"],
+		engines: {
+			node: ">=18",
+		},
+		bin: {
+			mdt: "bin/mdt.js",
+		},
+		files: ["bin", "README.md", "LICENSE"],
+		optionalDependencies,
+		publishConfig: {
+			access: "public",
+			provenance: true,
+		},
+	});
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const version = args.version;
+	const releaseTag = args["release-tag"];
+	const assetsDir = resolve(args["assets-dir"] ?? "");
+	const outDir = resolve(args["out-dir"] ?? "");
+
+	if (!version || !releaseTag || !args["assets-dir"] || !args["out-dir"]) {
+		throw new Error(
+			"usage: build-packages.mjs --version <x.y.z> --release-tag <vX.Y.Z> --assets-dir <dir> --out-dir <dir>",
+		);
+	}
+
+	ensureDirectory(outDir);
+	for (const spec of platforms) {
+		createPlatformPackage({ outDir, spec, version, releaseTag, assetsDir });
+	}
+	createRootPackage({ outDir, version });
+
+	const summary = {
+		platformPackages: platforms.map((spec) => spec.packageName),
+		rootPackage: "@ifi/mdt",
+		version,
+	};
+	writeFileSync(
+		join(outDir, "summary.json"),
+		`${JSON.stringify(summary, null, 2)}\n`,
+	);
+	console.log(`Generated npm packages for ${version} in ${outDir}`);
+}
+
+main();

--- a/scripts/npm/publish-packages.mjs
+++ b/scripts/npm/publish-packages.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+function parseArgs(argv) {
+	const args = {};
+	for (let index = 0; index < argv.length; index += 1) {
+		const key = argv[index];
+		const value = argv[index + 1];
+		if (!key.startsWith("--") || value === undefined) {
+			continue;
+		}
+		args[key.slice(2)] = value;
+		index += 1;
+	}
+	return args;
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		stdio: options.stdio ?? "pipe",
+		cwd: options.cwd,
+	});
+	if (result.status !== 0) {
+		const detail = result.stderr || result.stdout ||
+			`exit code ${result.status ?? "unknown"}`;
+		throw new Error(`${command} ${args.join(" ")} failed: ${detail}`);
+	}
+	return result;
+}
+
+function packageMetadata(dir) {
+	return JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+}
+
+function packageExists(name, version) {
+	const result = spawnSync("npm", [
+		"view",
+		`${name}@${version}`,
+		"version",
+		"--json",
+	], {
+		encoding: "utf8",
+		stdio: "pipe",
+	});
+	return result.status === 0;
+}
+
+function publishPackage(dir) {
+	const pkg = packageMetadata(dir);
+	if (packageExists(pkg.name, pkg.version)) {
+		console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
+		return;
+	}
+
+	console.log(`Publishing ${pkg.name}@${pkg.version}...`);
+	run("npm", ["publish", "--access", "public", "--provenance"], {
+		cwd: dir,
+		stdio: "inherit",
+	});
+}
+
+function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const packagesDir = resolve(args["packages-dir"] ?? "");
+	if (!args["packages-dir"]) {
+		throw new Error("usage: publish-packages.mjs --packages-dir <dir>");
+	}
+
+	const platformRoot = join(packagesDir, "platform");
+	const platformPackages = readdirSync(platformRoot)
+		.sort()
+		.map((entry) => join(platformRoot, entry));
+
+	for (const packageDir of platformPackages) {
+		publishPackage(packageDir);
+	}
+	publishPackage(join(packagesDir, "root"));
+}
+
+main();

--- a/scripts/npm/tests/build-packages.test.mjs
+++ b/scripts/npm/tests/build-packages.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const scriptPath = join(process.cwd(), "scripts/npm/build-packages.mjs");
+
+const targets = [
+	{ target: "aarch64-unknown-linux-gnu", ext: "tar.gz", binary: "mdt" },
+	{ target: "aarch64-unknown-linux-musl", ext: "tar.gz", binary: "mdt" },
+	{ target: "aarch64-apple-darwin", ext: "tar.gz", binary: "mdt" },
+	{ target: "x86_64-unknown-linux-gnu", ext: "tar.gz", binary: "mdt" },
+	{ target: "x86_64-unknown-linux-musl", ext: "tar.gz", binary: "mdt" },
+	{ target: "x86_64-apple-darwin", ext: "tar.gz", binary: "mdt" },
+	{ target: "x86_64-pc-windows-msvc", ext: "zip", binary: "mdt.exe" },
+	{ target: "aarch64-pc-windows-msvc", ext: "zip", binary: "mdt.exe" },
+];
+
+function run(command, args, cwd) {
+	const result = spawnSync(command, args, { cwd, encoding: "utf8" });
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+function writeArchive(assetsDir, releaseTag, spec, tempRoot) {
+	const workDir = join(tempRoot, spec.target);
+	mkdirSync(workDir, { recursive: true });
+	if (spec.binary === "mdt") {
+		writeFileSync(join(workDir, spec.binary), "#!/bin/sh\necho packaged\n", {
+			mode: 0o755,
+		});
+		run(
+			"tar",
+			[
+				"-czf",
+				join(assetsDir, `mdt-${spec.target}-${releaseTag}.tar.gz`),
+				"-C",
+				workDir,
+				spec.binary,
+			],
+			process.cwd(),
+		);
+	} else {
+		writeFileSync(join(workDir, spec.binary), "fake-windows-binary");
+		run(
+			"zip",
+			[
+				"-q",
+				join(assetsDir, `mdt-${spec.target}-${releaseTag}.zip`),
+				spec.binary,
+			],
+			workDir,
+		);
+	}
+}
+
+test("build-packages generates root and platform npm packages from release archives", () => {
+	const tempRoot = join(
+		tmpdir(),
+		`mdt-build-packages-${process.pid}-${Date.now()}`,
+	);
+	const assetsDir = join(tempRoot, "assets");
+	const outDir = join(tempRoot, "out");
+	const releaseTag = "v1.2.3";
+
+	mkdirSync(assetsDir, { recursive: true });
+	for (const spec of targets) {
+		writeArchive(assetsDir, releaseTag, spec, tempRoot);
+	}
+
+	const result = spawnSync(
+		"node",
+		[
+			scriptPath,
+			"--version",
+			"1.2.3",
+			"--release-tag",
+			releaseTag,
+			"--assets-dir",
+			assetsDir,
+			"--out-dir",
+			outDir,
+		],
+		{ encoding: "utf8" },
+	);
+
+	try {
+		assert.equal(result.status, 0, result.stderr || result.stdout);
+		assert.ok(existsSync(join(outDir, "root", "bin", "mdt.js")));
+		assert.ok(
+			existsSync(
+				join(outDir, "platform", "@ifi__mdt-linux-x64-gnu", "bin", "mdt"),
+			),
+		);
+		assert.ok(
+			existsSync(
+				join(outDir, "platform", "@ifi__mdt-win32-x64-msvc", "bin", "mdt.exe"),
+			),
+		);
+
+		const rootPackage = JSON.parse(
+			readFileSync(join(outDir, "root", "package.json"), "utf8"),
+		);
+		assert.equal(rootPackage.name, "@ifi/mdt");
+		assert.equal(rootPackage.version, "1.2.3");
+		assert.equal(rootPackage.bin.mdt, "bin/mdt.js");
+		assert.equal(
+			rootPackage.optionalDependencies["@ifi/mdt-darwin-arm64"],
+			"1.2.3",
+		);
+
+		const linuxPackage = JSON.parse(
+			readFileSync(
+				join(outDir, "platform", "@ifi__mdt-linux-x64-gnu", "package.json"),
+				"utf8",
+			),
+		);
+		assert.equal(linuxPackage.name, "@ifi/mdt-linux-x64-gnu");
+		assert.deepEqual(linuxPackage.os, ["linux"]);
+		assert.deepEqual(linuxPackage.cpu, ["x64"]);
+		assert.deepEqual(linuxPackage.libc, ["glibc"]);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
+});

--- a/template.t.md
+++ b/template.t.md
@@ -277,7 +277,19 @@ mdt_mcp = "{{ cargo.workspace.package.version }}"
 
 <!-- {@mdtCliInstall} -->
 
-- Download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
+- Install with npm:
+
+```sh
+npm install -g @ifi/mdt
+```
+
+- Or run it without installing:
+
+```sh
+npx @ifi/mdt --help
+```
+
+- Or download a prebuilt binary from the [latest GitHub release](https://github.com/ifiokjr/mdt/releases/latest)
 - Or install with Cargo:
 
 ```sh


### PR DESCRIPTION
## Summary

- add npm packaging scripts for `@ifi/mdt` plus platform-specific binary packages
- split npm publishing into a separate `npm-publish` workflow that runs after the `release` workflow completes
- add integration tests for the npm launcher and npm package generation flow
- document npm install and `npx` usage in installation docs and READMEs

## Details

This PR adds an npm distribution channel for the `mdt` CLI without requiring users to install Rust.

### Packaging model

Release behavior after this change:

1. the `release` workflow builds and uploads the GitHub release binaries
2. the `release` workflow uploads a small metadata artifact containing the release tag
3. the `npm-publish` workflow runs after `release` completes successfully
4. `npm-publish` downloads the release assets for that tag
5. it generates platform-specific npm packages for Linux, macOS, and Windows
6. it publishes the platform packages first
7. it publishes the top-level `@ifi/mdt` package last

The top-level package uses `optionalDependencies` and a small launcher script so:

```sh
npm install -g @ifi/mdt
npx @ifi/mdt --help
```

both work while still installing the native `mdt` binary for the current platform.

### Workflow behavior

- `release.yml` now only handles binary release assets and npm publish metadata
- `npm-publish.yml` is responsible for npm publishing
- `npm-publish.yml` also supports manual recovery/replay via `workflow_dispatch` with a `tag` input

## Validation

- `node --check npm/bin/mdt.js`
- `node --check scripts/npm/build-packages.mjs`
- `node --check scripts/npm/publish-packages.mjs`
- `node --test npm/tests/*.test.mjs scripts/npm/tests/*.test.mjs`
- smoke-tested `scripts/npm/build-packages.mjs` with generated sample archives for all release targets
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`
- `git diff --check`

## Follow-up / setup

- requires `NPM_TOKEN` in GitHub Actions secrets to publish to npm
- assumes the `@ifi` npm scope is available for publish
