### PR TITLE
chore(deps): validate dependency updates

### DIFF
--- a/.changeset/package-repository-metadata.md
+++ b/.changeset/package-repository-metadata.md
@@ -1,0 +1,19 @@
+---
+mdt_cli: patch
+mdt_core: patch
+mdt_lsp: patch
+"@m-d-t/cli": patch
+"@m-d-t/cli-darwin-arm64": patch
+"@m-d-t/cli-darwin-x64": patch
+"@m-d-t/cli-linux-arm64-gnu": patch
+"@m-d-t/cli-linux-arm64-musl": patch
+"@m-d-t/cli-linux-x64-gnu": patch
+"@m-d-t/cli-linux-x64-musl": patch
+"@m-d-t/cli-win32-arm64-msvc": patch
+"@m-d-t/cli-win32-x64-msvc": patch
+"@m-d-t/skills": patch
+---
+
+# Add package repository metadata
+
+Cargo and npm package manifests now include package-specific repository URLs. This keeps package metadata aligned with monochange manifest linting and points registry users directly to each package's source directory.

--- a/.changeset/update-rmcp-dep-mcp.md
+++ b/.changeset/update-rmcp-dep-mcp.md
@@ -1,0 +1,9 @@
+---
+mdt_mcp: patch
+---
+
+# Update rmcp server result construction
+
+`rmcp` has been updated to 2.1.0. The MCP server now uses `ServerInfo::new().with_instructions()` for server metadata, the `CallToolResult::success()` and `CallToolResult::error()` constructors, and `ContentBlock` for text tool responses.
+
+This keeps the MCP integration aligned with the current `rmcp` API while preserving the same tool behavior for clients.

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -42,7 +42,7 @@ jobs:
           set -euo pipefail
 
           mapfile -t labels < <(jq -r '.[]' <<<"$PR_LABELS_JSON")
-          args=(step:affected-packages --format json --verify)
+          args=(step affected-packages --format json --verify)
 
           for path in $CHANGED_FILES; do
             args+=(--changed-paths "$path")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           set -euo pipefail
 
           release_record_error="$(mktemp)"
-          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
+          if is_release_commit="$(mc step release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit' 2>"$release_record_error")"; then
             echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -228,7 +228,7 @@ jobs:
             GH_TOKEN="$GH_TOKEN" \
             GITHUB_TOKEN="$GH_TOKEN" \
             GITHUB_COMMIT_TOKEN="$GITHUB_COMMIT_TOKEN" \
-            mc --log-level=debug release --commit --create-pr
+            mc --log-level=debug run release --commit --create-pr
 
       - name: skip refresh on merged release commit
         if: steps.release_record.outputs.is_release_commit == 'true'
@@ -267,17 +267,17 @@ jobs:
             bash -e <<'EOF'
           set -euo pipefail
 
-          if is_release_commit="$(mc step:release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit')"; then
+          if is_release_commit="$(mc step release-record --from HEAD --format json --jq '.resolvedCommit == .recordCommit')"; then
             echo "is_release_commit=${is_release_commit}" >> "$GITHUB_OUTPUT"
             if [ "${is_release_commit}" = "true" ]; then
-              mc step:tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
+              mc step tag-release --from HEAD --push=true --format json | tee /tmp/tag-report.json
             fi
           else
             subject="$(git log -1 --pretty=%s)"
             body="$(git log -1 --pretty=%B)"
             if [[ "$subject" == chore\(release\):* ]] || grep -q '<!-- monochange:release-record:start -->' <<<"$body"; then
               echo "::error::Release-looking commit could not be read as a release record; failing instead of silently skipping release automation."
-              mc step:release-record --from HEAD --format json
+              mc step release-record --from HEAD --format json
               exit 1
             fi
             echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
@@ -292,7 +292,7 @@ jobs:
           devenv shell -- env \
             GH_TOKEN="$GH_TOKEN" \
             GITHUB_TOKEN="$GH_TOKEN" \
-            mc step:publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
+            mc step publish-release --from-ref="HEAD" --draft --format json | tee /tmp/publish-release.json
 
       - name: comment on released issues
         if: steps.tag_release.outputs.is_release_commit == 'true'
@@ -302,7 +302,7 @@ jobs:
           devenv shell -- env \
             GH_TOKEN="$GH_TOKEN" \
             GITHUB_TOKEN="$GH_TOKEN" \
-            mc step:comment-released-issues --from-ref="HEAD" --auto-close-issues
+            mc step comment-released-issues --from-ref="HEAD" --auto-close-issues
 
       - name: trigger release workflow
         if: steps.tag_release.outputs.is_release_commit == 'true'
@@ -346,7 +346,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           before="$(git rev-parse HEAD)"
-          mc release --commit
+          mc run release --commit
           after="$(git rev-parse HEAD)"
           if [ "$before" != "$after" ]; then
             echo "created=true" >> "$GITHUB_OUTPUT"
@@ -385,7 +385,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           before="$(git rev-parse HEAD)"
-          mc release --commit
+          mc run release --commit
           after="$(git rev-parse HEAD)"
           if [ "$before" != "$after" ]; then
             echo "created=true" >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,12 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "borrow-or-share"
@@ -161,13 +155,13 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -178,15 +172,15 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -258,9 +252,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -440,12 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,15 +538,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -591,15 +577,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -650,12 +627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,9 +634,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -685,8 +656,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -702,32 +671,33 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "serde",
  "similar 2.7.0",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
 [[package]]
 name = "insta-cmd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeeefa927925cced49ccb01bf3e57c9d4cd132df21e576eb9415baeab2d3de6"
+checksum = "bffdf4af1db390cf0401535d7c1303cd079a074d28d8473b026fdb6559c41403"
 dependencies = [
  "insta",
  "serde",
@@ -765,13 +735,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -814,12 +783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -996,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memo-map"
@@ -1038,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
  "memo-map",
  "serde",
@@ -1218,16 +1181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1291,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1314,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -1332,9 +1285,9 @@ checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1353,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1616,9 +1569,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snailquote"
@@ -1628,6 +1581,15 @@ checksum = "ec62a949bda7f15800481a711909f946e1204f2460f89210eaf7f57730f88f86"
 dependencies = [
  "thiserror 1.0.69",
  "unicode_categories",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -1669,9 +1631,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2023,12 +1985,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,28 +2049,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2116,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2126,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2139,45 +2086,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2347,100 +2260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ float-cmp = { default-features = false, version = "^0.10" }
 globset = { default-features = false, version = "^0.4" }
 ignore = { default-features = false, version = "^0.4" }
 insta = { default-features = false, version = "^1" }
-insta-cmd = { default-features = false, version = "^0.6" }
+insta-cmd = { default-features = false, version = "0.7.0" }
 kdl = { default-features = false, version = "^6" }
 logos = { default-features = false, version = "0.16.1" }
 markdown = { default-features = false, version = "^1" }
@@ -31,7 +31,7 @@ minijinja = { default-features = false, version = "^2" }
 notify = { default-features = false, version = "^8" }
 owo-colors = { default-features = false, version = "^4" }
 predicates = { default-features = false, version = "^3" }
-rmcp = { default-features = false, version = "1.3.0" }
+rmcp = { default-features = false, version = "2.1.0" }
 rstest = { default-features = false, version = "^0.26" }
 serde = { default-features = false, version = "^1" }
 serde_ini = { default-features = false, version = "^0.2" }

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1780543372,
-        "narHash": "sha256-FCGxk82Lc4koWcFw5xgr+W5vbwLVFLCnSMwm2gQOgr0=",
+        "lastModified": 1783049965,
+        "narHash": "sha256-z2QvrvE+gzLnpqfLpQA4aq2gAB4xn6C5q2o1l7GBMXU=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "f693b472c731e7dda69402daa88c06369d54fd3a",
+        "rev": "afed7bf3240c70d2827569568d2c46c25a64db51",
         "type": "github"
       },
       "original": {
@@ -54,43 +54,21 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -100,11 +78,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780558210,
-        "narHash": "sha256-fyV4wO4o2KTFRKdoE/dUWb08pMkEq0xqQrdZuYmSIy0=",
+        "lastModified": 1783062005,
+        "narHash": "sha256-/Mz/cVcN7yC8DNZbpbf94sgacMDRs09m7as4d3jYsWQ=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "3f2d059d0f4753fe91efc5e760fbf8617104119d",
+        "rev": "6b9b9115cafe83637dd099c15f3815b003f947e4",
         "type": "github"
       },
       "original": {
@@ -115,11 +93,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {
@@ -131,11 +109,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1782918843,
+        "narHash": "sha256-ETYnV9U7Sr+A45dohzZdfCZKOss4qrTkO+wgNZNvEc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "e8273b29fe1390ec8d4603f2477357555291432e",
         "type": "github"
       },
       "original": {
@@ -175,11 +153,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1780543271,
-        "narHash": "sha256-oPJ7eJN1sM37v92Rp/eyQL7/rUm0BOvXEBAoq/zN0cM=",
+        "lastModified": 1783058364,
+        "narHash": "sha256-felUcVUtcdI15evRNkVfLq3opwceShhbrJt6hDlZvrk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c30ca201c5093540cf792f6982f81ba1aa0f3514",
+        "rev": "e7a078c7feb51f37955a832b22a96de5fccb1f7a",
         "type": "github"
       },
       "original": {

--- a/mdt_cli/Cargo.toml
+++ b/mdt_cli/Cargo.toml
@@ -8,7 +8,7 @@ include = ["src/**/*.rs", "tests/**/*.rs", "Cargo.toml", "readme.md"]
 keywords = ["markdown", "templates", "cli"]
 license = { workspace = true }
 readme = "readme.md"
-repository = { workspace = true }
+repository = "https://github.com/ifiokjr/mdt/tree/main/mdt_cli"
 rust-version = { workspace = true }
 description = "Write docs once, sync everywhere — markdown templates that eliminate doc drift"
 

--- a/mdt_core/Cargo.toml
+++ b/mdt_core/Cargo.toml
@@ -8,7 +8,7 @@ include = { workspace = true }
 keywords = ["markdown", "templates"]
 license = { workspace = true }
 readme = "readme.md"
-repository = { workspace = true }
+repository = "https://github.com/ifiokjr/mdt/tree/main/mdt_core"
 rust-version = { workspace = true }
 description = "Core engine for mdt — lexer, parser, scanner, and template engine for markdown synchronization"
 

--- a/mdt_lsp/Cargo.toml
+++ b/mdt_lsp/Cargo.toml
@@ -8,7 +8,7 @@ include = { workspace = true }
 keywords = ["markdown", "templates", "lsp"]
 license = { workspace = true }
 readme = "readme.md"
-repository = { workspace = true }
+repository = "https://github.com/ifiokjr/mdt/tree/main/mdt_lsp"
 rust-version = { workspace = true }
 description = "LSP server for mdt — editor diagnostics, completions, and code actions for markdown templates"
 

--- a/mdt_mcp/Cargo.toml
+++ b/mdt_mcp/Cargo.toml
@@ -8,7 +8,7 @@ include = { workspace = true }
 keywords = ["markdown", "templates", "mcp"]
 license = { workspace = true }
 readme = "readme.md"
-repository = { workspace = true }
+repository = "https://github.com/ifiokjr/mdt/tree/main/mdt_mcp"
 rust-version = { workspace = true }
 description = "MCP server for mdt — AI assistant integration for markdown template synchronization"
 

--- a/mdt_mcp/src/__tests.rs
+++ b/mdt_mcp/src/__tests.rs
@@ -9,12 +9,15 @@ use super::*;
 // ---------------------------------------------------------------------------
 
 fn extract_text(result: &CallToolResult) -> &str {
-	result.content[0]
-		.raw
-		.as_text()
-		.unwrap_or_else(|| panic!("expected text content"))
-		.text
-		.as_str()
+	let content = result
+		.content
+		.first()
+		.unwrap_or_else(|| panic!("expected content"));
+	let ContentBlock::Text(text) = content else {
+		panic!("expected text content");
+	};
+
+	text.text.as_str()
 }
 
 fn extract_json(result: &CallToolResult) -> serde_json::Value {

--- a/mdt_mcp/src/lib.rs
+++ b/mdt_mcp/src/lib.rs
@@ -224,7 +224,7 @@ fn scan_ctx(root: &Path) -> Result<ProjectContext, McpError> {
 fn json_result(value: serde_json::Value) -> CallToolResult {
 	let text = serde_json::to_string_pretty(&value)
 		.unwrap_or_else(|_| "{\"ok\":false,\"summary\":\"failed to serialize\"}".to_string());
-	let mut result = CallToolResult::success(vec![Content::text(text)]);
+	let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
 	result.structured_content = Some(value);
 	result
 }
@@ -232,7 +232,7 @@ fn json_result(value: serde_json::Value) -> CallToolResult {
 fn json_error_result(value: serde_json::Value) -> CallToolResult {
 	let text = serde_json::to_string_pretty(&value)
 		.unwrap_or_else(|_| "{\"ok\":false,\"summary\":\"failed to serialize\"}".to_string());
-	let mut result = CallToolResult::error(vec![Content::text(text)]);
+	let mut result = CallToolResult::error(vec![ContentBlock::text(text)]);
 	result.structured_content = Some(value);
 	result
 }

--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
 		"build": "tsdown"
 	},
 	"devDependencies": {
-		"@rslint/tsgo": "^0.5.0",
-		"@types/node": "^25.9.1",
-		"oxfmt": "^0.53.0",
-		"oxlint": "^1.68.0",
-		"oxlint-tsgolint": "^0.23.0",
-		"tsdown": "^0.22.1",
+		"@rslint/tsgo": "^0.6.4",
+		"@types/node": "^26.1.0",
+		"oxfmt": "^0.57.0",
+		"oxlint": "^1.72.0",
+		"oxlint-tsgolint": "^0.24.0",
+		"tsdown": "^0.22.3",
 		"tsx": "^4.22.4",
 		"typescript": "^6.0.3",
-		"vitest": "^4.1.8"
+		"vitest": "^4.1.9"
 	},
 	"engines": {
 		"node": ">=24.0.0",

--- a/packages/m-d-t__cli-darwin-arm64/package.json
+++ b/packages/m-d-t__cli-darwin-arm64/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-darwin-arm64",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-darwin-x64/package.json
+++ b/packages/m-d-t__cli-darwin-x64/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-darwin-x64",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-linux-arm64-gnu/package.json
+++ b/packages/m-d-t__cli-linux-arm64-gnu/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-linux-arm64-gnu",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-linux-arm64-musl/package.json
+++ b/packages/m-d-t__cli-linux-arm64-musl/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-linux-arm64-musl",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-linux-x64-gnu/package.json
+++ b/packages/m-d-t__cli-linux-x64-gnu/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-linux-x64-gnu",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-linux-x64-musl/package.json
+++ b/packages/m-d-t__cli-linux-x64-musl/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-linux-x64-musl",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-win32-arm64-msvc/package.json
+++ b/packages/m-d-t__cli-win32-arm64-msvc/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-win32-arm64-msvc",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli-win32-x64-msvc/package.json
+++ b/packages/m-d-t__cli-win32-x64-msvc/package.json
@@ -7,10 +7,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli-win32-x64-msvc",
 	"files": [
 		"bin"
 	],

--- a/packages/m-d-t__cli/package.json
+++ b/packages/m-d-t__cli/package.json
@@ -15,10 +15,7 @@
 		"url": "https://github.com/ifiokjr/mdt/issues"
 	},
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__cli",
 	"bin": {
 		"mdt": "bin/mdt.js"
 	},

--- a/packages/m-d-t__skills/package.json
+++ b/packages/m-d-t__skills/package.json
@@ -3,11 +3,7 @@
 	"version": "0.8.0",
 	"description": "Agent skills for mdt — keep markdown templates synchronized across your project. Includes MCP tool guidance, template syntax, and CLI workflow instructions.",
 	"license": "Unlicense",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/ifiokjr/mdt.git",
-		"directory": "packages/m-d-t__skills"
-	},
+	"repository": "https://github.com/ifiokjr/mdt/tree/main/packages/m-d-t__skills",
 	"homepage": "https://github.com/ifiokjr/mdt",
 	"bugs": {
 		"url": "https://github.com/ifiokjr/mdt/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,23 +8,23 @@ importers:
   .:
     devDependencies:
       "@rslint/tsgo":
-        specifier: ^0.5.0
-        version: 0.5.3
+        specifier: ^0.6.4
+        version: 0.6.4
       "@types/node":
-        specifier: ^25.9.1
-        version: 25.9.1
+        specifier: ^26.1.0
+        version: 26.1.0
       oxfmt:
-        specifier: ^0.53.0
-        version: 0.53.0
+        specifier: ^0.57.0
+        version: 0.57.0
       oxlint:
-        specifier: ^1.68.0
-        version: 1.68.0(oxlint-tsgolint@0.23.0)
+        specifier: ^1.72.0
+        version: 1.72.0(oxlint-tsgolint@0.24.0)
       oxlint-tsgolint:
-        specifier: ^0.23.0
-        version: 0.23.0
+        specifier: ^0.24.0
+        version: 0.24.0
       tsdown:
-        specifier: ^0.22.1
-        version: 0.22.1(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)
+        specifier: ^0.22.3
+        version: 0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
@@ -32,34 +32,34 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4))
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.0)(vite@8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4))
 
   packages/m-d-t__cli:
     optionalDependencies:
       "@m-d-t/cli-darwin-arm64":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-darwin-arm64
       "@m-d-t/cli-darwin-x64":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-darwin-x64
       "@m-d-t/cli-linux-arm64-gnu":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-linux-arm64-gnu
       "@m-d-t/cli-linux-arm64-musl":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-linux-arm64-musl
       "@m-d-t/cli-linux-x64-gnu":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-linux-x64-gnu
       "@m-d-t/cli-linux-x64-musl":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-linux-x64-musl
       "@m-d-t/cli-win32-arm64-msvc":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-win32-arm64-msvc
       "@m-d-t/cli-win32-x64-msvc":
-        specifier: ^0.0.0
+        specifier: ^0.8.0
         version: link:../m-d-t__cli-win32-x64-msvc
 
   packages/m-d-t__cli-darwin-arm64: {}
@@ -81,34 +81,34 @@ importers:
   packages/m-d-t__skills: {}
 
 packages:
-  "@babel/generator@8.0.0-rc.6":
+  "@babel/generator@8.0.0":
     resolution: {
-      integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==,
+      integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==,
     }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
-  "@babel/helper-string-parser@8.0.0-rc.6":
+  "@babel/helper-string-parser@8.0.0":
     resolution: {
-      integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==,
+      integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==,
     }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
-  "@babel/helper-validator-identifier@8.0.0-rc.6":
+  "@babel/helper-validator-identifier@8.0.2":
     resolution: {
-      integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==,
+      integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==,
     }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
-  "@babel/parser@8.0.0-rc.6":
+  "@babel/parser@8.0.0":
     resolution: {
-      integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==,
+      integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==,
     }
     engines: { node: ^22.18.0 || >=24.11.0 }
     hasBin: true
 
-  "@babel/types@8.0.0-rc.6":
+  "@babel/types@8.0.0":
     resolution: {
-      integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==,
+      integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==,
     }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
@@ -117,14 +117,29 @@ packages:
       integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
     }
 
+  "@emnapi/core@1.11.1":
+    resolution: {
+      integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
+    }
+
   "@emnapi/runtime@1.10.0":
     resolution: {
       integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
     }
 
+  "@emnapi/runtime@1.11.1":
+    resolution: {
+      integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+    }
+
   "@emnapi/wasi-threads@1.2.1":
     resolution: {
       integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
+    }
+
+  "@emnapi/wasi-threads@1.2.2":
+    resolution: {
+      integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
     }
 
   "@esbuild/aix-ppc64@0.28.0":
@@ -356,9 +371,9 @@ packages:
       integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
     }
 
-  "@napi-rs/wasm-runtime@1.1.4":
+  "@napi-rs/wasm-runtime@1.1.6":
     resolution: {
-      integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
     }
     peerDependencies:
       "@emnapi/core": ^1.7.1
@@ -374,368 +389,368 @@ packages:
       integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==,
     }
 
-  "@oxc-project/types@0.133.0":
+  "@oxc-project/types@0.138.0":
     resolution: {
-      integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==,
+      integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==,
     }
 
-  "@oxfmt/binding-android-arm-eabi@0.53.0":
+  "@oxfmt/binding-android-arm-eabi@0.57.0":
     resolution: {
-      integrity: sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==,
+      integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxfmt/binding-android-arm64@0.53.0":
+  "@oxfmt/binding-android-arm64@0.57.0":
     resolution: {
-      integrity: sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==,
+      integrity: sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxfmt/binding-darwin-arm64@0.53.0":
+  "@oxfmt/binding-darwin-arm64@0.57.0":
     resolution: {
-      integrity: sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==,
+      integrity: sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxfmt/binding-darwin-x64@0.53.0":
+  "@oxfmt/binding-darwin-x64@0.57.0":
     resolution: {
-      integrity: sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==,
+      integrity: sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxfmt/binding-freebsd-x64@0.53.0":
+  "@oxfmt/binding-freebsd-x64@0.57.0":
     resolution: {
-      integrity: sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==,
+      integrity: sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxfmt/binding-linux-arm-gnueabihf@0.53.0":
+  "@oxfmt/binding-linux-arm-gnueabihf@0.57.0":
     resolution: {
-      integrity: sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==,
+      integrity: sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxfmt/binding-linux-arm-musleabihf@0.53.0":
+  "@oxfmt/binding-linux-arm-musleabihf@0.57.0":
     resolution: {
-      integrity: sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==,
+      integrity: sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxfmt/binding-linux-arm64-gnu@0.53.0":
+  "@oxfmt/binding-linux-arm64-gnu@0.57.0":
     resolution: {
-      integrity: sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==,
+      integrity: sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxfmt/binding-linux-arm64-musl@0.53.0":
+  "@oxfmt/binding-linux-arm64-musl@0.57.0":
     resolution: {
-      integrity: sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==,
+      integrity: sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxfmt/binding-linux-ppc64-gnu@0.53.0":
+  "@oxfmt/binding-linux-ppc64-gnu@0.57.0":
     resolution: {
-      integrity: sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==,
+      integrity: sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxfmt/binding-linux-riscv64-gnu@0.53.0":
+  "@oxfmt/binding-linux-riscv64-gnu@0.57.0":
     resolution: {
-      integrity: sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==,
+      integrity: sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxfmt/binding-linux-riscv64-musl@0.53.0":
+  "@oxfmt/binding-linux-riscv64-musl@0.57.0":
     resolution: {
-      integrity: sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==,
+      integrity: sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxfmt/binding-linux-s390x-gnu@0.53.0":
+  "@oxfmt/binding-linux-s390x-gnu@0.57.0":
     resolution: {
-      integrity: sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==,
+      integrity: sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxfmt/binding-linux-x64-gnu@0.53.0":
+  "@oxfmt/binding-linux-x64-gnu@0.57.0":
     resolution: {
-      integrity: sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==,
+      integrity: sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxfmt/binding-linux-x64-musl@0.53.0":
+  "@oxfmt/binding-linux-x64-musl@0.57.0":
     resolution: {
-      integrity: sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==,
+      integrity: sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxfmt/binding-openharmony-arm64@0.53.0":
+  "@oxfmt/binding-openharmony-arm64@0.57.0":
     resolution: {
-      integrity: sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==,
+      integrity: sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxfmt/binding-win32-arm64-msvc@0.53.0":
+  "@oxfmt/binding-win32-arm64-msvc@0.57.0":
     resolution: {
-      integrity: sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==,
+      integrity: sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxfmt/binding-win32-ia32-msvc@0.53.0":
+  "@oxfmt/binding-win32-ia32-msvc@0.57.0":
     resolution: {
-      integrity: sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==,
+      integrity: sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxfmt/binding-win32-x64-msvc@0.53.0":
+  "@oxfmt/binding-win32-x64-msvc@0.57.0":
     resolution: {
-      integrity: sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==,
+      integrity: sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
 
-  "@oxlint-tsgolint/darwin-arm64@0.23.0":
+  "@oxlint-tsgolint/darwin-arm64@0.24.0":
     resolution: {
-      integrity: sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw==,
+      integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==,
     }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxlint-tsgolint/darwin-x64@0.23.0":
+  "@oxlint-tsgolint/darwin-x64@0.24.0":
     resolution: {
-      integrity: sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA==,
+      integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==,
     }
     cpu: [x64]
     os: [darwin]
 
-  "@oxlint-tsgolint/linux-arm64@0.23.0":
+  "@oxlint-tsgolint/linux-arm64@0.24.0":
     resolution: {
-      integrity: sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw==,
+      integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==,
     }
     cpu: [arm64]
     os: [linux]
 
-  "@oxlint-tsgolint/linux-x64@0.23.0":
+  "@oxlint-tsgolint/linux-x64@0.24.0":
     resolution: {
-      integrity: sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA==,
+      integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==,
     }
     cpu: [x64]
     os: [linux]
 
-  "@oxlint-tsgolint/win32-arm64@0.23.0":
+  "@oxlint-tsgolint/win32-arm64@0.24.0":
     resolution: {
-      integrity: sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw==,
+      integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==,
     }
     cpu: [arm64]
     os: [win32]
 
-  "@oxlint-tsgolint/win32-x64@0.23.0":
+  "@oxlint-tsgolint/win32-x64@0.24.0":
     resolution: {
-      integrity: sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ==,
+      integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==,
     }
     cpu: [x64]
     os: [win32]
 
-  "@oxlint/binding-android-arm-eabi@1.68.0":
+  "@oxlint/binding-android-arm-eabi@1.72.0":
     resolution: {
-      integrity: sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==,
+      integrity: sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxlint/binding-android-arm64@1.68.0":
+  "@oxlint/binding-android-arm64@1.72.0":
     resolution: {
-      integrity: sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==,
+      integrity: sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxlint/binding-darwin-arm64@1.68.0":
+  "@oxlint/binding-darwin-arm64@1.72.0":
     resolution: {
-      integrity: sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==,
+      integrity: sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxlint/binding-darwin-x64@1.68.0":
+  "@oxlint/binding-darwin-x64@1.72.0":
     resolution: {
-      integrity: sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==,
+      integrity: sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxlint/binding-freebsd-x64@1.68.0":
+  "@oxlint/binding-freebsd-x64@1.72.0":
     resolution: {
-      integrity: sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==,
+      integrity: sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.68.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.72.0":
     resolution: {
-      integrity: sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==,
+      integrity: sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm-musleabihf@1.68.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.72.0":
     resolution: {
-      integrity: sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==,
+      integrity: sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm64-gnu@1.68.0":
+  "@oxlint/binding-linux-arm64-gnu@1.72.0":
     resolution: {
-      integrity: sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==,
+      integrity: sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-arm64-musl@1.68.0":
+  "@oxlint/binding-linux-arm64-musl@1.72.0":
     resolution: {
-      integrity: sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==,
+      integrity: sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-ppc64-gnu@1.68.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.72.0":
     resolution: {
-      integrity: sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==,
+      integrity: sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-gnu@1.68.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.72.0":
     resolution: {
-      integrity: sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==,
+      integrity: sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-musl@1.68.0":
+  "@oxlint/binding-linux-riscv64-musl@1.72.0":
     resolution: {
-      integrity: sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==,
+      integrity: sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-s390x-gnu@1.68.0":
+  "@oxlint/binding-linux-s390x-gnu@1.72.0":
     resolution: {
-      integrity: sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==,
+      integrity: sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-gnu@1.68.0":
+  "@oxlint/binding-linux-x64-gnu@1.72.0":
     resolution: {
-      integrity: sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==,
+      integrity: sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-musl@1.68.0":
+  "@oxlint/binding-linux-x64-musl@1.72.0":
     resolution: {
-      integrity: sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==,
+      integrity: sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-openharmony-arm64@1.68.0":
+  "@oxlint/binding-openharmony-arm64@1.72.0":
     resolution: {
-      integrity: sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==,
+      integrity: sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxlint/binding-win32-arm64-msvc@1.68.0":
+  "@oxlint/binding-win32-arm64-msvc@1.72.0":
     resolution: {
-      integrity: sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==,
+      integrity: sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxlint/binding-win32-ia32-msvc@1.68.0":
+  "@oxlint/binding-win32-ia32-msvc@1.72.0":
     resolution: {
-      integrity: sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==,
+      integrity: sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxlint/binding-win32-x64-msvc@1.68.0":
+  "@oxlint/binding-win32-x64-msvc@1.72.0":
     resolution: {
-      integrity: sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==,
+      integrity: sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -762,9 +777,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-android-arm64@1.0.3":
+  "@rolldown/binding-android-arm64@1.1.4":
     resolution: {
-      integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==,
+      integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -786,9 +801,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-arm64@1.0.3":
+  "@rolldown/binding-darwin-arm64@1.1.4":
     resolution: {
-      integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==,
+      integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -810,9 +825,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.0.3":
+  "@rolldown/binding-darwin-x64@1.1.4":
     resolution: {
-      integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==,
+      integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -834,9 +849,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-freebsd-x64@1.0.3":
+  "@rolldown/binding-freebsd-x64@1.1.4":
     resolution: {
-      integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==,
+      integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -858,9 +873,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
+  "@rolldown/binding-linux-arm-gnueabihf@1.1.4":
     resolution: {
-      integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==,
+      integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
@@ -884,9 +899,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.3":
+  "@rolldown/binding-linux-arm64-gnu@1.1.4":
     resolution: {
-      integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==,
+      integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -911,9 +926,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-arm64-musl@1.0.3":
+  "@rolldown/binding-linux-arm64-musl@1.1.4":
     resolution: {
-      integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==,
+      integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -938,9 +953,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+  "@rolldown/binding-linux-ppc64-gnu@1.1.4":
     resolution: {
-      integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==,
+      integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
@@ -965,9 +980,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.3":
+  "@rolldown/binding-linux-s390x-gnu@1.1.4":
     resolution: {
-      integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==,
+      integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
@@ -992,9 +1007,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-gnu@1.0.3":
+  "@rolldown/binding-linux-x64-gnu@1.1.4":
     resolution: {
-      integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==,
+      integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1019,9 +1034,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-x64-musl@1.0.3":
+  "@rolldown/binding-linux-x64-musl@1.1.4":
     resolution: {
-      integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==,
+      integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1044,9 +1059,9 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-openharmony-arm64@1.0.3":
+  "@rolldown/binding-openharmony-arm64@1.1.4":
     resolution: {
-      integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==,
+      integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -1066,9 +1081,9 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
 
-  "@rolldown/binding-wasm32-wasi@1.0.3":
+  "@rolldown/binding-wasm32-wasi@1.1.4":
     resolution: {
-      integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==,
+      integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
@@ -1089,9 +1104,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.3":
+  "@rolldown/binding-win32-arm64-msvc@1.1.4":
     resolution: {
-      integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==,
+      integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -1113,9 +1128,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.0.3":
+  "@rolldown/binding-win32-x64-msvc@1.1.4":
     resolution: {
-      integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==,
+      integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1131,51 +1146,51 @@ packages:
       integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
     }
 
-  "@rslint/tsgo-darwin-arm64@0.5.3":
+  "@rslint/tsgo-darwin-arm64@0.6.4":
     resolution: {
-      integrity: sha512-HoSwWdRblj4Tg23o7zd7mRFJgy/q/rvMGPpaykqzVEOH99IEr2ph/HLfcLMHfa8Gf4mfcYuQ6DYsLyFgfhBZow==,
+      integrity: sha512-S8wwlwh19OQ1vTF98ihF0kGxPqj5TO1jYu4PkkRPUuyTtDBIGsSFsPUswzbIdQsafh5X+22wZLASMsQ0Tv0OXg==,
     }
     cpu: [arm64]
     os: [darwin]
 
-  "@rslint/tsgo-darwin-x64@0.5.3":
+  "@rslint/tsgo-darwin-x64@0.6.4":
     resolution: {
-      integrity: sha512-muthRhqM5UcgRd2REi2Y7WxVGDh/D2Y9AMDqKnJngizwOr4y7Rx65v9yPPrPQIEuJw6EPS4uaGyi1pxvHj+6Lw==,
+      integrity: sha512-NxNiXLYlGaSIrR0D0h55tEQxJ7V02j4OIbgtyikVU6OKg2CL0uvbeI2QE/GQtQ+CsFo6SnFlFpDImU8/EEzo3g==,
     }
     cpu: [x64]
     os: [darwin]
 
-  "@rslint/tsgo-linux-arm64@0.5.3":
+  "@rslint/tsgo-linux-arm64@0.6.4":
     resolution: {
-      integrity: sha512-DEZ8OB/2NGB2fJ1/sfIC6sTJkYYgGjP9X7AhS3ymOpQSBCLBSV5VNKOAToxY+B8JrAdSQ+NXDqQw+TqNBK+QIQ==,
+      integrity: sha512-iStkDXu36g0mtdh1dhBNh46h01ydp8/WRtnxghojbAfuW0iFwV9ai4rpG2W23Zy18rMPmjSszOxg+OoSa8yMdQ==,
     }
     cpu: [arm64]
     os: [linux]
 
-  "@rslint/tsgo-linux-x64@0.5.3":
+  "@rslint/tsgo-linux-x64@0.6.4":
     resolution: {
-      integrity: sha512-RIJgtxq7zTijD8+INGGizJcLunedBqkudSkW/fko8pzc7HBvOKewe+RF7gO6kb4s4usYZfU4ApvcBQuqEaHi1Q==,
+      integrity: sha512-az9KDhiph9TpBM/6ZlE6044CfwX0qqUgV8jXGEvOk8xXKJ/wwktP04lZQtOTVhxkb2WwAWTExUobCzL3sbfMTQ==,
     }
     cpu: [x64]
     os: [linux]
 
-  "@rslint/tsgo-win32-arm64@0.5.3":
+  "@rslint/tsgo-win32-arm64@0.6.4":
     resolution: {
-      integrity: sha512-e61+sRtHXK9uNYBy43BpLCMX9W/fLdawA4fet7r1H8ZRiVopU9fQUEfOg+g684yGXt8CJQmnQz7Vb9F2/QlAGw==,
+      integrity: sha512-Jy2H+HgbE1tJupBwZtXGKvTweD52Zk/+QrSwZXIkTB1B3yaxig6MjTWxHMO0/SgcAKIQfAJ6VB2Gm/MmHQNXsQ==,
     }
     cpu: [arm64]
     os: [win32]
 
-  "@rslint/tsgo-win32-x64@0.5.3":
+  "@rslint/tsgo-win32-x64@0.6.4":
     resolution: {
-      integrity: sha512-4WsQzXI+9i1okW7NJ62IsIDnYWUgw9KQm/QYsuxmyw+1pRQSVvMD51mt1fY98HrWtlHVoRlLlpUFhA0b0XNWWA==,
+      integrity: sha512-7rx3yTzo+HNk6K8Igb8jjt54OEpDCaxABA/izL51KuADi07pCwCfgDqBhuRxDJQpaRbJRvK6etBndkqvQSEEKA==,
     }
     cpu: [x64]
     os: [win32]
 
-  "@rslint/tsgo@0.5.3":
+  "@rslint/tsgo@0.6.4":
     resolution: {
-      integrity: sha512-QszTgXl0zP88jCIa+AbOuypX9My7nW6y4GNeTFmn/Zco1H6emIXQn8cigROcMqdmbYgw8a6kHB+37V8KaDA3cA==,
+      integrity: sha512-pmfAxGC0/FrfwTiGrmYYqJRbE1lVxMlZi0tRbOrGw9Uy5KlEaDCw+zUzQqWu5uD3ml+J4CUM3++UalvlawKJ8A==,
     }
     hasBin: true
 
@@ -1184,9 +1199,9 @@ packages:
       integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
     }
 
-  "@tybys/wasm-util@0.10.2":
+  "@tybys/wasm-util@0.10.3":
     resolution: {
-      integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
+      integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
     }
 
   "@types/chai@5.2.3":
@@ -1209,19 +1224,19 @@ packages:
       integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==,
     }
 
-  "@types/node@25.9.1":
+  "@types/node@26.1.0":
     resolution: {
-      integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==,
+      integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==,
     }
 
-  "@vitest/expect@4.1.8":
+  "@vitest/expect@4.1.9":
     resolution: {
-      integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==,
+      integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==,
     }
 
-  "@vitest/mocker@4.1.8":
+  "@vitest/mocker@4.1.9":
     resolution: {
-      integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==,
+      integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==,
     }
     peerDependencies:
       msw: ^2.4.9
@@ -1232,29 +1247,29 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.1.8":
+  "@vitest/pretty-format@4.1.9":
     resolution: {
-      integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==,
+      integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==,
     }
 
-  "@vitest/runner@4.1.8":
+  "@vitest/runner@4.1.9":
     resolution: {
-      integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==,
+      integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==,
     }
 
-  "@vitest/snapshot@4.1.8":
+  "@vitest/snapshot@4.1.9":
     resolution: {
-      integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==,
+      integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==,
     }
 
-  "@vitest/spy@4.1.8":
+  "@vitest/spy@4.1.9":
     resolution: {
-      integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==,
+      integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==,
     }
 
-  "@vitest/utils@4.1.8":
+  "@vitest/utils@4.1.9":
     resolution: {
-      integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==,
+      integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==,
     }
 
   ansis@4.3.1:
@@ -1269,11 +1284,11 @@ packages:
     }
     engines: { node: ">=12" }
 
-  ast-kit@3.0.0-beta.1:
+  ast-kit@3.0.0:
     resolution: {
-      integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==,
+      integrity: sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==,
     }
-    engines: { node: ">=20.19.0" }
+    engines: { node: ^22.18.0 || >=24.11.0 }
 
   birpc@4.0.0:
     resolution: {
@@ -1325,9 +1340,9 @@ packages:
     }
     engines: { node: ">=14" }
 
-  es-module-lexer@2.1.0:
+  es-module-lexer@2.3.0:
     resolution: {
-      integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==,
     }
 
   esbuild@0.28.0:
@@ -1342,9 +1357,9 @@ packages:
       integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
     }
 
-  expect-type@1.3.0:
+  expect-type@1.4.0:
     resolution: {
-      integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==,
     }
     engines: { node: ">=12.0.0" }
 
@@ -1493,21 +1508,22 @@ packages:
       integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
     }
 
-  nanoid@3.3.12:
+  nanoid@3.3.15:
     resolution: {
-      integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+      integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==,
     }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
-  obug@2.1.1:
+  obug@2.1.3:
     resolution: {
-      integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
     }
+    engines: { node: ">=12.20.0" }
 
-  oxfmt@0.53.0:
+  oxfmt@0.57.0:
     resolution: {
-      integrity: sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==,
+      integrity: sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -1520,15 +1536,15 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     resolution: {
-      integrity: sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA==,
+      integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==,
     }
     hasBin: true
 
-  oxlint@1.68.0:
+  oxlint@1.72.0:
     resolution: {
-      integrity: sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==,
+      integrity: sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -1557,9 +1573,9 @@ packages:
     }
     engines: { node: ">=12" }
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     resolution: {
-      integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+      integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==,
     }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -1573,17 +1589,17 @@ packages:
       integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
     }
 
-  rolldown-plugin-dts@0.25.2:
+  rolldown-plugin-dts@0.26.0:
     resolution: {
-      integrity: sha512-nMhN/R+vmR8GM45ZW1FWMSjRTSDDn/6w4GTf8RNrEFCBdl8B1kySWrU1ixPtbwzXoRlcO+R/S88VgXuJQwfdDg==,
+      integrity: sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==,
     }
-    engines: { node: ^22.18.0 || >=24.0.0 }
+    engines: { node: ^22.18.0 || >=24.11.0 }
     peerDependencies:
       "@ts-macro/tsc": ^0.3.6
       "@typescript/native-preview": ">=7.0.0-dev.20260325.1"
       rolldown: ^1.0.0
       typescript: ^5.0.0 || ^6.0.0
-      vue-tsc: ~3.2.0
+      vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
       "@ts-macro/tsc":
         optional: true
@@ -1608,16 +1624,16 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
-  rolldown@1.0.3:
+  rolldown@1.1.4:
     resolution: {
-      integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==,
+      integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==,
     }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
-  semver@7.8.1:
+  semver@7.8.5:
     resolution: {
-      integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==,
+      integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
     }
     engines: { node: ">=10" }
     hasBin: true
@@ -1678,16 +1694,16 @@ packages:
     }
     hasBin: true
 
-  tsdown@0.22.1:
+  tsdown@0.22.3:
     resolution: {
-      integrity: sha512-Ldx1jLyDFEzsN/fMBi2TBVaZe4fuEJhIiHjQhX0pV7oa5uYz5Imdivs5mNzEXOrMEtFRR6C9BQ2YqLoroffB+Q==,
+      integrity: sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg==,
     }
-    engines: { node: ^22.18.0 || >=24.0.0 }
+    engines: { node: ^22.18.0 || >=24.11.0 }
     hasBin: true
     peerDependencies:
       "@arethetypeswrong/core": ^0.18.1
-      "@tsdown/css": 0.22.1
-      "@tsdown/exe": 0.22.1
+      "@tsdown/css": 0.22.3
+      "@tsdown/exe": 0.22.3
       "@vitejs/devtools": "*"
       publint: ^0.3.8
       tsx: "*"
@@ -1738,9 +1754,9 @@ packages:
       integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==,
     }
 
-  undici-types@7.24.6:
+  undici-types@8.3.0:
     resolution: {
-      integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==,
+      integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==,
     }
 
   unrun@0.2.39:
@@ -1800,9 +1816,9 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
+  vitest@4.1.9:
     resolution: {
-      integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==,
+      integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==,
     }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -1810,12 +1826,12 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.8
-      "@vitest/browser-preview": 4.1.8
-      "@vitest/browser-webdriverio": 4.1.8
-      "@vitest/coverage-istanbul": 4.1.8
-      "@vitest/coverage-v8": 4.1.8
-      "@vitest/ui": 4.1.8
+      "@vitest/browser-playwright": 4.1.9
+      "@vitest/browser-preview": 4.1.9
+      "@vitest/browser-webdriverio": 4.1.9
+      "@vitest/coverage-istanbul": 4.1.9
+      "@vitest/coverage-v8": 4.1.9
+      "@vitest/ui": 4.1.9
       happy-dom: "*"
       jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1851,31 +1867,37 @@ packages:
     hasBin: true
 
 snapshots:
-  "@babel/generator@8.0.0-rc.6":
+  "@babel/generator@8.0.0":
     dependencies:
-      "@babel/parser": 8.0.0-rc.6
-      "@babel/types": 8.0.0-rc.6
+      "@babel/parser": 8.0.0
+      "@babel/types": 8.0.0
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
       "@types/jsesc": 2.5.1
       jsesc: 3.1.0
 
-  "@babel/helper-string-parser@8.0.0-rc.6": {}
+  "@babel/helper-string-parser@8.0.0": {}
 
-  "@babel/helper-validator-identifier@8.0.0-rc.6": {}
+  "@babel/helper-validator-identifier@8.0.2": {}
 
-  "@babel/parser@8.0.0-rc.6":
+  "@babel/parser@8.0.0":
     dependencies:
-      "@babel/types": 8.0.0-rc.6
+      "@babel/types": 8.0.0
 
-  "@babel/types@8.0.0-rc.6":
+  "@babel/types@8.0.0":
     dependencies:
-      "@babel/helper-string-parser": 8.0.0-rc.6
-      "@babel/helper-validator-identifier": 8.0.0-rc.6
+      "@babel/helper-string-parser": 8.0.0
+      "@babel/helper-validator-identifier": 8.0.2
 
   "@emnapi/core@1.10.0":
     dependencies:
       "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/core@1.11.1":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.2
       tslib: 2.8.1
     optional: true
 
@@ -1884,7 +1906,17 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@emnapi/runtime@1.11.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/wasi-threads@1.2.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.2":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1981,11 +2013,18 @@ snapshots:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
       "@emnapi/core": 1.10.0
       "@emnapi/runtime": 1.10.0
-      "@tybys/wasm-util": 0.10.2
+      "@tybys/wasm-util": 0.10.3
+    optional: true
+
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
+    dependencies:
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@tybys/wasm-util": 0.10.3
     optional: true
 
   "@oxc-project/types@0.127.0":
@@ -1993,138 +2032,138 @@ snapshots:
 
   "@oxc-project/types@0.132.0": {}
 
-  "@oxc-project/types@0.133.0": {}
+  "@oxc-project/types@0.138.0": {}
 
-  "@oxfmt/binding-android-arm-eabi@0.53.0":
+  "@oxfmt/binding-android-arm-eabi@0.57.0":
     optional: true
 
-  "@oxfmt/binding-android-arm64@0.53.0":
+  "@oxfmt/binding-android-arm64@0.57.0":
     optional: true
 
-  "@oxfmt/binding-darwin-arm64@0.53.0":
+  "@oxfmt/binding-darwin-arm64@0.57.0":
     optional: true
 
-  "@oxfmt/binding-darwin-x64@0.53.0":
+  "@oxfmt/binding-darwin-x64@0.57.0":
     optional: true
 
-  "@oxfmt/binding-freebsd-x64@0.53.0":
+  "@oxfmt/binding-freebsd-x64@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-arm-gnueabihf@0.53.0":
+  "@oxfmt/binding-linux-arm-gnueabihf@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-arm-musleabihf@0.53.0":
+  "@oxfmt/binding-linux-arm-musleabihf@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-arm64-gnu@0.53.0":
+  "@oxfmt/binding-linux-arm64-gnu@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-arm64-musl@0.53.0":
+  "@oxfmt/binding-linux-arm64-musl@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-ppc64-gnu@0.53.0":
+  "@oxfmt/binding-linux-ppc64-gnu@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-riscv64-gnu@0.53.0":
+  "@oxfmt/binding-linux-riscv64-gnu@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-riscv64-musl@0.53.0":
+  "@oxfmt/binding-linux-riscv64-musl@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-s390x-gnu@0.53.0":
+  "@oxfmt/binding-linux-s390x-gnu@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-x64-gnu@0.53.0":
+  "@oxfmt/binding-linux-x64-gnu@0.57.0":
     optional: true
 
-  "@oxfmt/binding-linux-x64-musl@0.53.0":
+  "@oxfmt/binding-linux-x64-musl@0.57.0":
     optional: true
 
-  "@oxfmt/binding-openharmony-arm64@0.53.0":
+  "@oxfmt/binding-openharmony-arm64@0.57.0":
     optional: true
 
-  "@oxfmt/binding-win32-arm64-msvc@0.53.0":
+  "@oxfmt/binding-win32-arm64-msvc@0.57.0":
     optional: true
 
-  "@oxfmt/binding-win32-ia32-msvc@0.53.0":
+  "@oxfmt/binding-win32-ia32-msvc@0.57.0":
     optional: true
 
-  "@oxfmt/binding-win32-x64-msvc@0.53.0":
+  "@oxfmt/binding-win32-x64-msvc@0.57.0":
     optional: true
 
-  "@oxlint-tsgolint/darwin-arm64@0.23.0":
+  "@oxlint-tsgolint/darwin-arm64@0.24.0":
     optional: true
 
-  "@oxlint-tsgolint/darwin-x64@0.23.0":
+  "@oxlint-tsgolint/darwin-x64@0.24.0":
     optional: true
 
-  "@oxlint-tsgolint/linux-arm64@0.23.0":
+  "@oxlint-tsgolint/linux-arm64@0.24.0":
     optional: true
 
-  "@oxlint-tsgolint/linux-x64@0.23.0":
+  "@oxlint-tsgolint/linux-x64@0.24.0":
     optional: true
 
-  "@oxlint-tsgolint/win32-arm64@0.23.0":
+  "@oxlint-tsgolint/win32-arm64@0.24.0":
     optional: true
 
-  "@oxlint-tsgolint/win32-x64@0.23.0":
+  "@oxlint-tsgolint/win32-x64@0.24.0":
     optional: true
 
-  "@oxlint/binding-android-arm-eabi@1.68.0":
+  "@oxlint/binding-android-arm-eabi@1.72.0":
     optional: true
 
-  "@oxlint/binding-android-arm64@1.68.0":
+  "@oxlint/binding-android-arm64@1.72.0":
     optional: true
 
-  "@oxlint/binding-darwin-arm64@1.68.0":
+  "@oxlint/binding-darwin-arm64@1.72.0":
     optional: true
 
-  "@oxlint/binding-darwin-x64@1.68.0":
+  "@oxlint/binding-darwin-x64@1.72.0":
     optional: true
 
-  "@oxlint/binding-freebsd-x64@1.68.0":
+  "@oxlint/binding-freebsd-x64@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.68.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-musleabihf@1.68.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-gnu@1.68.0":
+  "@oxlint/binding-linux-arm64-gnu@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-musl@1.68.0":
+  "@oxlint/binding-linux-arm64-musl@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-ppc64-gnu@1.68.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-gnu@1.68.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-musl@1.68.0":
+  "@oxlint/binding-linux-riscv64-musl@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-s390x-gnu@1.68.0":
+  "@oxlint/binding-linux-s390x-gnu@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-gnu@1.68.0":
+  "@oxlint/binding-linux-x64-gnu@1.72.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-musl@1.68.0":
+  "@oxlint/binding-linux-x64-musl@1.72.0":
     optional: true
 
-  "@oxlint/binding-openharmony-arm64@1.68.0":
+  "@oxlint/binding-openharmony-arm64@1.72.0":
     optional: true
 
-  "@oxlint/binding-win32-arm64-msvc@1.68.0":
+  "@oxlint/binding-win32-arm64-msvc@1.72.0":
     optional: true
 
-  "@oxlint/binding-win32-ia32-msvc@1.68.0":
+  "@oxlint/binding-win32-ia32-msvc@1.72.0":
     optional: true
 
-  "@oxlint/binding-win32-x64-msvc@1.68.0":
+  "@oxlint/binding-win32-x64-msvc@1.72.0":
     optional: true
 
   "@quansync/fs@1.0.0":
@@ -2137,7 +2176,7 @@ snapshots:
   "@rolldown/binding-android-arm64@1.0.2":
     optional: true
 
-  "@rolldown/binding-android-arm64@1.0.3":
+  "@rolldown/binding-android-arm64@1.1.4":
     optional: true
 
   "@rolldown/binding-darwin-arm64@1.0.0-rc.17":
@@ -2146,7 +2185,7 @@ snapshots:
   "@rolldown/binding-darwin-arm64@1.0.2":
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.0.3":
+  "@rolldown/binding-darwin-arm64@1.1.4":
     optional: true
 
   "@rolldown/binding-darwin-x64@1.0.0-rc.17":
@@ -2155,7 +2194,7 @@ snapshots:
   "@rolldown/binding-darwin-x64@1.0.2":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.0.3":
+  "@rolldown/binding-darwin-x64@1.1.4":
     optional: true
 
   "@rolldown/binding-freebsd-x64@1.0.0-rc.17":
@@ -2164,7 +2203,7 @@ snapshots:
   "@rolldown/binding-freebsd-x64@1.0.2":
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.0.3":
+  "@rolldown/binding-freebsd-x64@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17":
@@ -2173,7 +2212,7 @@ snapshots:
   "@rolldown/binding-linux-arm-gnueabihf@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.3":
+  "@rolldown/binding-linux-arm-gnueabihf@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17":
@@ -2182,7 +2221,7 @@ snapshots:
   "@rolldown/binding-linux-arm64-gnu@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.3":
+  "@rolldown/binding-linux-arm64-gnu@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-arm64-musl@1.0.0-rc.17":
@@ -2191,7 +2230,7 @@ snapshots:
   "@rolldown/binding-linux-arm64-musl@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.0.3":
+  "@rolldown/binding-linux-arm64-musl@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17":
@@ -2200,7 +2239,7 @@ snapshots:
   "@rolldown/binding-linux-ppc64-gnu@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.3":
+  "@rolldown/binding-linux-ppc64-gnu@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17":
@@ -2209,7 +2248,7 @@ snapshots:
   "@rolldown/binding-linux-s390x-gnu@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.3":
+  "@rolldown/binding-linux-s390x-gnu@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-x64-gnu@1.0.0-rc.17":
@@ -2218,7 +2257,7 @@ snapshots:
   "@rolldown/binding-linux-x64-gnu@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.0.3":
+  "@rolldown/binding-linux-x64-gnu@1.1.4":
     optional: true
 
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.17":
@@ -2227,7 +2266,7 @@ snapshots:
   "@rolldown/binding-linux-x64-musl@1.0.2":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.0.3":
+  "@rolldown/binding-linux-x64-musl@1.1.4":
     optional: true
 
   "@rolldown/binding-openharmony-arm64@1.0.0-rc.17":
@@ -2236,28 +2275,28 @@ snapshots:
   "@rolldown/binding-openharmony-arm64@1.0.2":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.0.3":
+  "@rolldown/binding-openharmony-arm64@1.1.4":
     optional: true
 
   "@rolldown/binding-wasm32-wasi@1.0.0-rc.17":
     dependencies:
       "@emnapi/core": 1.10.0
       "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   "@rolldown/binding-wasm32-wasi@1.0.2":
     dependencies:
       "@emnapi/core": 1.10.0
       "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.3":
+  "@rolldown/binding-wasm32-wasi@1.1.4":
     dependencies:
-      "@emnapi/core": 1.10.0
-      "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17":
@@ -2266,7 +2305,7 @@ snapshots:
   "@rolldown/binding-win32-arm64-msvc@1.0.2":
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.3":
+  "@rolldown/binding-win32-arm64-msvc@1.1.4":
     optional: true
 
   "@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
@@ -2275,7 +2314,7 @@ snapshots:
   "@rolldown/binding-win32-x64-msvc@1.0.2":
     optional: true
 
-  "@rolldown/binding-win32-x64-msvc@1.0.3":
+  "@rolldown/binding-win32-x64-msvc@1.1.4":
     optional: true
 
   "@rolldown/pluginutils@1.0.0-rc.17":
@@ -2283,36 +2322,36 @@ snapshots:
 
   "@rolldown/pluginutils@1.0.1": {}
 
-  "@rslint/tsgo-darwin-arm64@0.5.3":
+  "@rslint/tsgo-darwin-arm64@0.6.4":
     optional: true
 
-  "@rslint/tsgo-darwin-x64@0.5.3":
+  "@rslint/tsgo-darwin-x64@0.6.4":
     optional: true
 
-  "@rslint/tsgo-linux-arm64@0.5.3":
+  "@rslint/tsgo-linux-arm64@0.6.4":
     optional: true
 
-  "@rslint/tsgo-linux-x64@0.5.3":
+  "@rslint/tsgo-linux-x64@0.6.4":
     optional: true
 
-  "@rslint/tsgo-win32-arm64@0.5.3":
+  "@rslint/tsgo-win32-arm64@0.6.4":
     optional: true
 
-  "@rslint/tsgo-win32-x64@0.5.3":
+  "@rslint/tsgo-win32-x64@0.6.4":
     optional: true
 
-  "@rslint/tsgo@0.5.3":
+  "@rslint/tsgo@0.6.4":
     optionalDependencies:
-      "@rslint/tsgo-darwin-arm64": 0.5.3
-      "@rslint/tsgo-darwin-x64": 0.5.3
-      "@rslint/tsgo-linux-arm64": 0.5.3
-      "@rslint/tsgo-linux-x64": 0.5.3
-      "@rslint/tsgo-win32-arm64": 0.5.3
-      "@rslint/tsgo-win32-x64": 0.5.3
+      "@rslint/tsgo-darwin-arm64": 0.6.4
+      "@rslint/tsgo-darwin-x64": 0.6.4
+      "@rslint/tsgo-linux-arm64": 0.6.4
+      "@rslint/tsgo-linux-x64": 0.6.4
+      "@rslint/tsgo-win32-arm64": 0.6.4
+      "@rslint/tsgo-win32-x64": 0.6.4
 
   "@standard-schema/spec@1.1.0": {}
 
-  "@tybys/wasm-util@0.10.2":
+  "@tybys/wasm-util@0.10.3":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2328,48 +2367,48 @@ snapshots:
 
   "@types/jsesc@2.5.1": {}
 
-  "@types/node@25.9.1":
+  "@types/node@26.1.0":
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 8.3.0
 
-  "@vitest/expect@4.1.8":
+  "@vitest/expect@4.1.9":
     dependencies:
       "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.8
-      "@vitest/utils": 4.1.8
+      "@vitest/spy": 4.1.9
+      "@vitest/utils": 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.8(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4))":
+  "@vitest/mocker@4.1.9(vite@8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4))":
     dependencies:
-      "@vitest/spy": 4.1.8
+      "@vitest/spy": 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)
+      vite: 8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4)
 
-  "@vitest/pretty-format@4.1.8":
+  "@vitest/pretty-format@4.1.9":
     dependencies:
       tinyrainbow: 3.1.0
 
-  "@vitest/runner@4.1.8":
+  "@vitest/runner@4.1.9":
     dependencies:
-      "@vitest/utils": 4.1.8
+      "@vitest/utils": 4.1.9
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.1.8":
+  "@vitest/snapshot@4.1.9":
     dependencies:
-      "@vitest/pretty-format": 4.1.8
-      "@vitest/utils": 4.1.8
+      "@vitest/pretty-format": 4.1.9
+      "@vitest/utils": 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.1.8": {}
+  "@vitest/spy@4.1.9": {}
 
-  "@vitest/utils@4.1.8":
+  "@vitest/utils@4.1.9":
     dependencies:
-      "@vitest/pretty-format": 4.1.8
+      "@vitest/pretty-format": 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2377,9 +2416,9 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@3.0.0-beta.1:
+  ast-kit@3.0.0:
     dependencies:
-      "@babel/parser": 8.0.0-rc.6
+      "@babel/parser": 8.0.0
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -2399,7 +2438,7 @@ snapshots:
 
   empathic@2.0.1: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.3.0: {}
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -2434,7 +2473,7 @@ snapshots:
     dependencies:
       "@types/estree": 1.0.9
 
-  expect-type@1.3.0: {}
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2506,65 +2545,65 @@ snapshots:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.15: {}
 
-  obug@2.1.1: {}
+  obug@2.1.3: {}
 
-  oxfmt@0.53.0:
+  oxfmt@0.57.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      "@oxfmt/binding-android-arm-eabi": 0.53.0
-      "@oxfmt/binding-android-arm64": 0.53.0
-      "@oxfmt/binding-darwin-arm64": 0.53.0
-      "@oxfmt/binding-darwin-x64": 0.53.0
-      "@oxfmt/binding-freebsd-x64": 0.53.0
-      "@oxfmt/binding-linux-arm-gnueabihf": 0.53.0
-      "@oxfmt/binding-linux-arm-musleabihf": 0.53.0
-      "@oxfmt/binding-linux-arm64-gnu": 0.53.0
-      "@oxfmt/binding-linux-arm64-musl": 0.53.0
-      "@oxfmt/binding-linux-ppc64-gnu": 0.53.0
-      "@oxfmt/binding-linux-riscv64-gnu": 0.53.0
-      "@oxfmt/binding-linux-riscv64-musl": 0.53.0
-      "@oxfmt/binding-linux-s390x-gnu": 0.53.0
-      "@oxfmt/binding-linux-x64-gnu": 0.53.0
-      "@oxfmt/binding-linux-x64-musl": 0.53.0
-      "@oxfmt/binding-openharmony-arm64": 0.53.0
-      "@oxfmt/binding-win32-arm64-msvc": 0.53.0
-      "@oxfmt/binding-win32-ia32-msvc": 0.53.0
-      "@oxfmt/binding-win32-x64-msvc": 0.53.0
+      "@oxfmt/binding-android-arm-eabi": 0.57.0
+      "@oxfmt/binding-android-arm64": 0.57.0
+      "@oxfmt/binding-darwin-arm64": 0.57.0
+      "@oxfmt/binding-darwin-x64": 0.57.0
+      "@oxfmt/binding-freebsd-x64": 0.57.0
+      "@oxfmt/binding-linux-arm-gnueabihf": 0.57.0
+      "@oxfmt/binding-linux-arm-musleabihf": 0.57.0
+      "@oxfmt/binding-linux-arm64-gnu": 0.57.0
+      "@oxfmt/binding-linux-arm64-musl": 0.57.0
+      "@oxfmt/binding-linux-ppc64-gnu": 0.57.0
+      "@oxfmt/binding-linux-riscv64-gnu": 0.57.0
+      "@oxfmt/binding-linux-riscv64-musl": 0.57.0
+      "@oxfmt/binding-linux-s390x-gnu": 0.57.0
+      "@oxfmt/binding-linux-x64-gnu": 0.57.0
+      "@oxfmt/binding-linux-x64-musl": 0.57.0
+      "@oxfmt/binding-openharmony-arm64": 0.57.0
+      "@oxfmt/binding-win32-arm64-msvc": 0.57.0
+      "@oxfmt/binding-win32-ia32-msvc": 0.57.0
+      "@oxfmt/binding-win32-x64-msvc": 0.57.0
 
-  oxlint-tsgolint@0.23.0:
+  oxlint-tsgolint@0.24.0:
     optionalDependencies:
-      "@oxlint-tsgolint/darwin-arm64": 0.23.0
-      "@oxlint-tsgolint/darwin-x64": 0.23.0
-      "@oxlint-tsgolint/linux-arm64": 0.23.0
-      "@oxlint-tsgolint/linux-x64": 0.23.0
-      "@oxlint-tsgolint/win32-arm64": 0.23.0
-      "@oxlint-tsgolint/win32-x64": 0.23.0
+      "@oxlint-tsgolint/darwin-arm64": 0.24.0
+      "@oxlint-tsgolint/darwin-x64": 0.24.0
+      "@oxlint-tsgolint/linux-arm64": 0.24.0
+      "@oxlint-tsgolint/linux-x64": 0.24.0
+      "@oxlint-tsgolint/win32-arm64": 0.24.0
+      "@oxlint-tsgolint/win32-x64": 0.24.0
 
-  oxlint@1.68.0(oxlint-tsgolint@0.23.0):
+  oxlint@1.72.0(oxlint-tsgolint@0.24.0):
     optionalDependencies:
-      "@oxlint/binding-android-arm-eabi": 1.68.0
-      "@oxlint/binding-android-arm64": 1.68.0
-      "@oxlint/binding-darwin-arm64": 1.68.0
-      "@oxlint/binding-darwin-x64": 1.68.0
-      "@oxlint/binding-freebsd-x64": 1.68.0
-      "@oxlint/binding-linux-arm-gnueabihf": 1.68.0
-      "@oxlint/binding-linux-arm-musleabihf": 1.68.0
-      "@oxlint/binding-linux-arm64-gnu": 1.68.0
-      "@oxlint/binding-linux-arm64-musl": 1.68.0
-      "@oxlint/binding-linux-ppc64-gnu": 1.68.0
-      "@oxlint/binding-linux-riscv64-gnu": 1.68.0
-      "@oxlint/binding-linux-riscv64-musl": 1.68.0
-      "@oxlint/binding-linux-s390x-gnu": 1.68.0
-      "@oxlint/binding-linux-x64-gnu": 1.68.0
-      "@oxlint/binding-linux-x64-musl": 1.68.0
-      "@oxlint/binding-openharmony-arm64": 1.68.0
-      "@oxlint/binding-win32-arm64-msvc": 1.68.0
-      "@oxlint/binding-win32-ia32-msvc": 1.68.0
-      "@oxlint/binding-win32-x64-msvc": 1.68.0
-      oxlint-tsgolint: 0.23.0
+      "@oxlint/binding-android-arm-eabi": 1.72.0
+      "@oxlint/binding-android-arm64": 1.72.0
+      "@oxlint/binding-darwin-arm64": 1.72.0
+      "@oxlint/binding-darwin-x64": 1.72.0
+      "@oxlint/binding-freebsd-x64": 1.72.0
+      "@oxlint/binding-linux-arm-gnueabihf": 1.72.0
+      "@oxlint/binding-linux-arm-musleabihf": 1.72.0
+      "@oxlint/binding-linux-arm64-gnu": 1.72.0
+      "@oxlint/binding-linux-arm64-musl": 1.72.0
+      "@oxlint/binding-linux-ppc64-gnu": 1.72.0
+      "@oxlint/binding-linux-riscv64-gnu": 1.72.0
+      "@oxlint/binding-linux-riscv64-musl": 1.72.0
+      "@oxlint/binding-linux-s390x-gnu": 1.72.0
+      "@oxlint/binding-linux-x64-gnu": 1.72.0
+      "@oxlint/binding-linux-x64-musl": 1.72.0
+      "@oxlint/binding-openharmony-arm64": 1.72.0
+      "@oxlint/binding-win32-arm64-msvc": 1.72.0
+      "@oxlint/binding-win32-ia32-msvc": 1.72.0
+      "@oxlint/binding-win32-x64-msvc": 1.72.0
+      oxlint-tsgolint: 0.24.0
 
   pathe@2.0.3: {}
 
@@ -2572,9 +2611,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2582,17 +2621,17 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.25.2(rolldown@1.0.3)(typescript@6.0.3):
+  rolldown-plugin-dts@0.26.0(rolldown@1.1.4)(typescript@6.0.3):
     dependencies:
-      "@babel/generator": 8.0.0-rc.6
-      "@babel/helper-validator-identifier": 8.0.0-rc.6
-      "@babel/parser": 8.0.0-rc.6
-      ast-kit: 3.0.0-beta.1
+      "@babel/generator": 8.0.0
+      "@babel/helper-validator-identifier": 8.0.2
+      "@babel/parser": 8.0.0
+      ast-kit: 3.0.0
       birpc: 4.0.0
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.1
-      rolldown: 1.0.3
+      obug: 2.1.3
+      rolldown: 1.1.4
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2641,28 +2680,28 @@ snapshots:
       "@rolldown/binding-win32-arm64-msvc": 1.0.2
       "@rolldown/binding-win32-x64-msvc": 1.0.2
 
-  rolldown@1.0.3:
+  rolldown@1.1.4:
     dependencies:
-      "@oxc-project/types": 0.133.0
+      "@oxc-project/types": 0.138.0
       "@rolldown/pluginutils": 1.0.1
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.3
-      "@rolldown/binding-darwin-arm64": 1.0.3
-      "@rolldown/binding-darwin-x64": 1.0.3
-      "@rolldown/binding-freebsd-x64": 1.0.3
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.3
-      "@rolldown/binding-linux-arm64-gnu": 1.0.3
-      "@rolldown/binding-linux-arm64-musl": 1.0.3
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.3
-      "@rolldown/binding-linux-s390x-gnu": 1.0.3
-      "@rolldown/binding-linux-x64-gnu": 1.0.3
-      "@rolldown/binding-linux-x64-musl": 1.0.3
-      "@rolldown/binding-openharmony-arm64": 1.0.3
-      "@rolldown/binding-wasm32-wasi": 1.0.3
-      "@rolldown/binding-win32-arm64-msvc": 1.0.3
-      "@rolldown/binding-win32-x64-msvc": 1.0.3
+      "@rolldown/binding-android-arm64": 1.1.4
+      "@rolldown/binding-darwin-arm64": 1.1.4
+      "@rolldown/binding-darwin-x64": 1.1.4
+      "@rolldown/binding-freebsd-x64": 1.1.4
+      "@rolldown/binding-linux-arm-gnueabihf": 1.1.4
+      "@rolldown/binding-linux-arm64-gnu": 1.1.4
+      "@rolldown/binding-linux-arm64-musl": 1.1.4
+      "@rolldown/binding-linux-ppc64-gnu": 1.1.4
+      "@rolldown/binding-linux-s390x-gnu": 1.1.4
+      "@rolldown/binding-linux-x64-gnu": 1.1.4
+      "@rolldown/binding-linux-x64-musl": 1.1.4
+      "@rolldown/binding-openharmony-arm64": 1.1.4
+      "@rolldown/binding-wasm32-wasi": 1.1.4
+      "@rolldown/binding-win32-arm64-msvc": 1.1.4
+      "@rolldown/binding-win32-x64-msvc": 1.1.4
 
-  semver@7.8.1: {}
+  semver@7.8.5: {}
 
   siginfo@2.0.0: {}
 
@@ -2687,7 +2726,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.1(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39):
+  tsdown@0.22.3(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -2695,11 +2734,11 @@ snapshots:
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.1
+      obug: 2.1.3
       picomatch: 4.0.4
-      rolldown: 1.0.3
-      rolldown-plugin-dts: 0.25.2(rolldown@1.0.3)(typescript@6.0.3)
-      semver: 7.8.1
+      rolldown: 1.1.4
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.4)(typescript@6.0.3)
+      semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -2730,39 +2769,39 @@ snapshots:
       "@quansync/fs": 1.0.0
       quansync: 1.0.0
 
-  undici-types@7.24.6: {}
+  undici-types@8.3.0: {}
 
   unrun@0.2.39:
     dependencies:
       rolldown: 1.0.0-rc.17
     optional: true
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4):
+  vite@8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      "@types/node": 25.9.1
+      "@types/node": 26.1.0
       esbuild: 0.28.0
       fsevents: 2.3.3
       tsx: 4.22.4
 
-  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)):
+  vitest@4.1.9(@types/node@26.1.0)(vite@8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4)):
     dependencies:
-      "@vitest/expect": 4.1.8
-      "@vitest/mocker": 4.1.8(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4))
-      "@vitest/pretty-format": 4.1.8
-      "@vitest/runner": 4.1.8
-      "@vitest/snapshot": 4.1.8
-      "@vitest/spy": 4.1.8
-      "@vitest/utils": 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
+      "@vitest/expect": 4.1.9
+      "@vitest/mocker": 4.1.9(vite@8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4))
+      "@vitest/pretty-format": 4.1.9
+      "@vitest/runner": 4.1.9
+      "@vitest/snapshot": 4.1.9
+      "@vitest/spy": 4.1.9
+      "@vitest/utils": 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
@@ -2770,10 +2809,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)
+      vite: 8.0.14(@types/node@26.1.0)(esbuild@0.28.0)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 25.9.1
+      "@types/node": 26.1.0
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,4 @@ packages:
 linkWorkspacePackages: true
 preferWorkspacePackages: true
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true


### PR DESCRIPTION
## Summary

- update Rust, npm, and devenv dependency locks
- adapt mdt_mcp to rmcp 2.1 ContentBlock API
- update monochange workflow step syntax and package repository metadata

## Validation

- devenv shell cargo build --locked
- env CI=true devenv shell build:all
- devenv shell test:all
- devenv shell lint:all
- devenv shell pnpm build
- devenv shell lint:push
- devenv shell mc check
- devenv shell mc step affected-packages --format json --verify