### PR TITLE
ci(release): add release automation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,157 @@ jobs:
       - name: run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
 
+  release-pr:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'ifiokjr'
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+
+      - name: configure git
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if user_info="$(gh api user --jq '{id: .id, login: .login, name: .name}')"; then
+            user_id="$(echo "$user_info" | jq -r '.id')"
+            user_login="$(echo "$user_info" | jq -r '.login')"
+            user_name="$(echo "$user_info" | jq -r '.name // .login')"
+          else
+            user_id="41898282"
+            user_login="github-actions[bot]"
+            user_name="github-actions[bot]"
+          fi
+
+          git config user.name "$user_name"
+          git config user.email "${user_id}+${user_login}@users.noreply.github.com"
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: refresh tags from origin
+        run: git fetch --force --tags origin
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: detect current release commit
+        id: release_record
+        run: |
+          set -euo pipefail
+
+          release_record_error="$(mktemp)"
+          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
+            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          subject="$(git log -1 --pretty=%s)"
+          body="$(git log -1 --pretty=%B)"
+          if [[ "$subject" == chore\(release\):* ]] || grep -q '<!-- monochange:release-record:start -->' <<<"$body"; then
+            echo "::error::Release-looking commit could not be read as a release record; failing instead of silently skipping release automation."
+            cat "$release_record_error" >&2
+            exit 1
+          fi
+
+          echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: refresh release pull request
+        if: steps.release_record.outputs.is_release_commit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_COMMIT_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: mc --log-level=debug release --commit --create-pr
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: skip refresh on merged release commit
+        if: steps.release_record.outputs.is_release_commit == 'true'
+        run: echo "HEAD is already a merged release commit; skipping release PR refresh."
+
+  release-post-merge:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'ifiokjr'
+    needs: release-pr
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: setup
+        uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: detect release commit and create tags
+        id: tag_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: devenv shell -c -- bash -e {0}
+        run: |
+          set -euo pipefail
+
+          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit')"; then
+            echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
+            if [ "${is_release_commit}" = "true" ]; then
+              mc step:tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
+            fi
+          else
+            subject="$(git log -1 --pretty=%s)"
+            body="$(git log -1 --pretty=%B)"
+            if [[ "$subject" == chore\(release\):* ]] || grep -q '<!-- monochange:release-record:start -->' <<<"$body"; then
+              echo "::error::Release-looking commit could not be read as a release record; failing instead of silently skipping release automation."
+              mc step:release-record --from HEAD --format json
+              exit 1
+            fi
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: create draft releases
+        if: steps.tag_release.outputs.is_release_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mc step:publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: comment on released issues
+        if: steps.tag_release.outputs.is_release_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
+        run: mc step:comment-released-issues --from-ref="HEAD" --auto-close-issues
+        shell: devenv shell -c -- bash -e {0}
+
+      - name: trigger release workflow
+        if: steps.tag_release.outputs.is_release_commit == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(jq -r '.tags.mdt // empty' /tmp/tag-report.json)"
+          if [ -z "$tag" ]; then
+            echo "No mdt group tag found in tag-report.json, skipping release trigger"
+            exit 0
+          fi
+          echo "Triggering release workflow for tag $tag"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            -f "tag=$tag"
+
   release-test:
     if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'monochange/release')
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- add Monochange release PR refresh automation for pushes to main
- add post-merge release tagging, draft release creation, released-issue comments, and release workflow trigger
- tailor owner, shell, and tag lookup to ifiokjr/mdt

## Validation
- ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml")'
