### PR TITLE
fix(ci): use release token when creating release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
       - name: refresh release pull request
         if: steps.release_record.outputs.is_release_commit != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
           GITHUB_COMMIT_TOKEN: ${{ secrets.RELEASE_PR_MERGE_TOKEN }}
         run: |
           devenv shell -- env \


### PR DESCRIPTION
## Summary
- use RELEASE_PR_MERGE_TOKEN as the GitHub API token for monochange release PR creation
- keeps GITHUB_COMMIT_TOKEN aligned to the same token

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'
