### PR TITLE
fix(ci): allow npm publish reruns for older tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -58,10 +58,10 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved release tag: $TAG"
 
-      - name: checkout
+      - name: checkout repository tools
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.release_tag.outputs.tag }}
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: setup node
         uses: actions/setup-node@v4

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -46,6 +46,7 @@ npm publishing is handled by a separate `npm-publish` workflow when `NPM_TOKEN` 
 
 - The `release` workflow builds and uploads the GitHub release binaries, then publishes a small metadata artifact containing the release tag.
 - The `npm-publish` workflow runs after the `release` workflow completes successfully, downloads that metadata artifact, then repackages the exact release binaries into npm packages.
+- `npm-publish` checks out the default branch tooling rather than the release tag itself, so manual reruns can publish older release tags even if the npm packaging scripts were added later.
 - The top-level package is `@ifi/mdt`.
 - Platform packages are published first (for Linux, macOS, and Windows targets).
 - The top-level package is published last and depends on those platform packages through `optionalDependencies`.


### PR DESCRIPTION
## Summary

- fix manual `npm-publish` reruns for older release tags
- keep using the selected tag for release assets while checking out npm publish tooling from the default branch
- clarify the rerun behavior in release docs

## Root cause

Manual `npm-publish` runs checked out the requested release tag before invoking `scripts/npm/build-packages.mjs`.

That fails for older tags like `v0.7.0`, because those tags predate the npm packaging scripts and therefore do not contain:

- `scripts/npm/build-packages.mjs`
- `scripts/npm/publish-packages.mjs`

The workflow already downloads binaries from the selected release tag, so it does not need to check out the tagged source tree just to publish npm packages.

## Fix

- checkout the repository tools from the default branch in `npm-publish.yml`
- continue resolving the release tag separately for downloading the actual release assets
- document that manual reruns intentionally use current packaging tooling with older tagged assets

## Validation

- `node --test npm/tests/*.test.mjs scripts/npm/tests/*.test.mjs`
- `/Users/ifiokjr/Developer/projects/mdt/target/debug/mdt check`
- `git diff --check`

## Follow-up

After merge, rerun the manual workflow for `v0.7.0` and it should reach package generation instead of failing on a missing script checkout.
