### PR TITLE
fix(release): run release PR workflow atomically

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -110,12 +110,7 @@ jobs:
           set -euo pipefail
           export GITHUB_TOKEN="$GH_TOKEN"
 
-          mc --log-level=debug step prepare-release --format json
-          cargo generate-lockfile
-          mdt update
-          fix:format
-          mc --log-level=debug step commit-release --stage-all --no-verify
-          mc --log-level=debug step open-release-request --stage-all --no-verify
+          mc --log-level=debug run release --commit --create-pr --no-verify=true
         shell: devenv shell -- bash -e {0}
 
       - name: skip refresh without changesets


### PR DESCRIPTION
## Summary
- replace separate release-pr monochange step invocations with the configured mc run release workflow
- keep prepare, lockfile/template sync, formatting, release commit, and PR refresh in one monochange execution so the prepared-release state does not go stale

## Validation
- devenv shell lint:actions
- devenv shell mc check
- devenv shell lint:all
- local verification: devenv shell -- mc run release --commit, then reset the temporary local release commit