### PR TITLE
fix(release): sanitize npm publish environment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
-          scope: "@m-d-t"
 
       - name: install pnpm
         uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
@@ -121,8 +119,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
         run: |
           unset NODE_AUTH_TOKEN
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ]; then
+            rm -f "$NPM_CONFIG_USERCONFIG"
+            unset NPM_CONFIG_USERCONFIG
+          fi
           mc step publish-readiness --from HEAD --output "$RUNNER_TEMP/publish-readiness.json" --format json
         shell: devenv shell -- bash -e {0}
 
@@ -130,8 +133,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-oidc.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
         run: |
           unset NODE_AUTH_TOKEN
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ]; then
+            rm -f "$NPM_CONFIG_USERCONFIG"
+            unset NPM_CONFIG_USERCONFIG
+          fi
           mc --log-level=info step publish-packages \
             --all \
             --output "$RUNNER_TEMP/publish-result.json" \


### PR DESCRIPTION
## Summary - stop setup-node from creating token-based npm auth config for trusted publishing; scrub inherited npm token config before monochange readiness/publish; disable npm lifecycle scripts during publish because packages are built/populated before publishing. ## Validation - devenv shell lint:actions; devenv shell lint:all; git diff --check.