### PR TITLE
fix(release): use existing cargo release profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           bin: mdt
           manifest-path: mdt_cli/Cargo.toml
-          profile: dist
+          profile: release
           ref: refs/tags/${{ env.RELEASE_TAG }}
           archive: $bin-$target-$tag
           target: ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- change release asset builds from the undefined Cargo profile dist to the built-in release profile
- fixes the release workflow failure: profile dist is not defined

## Validation
- devenv shell lint:actions
- devenv shell cargo build --profile release --bin mdt --manifest-path mdt_cli/Cargo.toml
- devenv shell lint:all