### PR TITLE
fix(release): keep pnpm lockfile current for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
           version: 10
 
       - name: build npm tooling
-        run: pnpm install && pnpm build
+        run: pnpm install --no-frozen-lockfile && pnpm build
 
       - name: get crates oidc auth token
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4

--- a/monochange.toml
+++ b/monochange.toml
@@ -216,6 +216,7 @@ inputs = [
 steps = [
   { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
   { type = "Command", name = "generate cargo lockfile", when = "{{ number_of_changesets > 0 }}", command = "cargo generate-lockfile" },
+  { type = "Command", name = "generate pnpm lockfile", when = "{{ number_of_changesets > 0 }}", command = "pnpm install --lockfile-only --no-frozen-lockfile" },
   { type = "Command", name = "sync template blocks", when = "{{ number_of_changesets > 0 }}", command = "mdt update" },
   { type = "Command", name = "format changed files", when = "{{ number_of_changesets > 0 }}", command = "dprint fmt --allow-no-files" },
   { type = "CommitRelease", name = "create release commit", when = "{{ number_of_changesets > 0 && inputs.commit }}", inputs = { no_verify = "{{ inputs.no_verify }}", stage_all = true } },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,28 +38,28 @@ importers:
   packages/m-d-t__cli:
     optionalDependencies:
       "@m-d-t/cli-darwin-arm64":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-darwin-arm64
       "@m-d-t/cli-darwin-x64":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-darwin-x64
       "@m-d-t/cli-linux-arm64-gnu":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-linux-arm64-gnu
       "@m-d-t/cli-linux-arm64-musl":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-linux-arm64-musl
       "@m-d-t/cli-linux-x64-gnu":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-linux-x64-gnu
       "@m-d-t/cli-linux-x64-musl":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-linux-x64-musl
       "@m-d-t/cli-win32-arm64-msvc":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-win32-arm64-msvc
       "@m-d-t/cli-win32-x64-msvc":
-        specifier: ^0.8.0
+        specifier: ^0.9.0
         version: link:../m-d-t__cli-win32-x64-msvc
 
   packages/m-d-t__cli-darwin-arm64: {}


### PR DESCRIPTION
## Summary - install npm tooling in publish with --no-frozen-lockfile so the existing v0.9.0 release tag can publish; update pnpm-lock.yaml for the current 0.9.0 package manifests; add a monochange release command step to refresh pnpm-lock.yaml in future release PRs. ## Validation - devenv shell fix:format; devenv shell lint:actions; devenv shell mc check; devenv shell pnpm install --no-frozen-lockfile && devenv shell pnpm build; devenv shell lint:all; git diff --check.