### PR TITLE
chore: add devenv-managed git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,11 @@ devenv shell
 install:all
 ```
 
+Entering the dev shell also installs the repository git hooks managed by `devenv`:
+
+- `pre-commit` applies autofixable `mdt`, formatting, and clippy updates to staged changes.
+- `pre-push` runs the CI-aligned lint, test, npm integration, and build checks.
+
 ## Building and Testing
 
 ```sh

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,17 +3,33 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1775201809,
-        "narHash": "sha256-WmpoCegCQ6Q2ZyxqO05zlz/7XXjt/l2iut4Nk5Nt+W4=",
+        "lastModified": 1775649035,
+        "narHash": "sha256-fN57wo1b9JF/hiEW523JWsDaI85/RagHS6056LBhLQI=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "42a5505d4700e791732e48a38b4cca05a755f94b",
+        "rev": "3ce9320dad64269d952e7e4e18c151e11f4072f5",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
         "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -35,17 +51,60 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "ifiokjr-nixpkgs": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1775223586,
-        "narHash": "sha256-AtiVUFlejqRudK85Mk+qKkQdfqm02/RMXb7rlSfyaG0=",
+        "lastModified": 1775629605,
+        "narHash": "sha256-U8zt4bKqLGXaAe1oSQmtPPkG84kDDbv/R/ZESEtKke0=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "608658d7ee0123cf8cb855f564c9031289770302",
+        "rev": "cbafdde35535e1bb5e4f9968aa08c167da0a3106",
         "type": "github"
       },
       "original": {
@@ -56,11 +115,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775095191,
-        "narHash": "sha256-CsqRiYbgQyv01LS0NlC7shwzhDhjNDQSrhBX8VuD3nM=",
+        "lastModified": 1775579569,
+        "narHash": "sha256-/m3yyS/EnXqoPGBJYVy4jTOsirdgsEZ3JdN2gGkBr14=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "106eb93cbb9d4e4726bf6bc367a3114f7ed6b32f",
+        "rev": "dfd9566f82a6e1d55c30f861879186440614696e",
         "type": "github"
       },
       "original": {
@@ -72,11 +131,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1775126147,
-        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
+        "lastModified": 1775608838,
+        "narHash": "sha256-2ySoGH+SAi34U0PeuQgABC0WiH9LQ3tkyHTiE93KUeg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
+        "rev": "9a01fad67a57e44e1b3e1d905c6881bcfb209e8a",
         "type": "github"
       },
       "original": {
@@ -105,6 +164,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "ifiokjr-nixpkgs": "ifiokjr-nixpkgs",
         "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay"
@@ -115,11 +175,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1775185947,
-        "narHash": "sha256-8ctPmj6RME4q4ELeg+BuY9lV/34M4AG1CNc0Im9PDDk=",
+        "lastModified": 1775617983,
+        "narHash": "sha256-2NWGA/I4j/qlx6qbg86QvJiK1/GyH9gnf0hFiARWVwE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "199eeb6748116f7da4fbd3a680bc854e99d9132b",
+        "rev": "d98b91b1feae7ef07fa2ccb3aa3f83f11abfae54",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -41,6 +41,42 @@ in
   # disable dotenv since it breaks the variable interpolation supported by `direnv`
   dotenv.disableHint = true;
 
+  git-hooks.hooks = {
+    mdt-pre-commit = {
+      enable = true;
+      name = "mdt pre-commit autofix";
+      description = "Apply autofixable formatting and lint updates to staged changes.";
+      entry = "bash scripts/git-hooks/pre-commit.sh";
+      language = "system";
+      pass_filenames = true;
+      require_serial = true;
+      always_run = true;
+      stages = [ "pre-commit" ];
+      extraPackages = with pkgs; [
+        bash
+        devenv
+        git
+      ];
+    };
+
+    mdt-pre-push = {
+      enable = true;
+      name = "mdt pre-push CI checks";
+      description = "Run the local CI-equivalent checks before pushing.";
+      entry = "bash scripts/git-hooks/pre-push.sh";
+      language = "system";
+      pass_filenames = false;
+      require_serial = true;
+      always_run = true;
+      stages = [ "pre-push" ];
+      extraPackages = with pkgs; [
+        bash
+        devenv
+        git
+      ];
+    };
+  };
+
   scripts = {
     "mdt" = {
       exec = ''

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,13 +1,16 @@
 # yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  ifiokjr-nixpkgs:
+    url: github:ifiokjr/nixpkgs
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
   rust-overlay:
     url: github:oxalica/rust-overlay
     overlays:
       - default
-  ifiokjr-nixpkgs:
-    url: github:ifiokjr/nixpkgs
-
-# If you're using non-OSS software, you can set allowUnfree to true.
-allowUnfree: true
+allow_unfree: true

--- a/scripts/git-hooks/pre-commit.sh
+++ b/scripts/git-hooks/pre-commit.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${MDT_GIT_HOOK_IN_DEVENV:-0}" != "1" ]]; then
+	exec devenv shell -- env MDT_GIT_HOOK_IN_DEVENV=1 bash "$0" "$@"
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+staged_files=("$@")
+existing_staged_files=()
+staged_rust_files=()
+
+for file in "${staged_files[@]}"; do
+	if [[ -e "$file" ]]; then
+		existing_staged_files+=("$file")
+	fi
+
+	if [[ "$file" == *.rs ]]; then
+		staged_rust_files+=("$file")
+	fi
+done
+
+echo "pre-commit: updating generated markdown targets"
+mdt update
+
+if ((${#staged_rust_files[@]} > 0)); then
+	echo "pre-commit: applying clippy fixes"
+	cargo clippy --workspace --fix --allow-dirty --allow-staged --all-features --all-targets
+else
+	echo "pre-commit: no staged Rust files; skipping clippy fixes"
+fi
+
+format_targets=()
+if ((${#existing_staged_files[@]} > 0)); then
+	format_targets+=("${existing_staged_files[@]}")
+fi
+
+while IFS= read -r file; do
+	[[ -n "$file" && -e "$file" ]] || continue
+	format_targets+=("$file")
+done < <(git diff --name-only --diff-filter=ACMR)
+
+if ((${#format_targets[@]} > 0)); then
+	echo "pre-commit: formatting changed files"
+	if ! dprint fmt --config "$DEVENV_ROOT/dprint.json" --allow-no-files "${format_targets[@]}"; then
+		echo "pre-commit: staged-file formatting failed; retrying with full repository formatting"
+		fix:format
+	fi
+else
+	echo "pre-commit: no changed files to format"
+fi
+
+echo "pre-commit: staging autofixed changes"
+git add -u -- .
+if ((${#existing_staged_files[@]} > 0)); then
+	git add -- "${existing_staged_files[@]}"
+fi

--- a/scripts/git-hooks/pre-push.sh
+++ b/scripts/git-hooks/pre-push.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${MDT_GIT_HOOK_IN_DEVENV:-0}" != "1" ]]; then
+	exec devenv shell -- env MDT_GIT_HOOK_IN_DEVENV=1 bash "$0" "$@"
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+echo "pre-push: running CI-aligned checks"
+lint:all
+test:all
+node --test npm/tests/*.test.mjs scripts/npm/tests/*.test.mjs
+cargo build --locked
+cargo build --all-features --locked


### PR DESCRIPTION
## Summary\n- add devenv-managed pre-commit and pre-push hooks\n- make pre-commit run mdt update, clippy fixes, and staged-file formatting with a full-format fallback\n- make pre-push run the CI-aligned lint, test, npm integration, and build checks\n\n## Testing\n- devenv shell -- lint:all\n- bash ./scripts/git-hooks/pre-push.sh\n