### PR TITLE
ci(pages): deploy docs from main pushes

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,12 +1,12 @@
 name: "docs-pages"
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build docs from (tag, branch, or commit SHA). Defaults to the default branch."
+        description: "Git ref to build docs from (tag, branch, or commit SHA). Defaults to the workflow ref."
         required: false
         type: string
 
@@ -27,7 +27,7 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: install mdbook
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary

- Move the GitHub Pages docs workflow from release-published events to pushes on main
- Keep manual dispatch support, with an optional ref for ad-hoc debugging
- Avoid release-tag deployments that are rejected by the github-pages environment branch policy

## Investigation

Previous github-pages deployments failed before the deploy job ran any steps. The repository environment is configured with a custom deployment branch policy that only allows the main branch, but the docs workflow ran on published release tags like v0.7.0 and v0.6.0. GitHub rejected those tag-based deployments immediately.

Deploying from main pushes matches the environment policy and also gives us a docs deployment after release changes merge to main, making future failures easier to diagnose.

## Verification

- devenv shell lint:all
- devenv shell build:book
- devenv shell mc step:affected-packages --format json --verify --changed-paths .github/workflows/docs-pages.yml