### PR TITLE
ci: preserve actions env in devenv shell steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,15 @@ jobs:
 
       - name: lint clippy
         run: lint:clippy
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: lint formatting
         run: lint:format
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: check mdt blocks
         run: cargo run --bin mdt -- check
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
   typecheck:
     timeout-minutes: 10
@@ -106,7 +106,7 @@ jobs:
 
       - name: run rust tests
         run: test:all
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: setup node for npm tests
         uses: actions/setup-node@v4
@@ -138,11 +138,11 @@ jobs:
 
       - name: build
         run: cargo build --locked
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: build all features
         run: cargo build --all-features --locked
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
   cargo-deny:
     timeout-minutes: 30
@@ -190,11 +190,11 @@ jobs:
 
           git config user.name "$user_name"
           git config user.email "${user_id}+${user_login}@users.noreply.github.com"
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: refresh tags from origin
         run: git fetch --force --tags origin
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: detect current release commit
         id: release_record

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: generate Rust coverage report
         run: cargo llvm-cov nextest --lcov --output-path rust-lcov.info
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: generate JavaScript coverage report
         run: |


### PR DESCRIPTION
## Summary

- Remove the `-c` flag from GitHub Actions `devenv shell` step shells
- Fix release automation steps losing runner-provided variables like `GITHUB_OUTPUT`
- Apply the same shell form to coverage and CI devenv-backed steps for consistency

## Why

The release-pr job failed with:

```text
GITHUB_OUTPUT: unbound variable
```

The failing step was running through `devenv shell -c -- bash -e {0}`, which did not preserve the GitHub Actions output file variable. Using `devenv shell -- bash -e {0}` matches the working form already used elsewhere in the workflow.

## Verification

- `devenv shell lint:format`
- `devenv shell mc step:affected-packages --format json --verify --changed-paths .github/workflows/ci.yml --changed-paths .github/workflows/coverage.yml`
