### PR TITLE
fix(ci): preserve GitHub output in release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           fi
 
           echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
 
       - name: refresh release pull request
         if: steps.release_record.outputs.is_release_commit != 'true'
@@ -255,7 +255,7 @@ jobs:
         id: tag_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: devenv shell -c -- bash -e {0}
+        shell: devenv shell -- bash -e {0}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- use the non-`-c` devenv shell form for release steps that write GitHub Actions outputs
- fixes the main-branch release-pr failure from run 26884641831 where `GITHUB_OUTPUT` was unset inside the devenv shell

## Validation
- devenv shell -c -- dprint fmt .github/workflows/ci.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'
- GITHUB_OUTPUT=/tmp/mdt-gh-output-test devenv shell -- bash -e -c 'set -u; echo "ok=true" >> ""'
