### PR TITLE
fix(release): dispatch publish workflow from main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,7 +231,7 @@ jobs:
           done
           gh workflow run publish.yml \
             --repo "${{ github.repository }}" \
-            --ref "$RELEASE_TAG" \
+            --ref main \
             -f "tag=$RELEASE_TAG"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- dispatch publish.yml from main instead of the release tag ref
- keep passing the release tag as input so publish.yml still checks out and publishes the tagged release
- fixes publisher environment rejection for tag deployments

## Validation
- devenv shell lint:actions